### PR TITLE
[20250203] BOJ / 골드4 / 로또 / 권혁준

### DIFF
--- a/khj20006/202502/03 BOJ G4 로또.md
+++ b/khj20006/202502/03 BOJ G4 로또.md
@@ -1,0 +1,43 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+
+	public static void main(String[] args) throws Exception {
+
+		long[][] dp = new long[11][2001];
+		for(int i=1;i<=2000;i++) dp[1][i] = i;
+		for(int i=2;i<=10;i++) {
+			for(int j=1;j<=2000;j++) dp[i][j] = dp[i][j-1] + dp[i-1][j/2];
+		}
+		
+		nextLine();
+		int T = nextInt();
+		
+		while(T-- > 0) {
+			nextLine();
+			int n = nextInt(), m = nextInt();
+			bw.write(dp[n][m]+"\n");
+		}
+		
+		bwEnd();
+	}
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2758

## 🧭 풀이 시간
10분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
$1$부터 $m$까지의 수 중 $n$개의 수를 고르는데, 이전에 고른 수의 2배 이상인 수만 고른다고 합니다.
수를 고르는 방법의 수를 구해야 합니다.

## 🔍 풀이 방법
$dp[n][m]$을 $n$개를 골랐고, 마지막에 고른 수가 $m$일 때의 경우의 수라고 합시다.
$dp[n][m] = dp[n-1][1] + \cdots + dp[n-1][\lfloor \frac{m}{2} \rfloor]$ 와 같은 식이 성립합니다.

정의를 살짝 바꿔서, $n$개를 골랐고 마지막에 고른 수가 $m$ 이하일 때의 경우의 수라고 합시다.
$dp[n][m] = dp[n][m-1] + dp[n-1][m/2]$로 식을 간단하게 줄일 수 있습니다.

## ⏳ 회고
테스트 케이스의 수가 주어지지 않아서 원래 식인 $O(NM^2)$로 풀게 되면 시간에 걸릴 것 같아 식 최적화를 떠올리게 되었습니다