### PR TITLE
[20250204] BOJ / 골드4 / 파이프 옮기기 2 / 설진영

### DIFF
--- a/Seol-JY/202502/04 BOJ G4 파이프 옮기기 2.md
+++ b/Seol-JY/202502/04 BOJ G4 파이프 옮기기 2.md
@@ -1,0 +1,49 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    private static final int H = 0;
+    private static final int V = 1;
+    private static final int D = 2;
+
+    private static int SIZE;
+    static int[][] map;
+    static long[][][] dp;
+    
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        SIZE = Integer.parseInt(br.readLine());
+
+        map = new int[SIZE + 1][SIZE + 1];
+        dp = new long[3][SIZE + 1][SIZE + 1];
+
+        StringTokenizer st;
+        for (int i = 1; i <= SIZE; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 1; j <= SIZE; j++) {
+                if (1 == Integer.parseInt(st.nextToken())) {
+                    map[i][j] = 1;
+                }
+            }
+        }
+        
+        dp[H][1][2] = 1;
+        
+        for (int i = 1; i <= SIZE; i++) {
+        	for (int j = 1; j <= SIZE; j++) {
+        		if (i == 1 && j <= 2) continue;
+        		
+        		if (map[i][j] == 1) continue;
+        		dp[H][i][j] = dp[H][i][j-1] + dp[D][i][j-1];
+        		dp[V][i][j] = dp[V][i-1][j] + dp[D][i-1][j];
+        		
+        		if(map[i][j-1] == 1 || map[i-1][j] == 1) continue;
+        		dp[D][i][j] = dp[H][i-1][j-1] + dp[V][i-1][j-1] + dp[D][i-1][j-1];
+        	}
+        }
+        
+        System.out.println(dp[H][SIZE][SIZE] + dp[V][SIZE][SIZE] + dp[D][SIZE][SIZE]);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17069

## 🧭 풀이 시간
30분 - 근데 풀이 옛날부터 고민했음

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
파이프 옮기기, dp를 곁들인..

## 🔍 풀이 방법
파이프 옮기기 1 은 DFS로 풀었는데, 2는 시간초과가 난다. DFS 했던거 그대로 역순으로 생각하면 DP로 비교적 쉽게 나오는 것 같다. 점화식만 세우면 크게 어렵지 않다.

## ⏳ 회고
반복문 돌릴때 초기값 덮어쓰지 않도록 유의, 또또 오버플로우 났음.. 그냥 long 써야겠다 앞으로