### PR TITLE
[20250206] BOJ / 골드2 / 집합의 개수 / 권혁준

### DIFF
--- a/khj20006/202502/06 BOJ G2 집합의 개수.md
+++ b/khj20006/202502/06 BOJ G2 집합의 개수.md
@@ -1,0 +1,74 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	static int[] dp;
+	static int[] cnt;
+	static int T, A, S, B;
+	static int mod = 1000000;
+	
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+		
+		bwEnd();
+	}
+	
+	static void ready() throws Exception{
+
+		nextLine();
+		T = nextInt();
+		A = nextInt();
+		S = nextInt();
+		B = nextInt();
+		dp = new int[A+1];
+		cnt = new int[201];
+		
+		nextLine();
+		for(int i=0;i<A;i++) cnt[nextInt()]++;
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		dp[0] = 1;
+		
+		for(int i=1;i<=200;i++) {
+			int[] ndp = new int[A+1];
+			ndp[0] = 1;
+			
+			for(int j=1;j<=A;j++) {
+				for(int k=0;k<=Math.min(j, cnt[i]);k++) {
+					ndp[j] += dp[j-k];
+					ndp[j] %= mod;
+				}
+			}
+			dp = ndp;
+		}
+		
+		int ans = 0;
+		for(int j=S;j<=B;j++) ans = (ans + dp[j]) % mod;
+		
+		bw.write(ans+"\n");
+		
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2092

## 🧭 풀이 시간
14분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
1부터 T까지의 범위에 있는 수들이 총 A개 있다. 이들 중 K개를 골라서 집합을 만들 때, 가능한 집합의 개수를 세려 한다.
단, K의 범위는 1 ≤ S ≤ K ≤ B ≤ A로 한다. 즉, 두 정수 S, B를 입력받아서 K = S일 경우, …, K = B일 경우의 집합의 개수를 모두 더하려고 한다.

이 문제에서는 집합에 같은 원소가 여러 번 들어가도 되지만, 원소의 순서는 고려하지 않는다. (원소의 구성은 같고 순서만 다른 경우는 하나로 가정함.)

## 🔍 풀이 방법
순서를 고려하지 않아서 작은 수부터 넣어주는 경우만 고려했다.

$dp[n][k] =$ 1~n까지의 수들 중에서 집합에 k개를 넣은 경우의 수라고 정의했다.

위 정의 대로면 자연스럽게 $dp[n][k] = \sum \limits_{i=0}^{cnt[n]} {dp[n-1][k-i]}$라는 식을 도출할 수 있고, 이대로 3중 반복문을 구현해줬다.


## ⏳ 회고
변수 이름이 정신 나간 것 같다.