### PR TITLE
[20250203] BOJ / 골드5 / 모독 / 권혁준

### DIFF
--- a/khj20006/202502/03 BOJ G4 모독.md
+++ b/khj20006/202502/03 BOJ G4 모독.md
@@ -1,0 +1,44 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+
+	public static void main(String[] args) throws Exception {
+
+		nextLine();
+		int N = nextInt();
+		int[] A = new int[N];
+		for(int i=0;i<N;i++) A[i] = Integer.parseInt(br.readLine());
+		Arrays.sort(A);
+		
+		long ans = 0;
+		int c = 1;
+		for(int i=0;i<N;i++) {
+			int p = i;
+			while(i<N-1 && A[i] == A[i+1] && A[i] == c) i++;
+			ans += (long)(i-p+1)*Math.max(0,A[p]-c++);
+		}
+		bw.write(ans+"\n");
+		
+		
+		bwEnd();
+	}
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16678

## 🧭 풀이 시간
16분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
길이 $N$인 수열 $A$가 주어집니다. $(1 \le A_i \le 100\.000)$
버튼을 누르면 다음 과정이 수행됩니다.
1. 모든 $A_i$가 $1$씩 감소합니다.
2. $0$ 이하가 된 원소가 존재한다면, 1번 과정으로 돌아갑니다.
3. 그렇지 않으면 수행을 종료합니다.

버튼을 누르기 전에 원하는 만큼 **조작**을 할 수 있습니다.
**조작**이란, 원소 하나를 $1$ 감소시키는 걸 의미합니다.
버튼을 한 번만 눌러서 $A$의 모든 원소를 $0$으로 만들려고 할 때, 필요한 **조작**의 최소 횟수를 구해야 합니다.

## 🔍 풀이 방법
정렬시키고 작은 수부터 하나씩 $1$부터 배정하면 됩니다.
만약, 배정하려는 수와 현재 수가 같다면 인접한 같은 수들을 모두 하나로 취급해야 합니다.

## ⏳ 회고
같은 수들에 대한 처리를 생각하는데 너무 오래 걸렸습니다. 예제가 너무 불친절합니다.