### PR TITLE
[20250203] BOJ / 골드5 / 차트 / 이강현

### DIFF
--- a/lkhyun/202502/03 BOJ 골드5 차트.md
+++ b/lkhyun/202502/03 BOJ 골드5 차트.md
@@ -1,3 +1,4 @@
+```java
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.InputStreamReader;
@@ -52,3 +53,4 @@ public class Main {
         }
     }
 }
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1239

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [X] 중
- [ ] 하

## ✏️ 문제 설명
총 합이 100인 정수를 N개 입력받고 이를 통해 만들 수 있는 원형 차트의 종류중 
원을 이등분하는 선이 가장 많은 차트의 선 개수를 출력.

## 🔍 풀이 방법
백트래킹으로 제공된 시간들의 가능한 순열을 모두 구하고 마지막 depth일때 앞에서부터 차례대로 더해
합이 50인 경우에 count++을 하였음. 마지막으로 해당 순열의 count가 static 변수 max보다 클 경우 값을 바꿔
최댓값을 구함.
## ⏳ 회고
골드치고는 ez
