### PR TITLE
[20250203] BOJ / 골드5 / 차트 / 이강현

### DIFF
--- a/lkhyun/202502/03 BOJ 차트.md
+++ b/lkhyun/202502/03 BOJ 차트.md
@@ -1,0 +1,54 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.*;
+public class Main {
+    static BufferedReader br;
+    static BufferedWriter bw;
+    static int N;
+    static int[] comb;
+    static boolean[] visited;
+    static int[] dogs;
+    static int max = 0;
+    public static void main(String[] args) throws Exception {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        N = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        dogs = new int[N];
+        comb = new int[N];
+        visited = new boolean[N];
+        for(int i=0;i<N;i++){
+            dogs[i] = Integer.parseInt(st.nextToken());
+        }
+        combination(0);
+        bw.write(max + "");
+        bw.flush();
+    }
+
+    public static void combination(int depth){
+        if(depth == N){
+            int count = 0;
+            for(int j=0;j<N-1;j++){
+                int sum = comb[j];
+                for(int k=j+1;k<N;k++){
+                    if(sum == 50){count++; break;}
+                    else if(sum > 50){break;}
+                    sum += comb[k];
+                }
+            }
+            if(max<count){max = count;}
+            return;
+        }
+
+        for(int i=0;i<N;i++){
+            if(visited[i]){continue;}
+            visited[i] = true;
+            comb[depth] = dogs[i];
+            combination(depth+1);
+            visited[i] = false;
+        }
+    }
+}


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1239

## 🧭 풀이 시간
60분

## 👀 체감 난이도
중

## ✏️ 문제 설명
총 합이 100인 정수를 N개 입력받고 이를 통해 만들 수 있는 원형 차트의 종류중 
원을 이등분하는 선이 가장 많은 차트의 선 개수를 출력.

## 🔍 풀이 방법
백트래킹으로 제공된 시간들의 가능한 순열을 모두 구하고 마지막 depth일때 앞에서부터 차례대로 더해
합이 50인 경우에 count++을 하였음. 마지막으로 해당 순열의 count가 static 변수 max보다 클 경우 값을 바꿔
최댓값을 구함.
## ⏳ 회고
골드치고는 ez
