### PR TITLE
[20250203] BOJ / 골드5 / 차트 / 권혁준

### DIFF
--- a/khj20006/202502/03 BOJ G5 차트.md
+++ b/khj20006/202502/03 BOJ G5 차트.md
@@ -1,0 +1,61 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+
+	static int N;
+	static int ans = 0;
+	static int[] A = new int[8];
+	
+	static void sol(int pos, int choose, int[] arr) {
+		if(pos == N) {
+			int res = 0;
+			for(int i=1;i<N;i++) {
+				if(arr[i] < 50) continue;
+				for(int j=0;j<i;j++){
+					if(arr[j] == arr[i]-50) {
+						res++;
+						break;
+					}
+				}
+			}
+			ans = Math.max(ans, res);
+			return;
+		}
+		for(int i=0;i<N;i++) {
+			if((choose & (1<<i)) != 0) continue;
+			arr[pos+1] = arr[pos] + A[i];
+			sol(pos+1, choose | (1<<i), arr);
+			arr[pos+1] = 0;
+		}
+	}
+
+	public static void main(String[] args) throws Exception {
+
+		N = Integer.parseInt(br.readLine());
+		nextLine();
+		for(int i=0;i<N;i++) A[i] = nextInt();
+		sol(0, 0, new int[N+1]);
+		
+		bw.write(ans+"\n");
+		
+		bwEnd();
+	}
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1239

## 🧭 풀이 시간
10분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
데이터가 주어지면, 이를 적절히 배치해서 원형 차트를 만들 수 있습니다.
여러 가지 경우가 존재하는데, 이 중 원의 중심을 지나는 선의 최대 개수를 구해야 합니다.

## 🔍 풀이 방법
$O(8!)$ 완탐 풀이가 가장 먼저 떠올랐습니다.

순서가 정해지면, 누적 합 배열에서 차이가 50인 원소 쌍의 수를 구해서 해결했습니다.

## ⏳ 회고
코드 짜면서 순서를 잘못 배치해서 디버깅하는데 오래 걸렸습니다.
실수하지 않도록 신중하게 짜보겠습니다.