### PR TITLE
[20250205] BOJ / 골드2 / Catch-Up / 권혁준

### DIFF
--- a/khj20006/202502/05 BOJ G2 Catch-Up.md
+++ b/khj20006/202502/05 BOJ G2 Catch-Up.md
@@ -1,0 +1,45 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	static int gcd(int a, int b) {
+		if(a < b) {
+			int temp = a;
+			a = b;
+			b = temp;
+		}
+		return a%b==0 ? b : gcd(b,a%b);
+	}
+	
+	public static void main(String[] args) throws Exception {
+
+		nextLine();
+		int a = nextInt();
+		int b = nextInt();
+		int c = nextInt();
+		int d = nextInt();
+
+		if((b-a)*(d-c) < 0) bw.write("NO");
+		else if(b==a || c==d) bw.write(b-a == d-c ? "YES":"NO");
+		else bw.write("YES");
+
+		bwEnd();
+	}
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/28428

## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명

술래는 매 초 다음과 같이 움직일 수 있다
- 현재 위치가 $(x,y)$이고 $x,y$ 모두 $2$ 이상일 때 $(x-1,y-1)$로 움직인다.
- 현재 위치가 $(x,y)$일 때 $(x+1,y+1)$로 움직인다.
- 현재 위치가 $(x,y)$일 때 $(ax, ay)$로 움직인다. ($a$는 양의 정수)
- 현재 위치가 $(x,y)$일 때 $(x/d,y/d)$로 움직인다. ($d$는 $x$, $y$의 양의 공약수)

도망자는 (0,0)에서 시작해서 매 초 $(mx,my)$만큼 움직인다.

술래가 도망자를 잡을 수 있는지 판별하자

## 🔍 풀이 방법
도망자, 술래의 시작점을 각각 $(a,b), (c,d)$라고 하면,
$b-a$와 $d-c$의 부호에 따라 답이 정해짐을 알아챘다.

## ⏳ 회고
### 무지성 제출하지 말자