### PR TITLE
[20250204] BOJ / 골드5 / 주사위 쌓기 / 권혁준

### DIFF
--- a/khj20006/202502/04 BOJ G5 주사위 쌓기.md
+++ b/khj20006/202502/04 BOJ G5 주사위 쌓기.md
@@ -1,0 +1,68 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	public static void main(String[] args) throws Exception {
+
+		int[][] ch = {
+				{1,2,3,4},
+				{0,2,4,5},
+				{0,1,3,5},
+				{0,2,4,5},
+				{0,1,3,5},
+				{1,2,3,4}
+		};
+		int[] op = {5,3,4,1,2,0};
+		
+		nextLine();
+		int N = nextInt();
+		int[][] Dices = new int[N][6];
+		for(int i=0;i<N;i++) {
+			nextLine();
+			for(int j=0;j<6;j++) Dices[i][j] = nextInt();
+		}
+		
+		int ans = 0;
+		for(int t=0;t<6;t++) {
+			int res = 0;
+			for(int k=0;k<4;k++) res = Math.max(res, Dices[0][ch[t][k]]);
+			
+			int prev = Dices[0][t];
+			for(int i=1;i<N;i++) {
+				int down = 0;
+				while(down < 6) {
+					if(prev == Dices[i][down]) break;
+					down++;
+				}
+				int up = op[down];
+				int max = 0;
+				for(int k=0;k<4;k++) max = Math.max(max, Dices[i][ch[up][k]]);
+				res += max;
+				prev = Dices[i][up];
+			}
+			ans = Math.max(ans, res);
+		}
+		
+		bw.write(ans+"\n");
+		
+		bwEnd();
+	}
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2116

## 🧭 풀이 시간
15분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
주사위 $N$개가 주어지면, 문제 조건에 맞게 쌓았을 때 한 옆면의 합을 최대로

## 🔍 풀이 방법
주사위를 길이 6의 배열로 보고, 윗면이 i일 때 옆면의 인덱스들을 ch[i]라는 배열에 저장했다.

## ⏳ 회고
구현이 좀 어려웠다.