### PR TITLE
[20250205] BOJ / 플레4 / 시저 암호 / 신희을

### DIFF
--- a/ShinHeeEul/202502/05 BOJ P4 시저 암호.md
+++ b/ShinHeeEul/202502/05 BOJ P4 시저 암호.md
@@ -1,0 +1,96 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+
+	static int[] failure;
+	public static void main(String[] args) throws IOException {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		int T = Integer.parseInt(br.readLine());
+
+		StringBuilder sb = new StringBuilder();
+		
+		while(T --> 0) {
+			ArrayList<Integer> list = new ArrayList<>();
+			HashMap<Character, Integer> map = new HashMap<>();
+			
+			char[] A = br.readLine().toCharArray();
+			char[] W = br.readLine().toCharArray();
+			char[] S = br.readLine().toCharArray();
+			int aLength = A.length;
+			for(int i = 0; i < aLength; i++) {
+				map.put(A[i], i);
+			}
+			failure = new int[W.length];
+
+			failureFunction(W);
+			
+			for(int i = 0; i < aLength; i++) {
+				if(i != 0) {
+					for(int j = 0; j < S.length; j++) {
+						S[j] = A[(map.get(S[j]) + 1) % aLength];
+					}
+				}
+				
+				if(kmp(S, W)) {
+					list.add(i == 0 ? i : aLength - i);
+				}
+			}
+			if(list.size() == 0) {
+				sb.append("no solution").append("\n");
+			} else if(list.size() == 1) {
+				sb.append("unique: ").append(list.get(0)).append("\n");
+			} else {
+				Collections.sort(list);
+				sb.append("ambiguous: ");
+				for(int li : list) sb.append(li).append(" ");
+				sb.append("\n");
+			}
+		}
+		System.out.println(sb);
+	}
+	
+	public static void failureFunction(char[] pattern) {
+		
+		int pIdx = 0;
+		
+		for(int i = 1; i < pattern.length; i++) {
+			
+			while(pIdx != 0 && pattern[pIdx] != pattern[i]) 
+				pIdx = failure[pIdx - 1];
+			
+			if(pattern[pIdx] == pattern[i]) {
+				failure[i] = ++pIdx;
+			}
+		}
+	}
+	
+	public static boolean kmp(char[] s, char[] pattern) {
+		int pIdx = 0;
+		int max = 0;
+		// ABCBBABC
+		// ABC
+		// 
+		for(int i = 0; i < s.length; i++) {
+			
+			while(pIdx != 0 && pattern[pIdx] != s[i]) 
+				pIdx = failure[pIdx - 1];
+			
+			if(pattern[pIdx] == s[i]) {
+				if(pIdx == pattern.length - 1) {
+					max++;
+					pIdx = failure[pIdx];
+				} else {
+					pIdx++;
+				}
+			}
+		}
+		
+		return max == 1;
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1893
## 🧭 풀이 시간
90 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
알파벳 순서 A, 원문 W, 시저 암호화된 문자열 S가 있다. 암호화된 문자열 S는 특정 문자열의 문자들을 알파벳 순서에 따라 X 만큼 밀어서 만든 문자열이다. 암호화 되기 전의 문자열에 원문 W가 단 1번만 등장하는 X를 오름차순으로 출력하라.

## 🔍 풀이 방법
원문으로 실패 배열을 만들고, 암호화된 문자열을 하나씩 밀면서 문자열과 원문을 KMP로 단 한번만 등장하는 지를 체크한다.

## ⏳ 회고
KMP를 구현하는 방법이 가물가물해서, 범위 밖으로 너무 많이 튀어나갔다. 그리고 X만큼 밀어서 암호화된 문자열을 만들 수 있는 문자열에서 원문을 살펴야하는데, 암호화된 문자열에서 X만큼 민 값에 원문이 있는 지를 보고 있었다. 문제를 똑바로 읽는 습관을 들이도록 하자.