### PR TITLE
[20250203] BOJ / 골드4 / 방사형 그래프 / 권혁준

### DIFF
--- a/khj20006/202502/03 BOJ G4 방사형 그래프.md
+++ b/khj20006/202502/03 BOJ G4 방사형 그래프.md
@@ -1,0 +1,67 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Point{
+	double x, y;
+	Point(double x, double y){
+		this.x = x;
+		this.y = y;
+	}
+}
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	static double[] A = new double[8];
+	static int ans = 0;
+	
+	static int ccw(Point a, Point b, Point c) {
+		double r = (a.x*b.y + b.x*c.y + c.x*a.y) - (b.x*a.y + c.x*b.y + a.x*c.y);
+		return r > 0 ? 1 : (r < 0 ? -1 : 0);
+	}
+	
+	static void sol(int choose, List<Double> arr) {
+		if(arr.size() == 8) {
+			for(int i=0;i<8;i++) {
+				Point a = new Point(0,arr.get(i));
+				Point b = new Point(arr.get((i+1)%8) / Math.sqrt(2), arr.get((i+1)%8) / Math.sqrt(2));
+				Point c = new Point(arr.get((i+2)%8), 0);
+				if(ccw(a,b,c) > 0) return;
+			}
+			ans++;
+			return;
+		}
+		for(int i=0;i<8;i++) {
+			if((choose & (1<<i)) != 0) continue;
+			arr.add(A[i]);
+			sol(choose | (1<<i), arr);
+			arr.remove(arr.size()-1);
+		}
+	}
+
+	public static void main(String[] args) throws Exception {
+
+		nextLine();
+		for(int i=0;i<8;i++) A[i] = nextInt();
+		sol(0, new ArrayList<>());
+		
+		bw.write(ans+"\n");
+		
+		bwEnd();
+	}
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/25308

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
8개의 정수가 주어지면, 이것들로 정팔각형 내부에 방사형 그래프를 그릴 수 있습니다.

정수를 잘 배치해서, 방사형 그래프가 볼록 다각형이 되는 경우의 수를 구해야 합니다.

## 🔍 풀이 방법
시간복잡도 $O(8!)$의 완탐 풀이가 가장 먼저 떠올랐고, 시간도 널널해 보여서 이대로 구현했습니다.

정수들의 순서가 정해지면, ccw를 이용하여 반시계 관계가 발견되지 않을 때 볼록 다각형이라고 판별했습니다.

## ⏳ 회고
저는 이런 문제를 보면 습관적으로 피하게 되는데, 피하지만 말고 이런 것도 견뎌내고 풀어야겠다고 생각이 드네요