### PR TITLE
[20250210] BOJ / 플래3 / Game on Tree / 권혁준

### DIFF
--- a/khj20006/202502/10 BOJ P3 Game on Tree.md
+++ b/khj20006/202502/10 BOJ P3 Game on Tree.md
@@ -1,0 +1,79 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+
+	static int[] d;
+	static List<Integer>[] V;
+	static int N, ans = -1;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+	}
+	
+	static void ready() throws Exception{
+		
+		N = Integer.parseInt(br.readLine());
+		d = new int[N+1];
+		V = new ArrayList[N+1];
+		for(int i=1;i<=N;i++) V[i] = new ArrayList<>();
+		nextLine();
+		for(int i=2;i<=N;i++) {
+			int p = nextInt();
+			V[p].add(i);
+		}
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		dfs(1);
+		if(d[1] <= 1) {
+			bw.write("FIRST\n");
+			bw.write(findAns(1) + "\n");
+		}
+		else bw.write("SECOND");
+		
+	}
+	
+	static void dfs(int n) {
+		if(V[n].isEmpty()) d[n] = 2;
+		for(int i:V[n]) {
+			dfs(i);
+			d[n] += Math.max(0, d[i]-1);
+		}
+	}
+	
+	static int findAns(int n) {
+		if(V[n].isEmpty()) return n;
+		int next = n, max = -1;
+		for(int i:V[n]) {
+			if(d[i] > max) {
+				max = d[i];
+				next = i;
+			}
+		}
+		return findAns(next);
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/23655

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
루트가 1인 트리에서 A랑 B가 게임을 한다.
각자의 차례에 A는 리프 노드 하나를 막을 수 있고, B는 말을 인접한 노드로 옮기거나 가만히 놔둘 수 있다.
말이 리프 노드에 도달하면 B가 이기고, 모든 리프가 다 막히면 A가 이긴다.

말은 처음에 1번 노드에 있고, A부터 차례를 시작할 때 누가 이기는지 구해보자.

## 🔍 풀이 방법
이런 문제는 루트에서부터 깊이 파고들면서 각 서브트리에서 게임을 이길 수 있는가? 여부를 보는 것이 중요하다.

d[n] = n번 점을 루트로 하는 서브트리에서 A가 이기려면, 미리 막아놔야 하는 리프의 최소 개수라고 정의하자.

그럼, d[1] <= 1이면 A가 이긴다는 것이다.

만약 n이 리프라면 건너뛴다.
n이 리프가 아니라면, n의 자식들을 각각 c라고 할 때 d[n] = (리프의 개수) + $\sum {\max(d[c]-1, 0)}$이 된다.

A가 이기는 경우에는 dfs를 한 번 더 돌면서 답이 될 수 있는 점을 찾아주면 된다. (d[n]이 높은 쪽으로 파고들면 됨)

## ⏳ 회고
너무 어렵다