### PR TITLE
[20250203] BOJ / 골드4 / 로또 / 설진영

### DIFF
--- a/Seol-JY/202502/03 BOJ G4 로또.md
+++ b/Seol-JY/202502/03 BOJ G4 로또.md
@@ -1,0 +1,31 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        
+        long[][] arr = new long[101][2_001];
+        
+        for (long i = 1; i < 2_001; i++) {
+            arr[1][(int)i] = i;
+        }
+        
+        for (long i = 2; i < 101; i++) {
+            for (long j = 1; j < 2_001; j++) {
+                arr[(int)i][(int)j] = arr[(int)i][(int)(j-1)] + arr[(int)(i-1)][(int)(j/2)];
+            }
+        }
+        
+        long T = Long.parseLong(br.readLine());
+        
+        for (long i = 0; i < T; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            long n = Long.parseLong(st.nextToken());
+            long m = Long.parseLong(st.nextToken());
+            System.out.println(arr[(int)n][(int)m]);
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2758
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
선영이는 매주 엄청난 돈을 로또에 투자한다. 선영이가 하는 로또는 1부터 m까지 숫자 중에 n개의 수를 고르는 로또이다.

이렇게 열심히 로또를 하는데, 아직까지 한 번도 당첨되지 않은 이유는 수를 고를 때 각 숫자는 이전에 고른 수보다 적어도 2배가 되도록 고르기 때문이다.

선영이는 돈이 엄청나게 많기 때문에, 수를 고르는 방법의 수 만큼 로또를 구매하며, 같은 방법으로 2장이상 구매하지 않는다.

n과 m이 주어졌을 때, 선영이가 구매하는 로또의 개수를 출력하는 프로그램을 작성하시오.


## 🔍 풀이 방법
전형적인 DP 문제, 적어도 2배가 되어야 한다고 했으므로, dp[i][j] = dp[i][j-1] + dp[i-1][j/2] 라는 점화식을 통해 해결할 수 있다. 
## ⏳ 회고
DP는 항상 점화식 세우는게 제일 어려운 것 같다. 머리로 안될 것 같으면 손으로 특정 케이스까지 모조리 써가며(단, 정확하게) 경향 확인하는게 나을듯...
그리고 Long으로 안하면 오버플로우 나서 틀리는데, 이거 조심해야겠다.. n과 m 크기 조건만 보고선 초과하는지 알 수 없을듯
