### PR TITLE
[20250210] BOJ / 플래5 / OMOI / 권혁준

### DIFF
--- a/khj20006/202502/10 BOJ P5 OMOI.md
+++ b/khj20006/202502/10 BOJ P5 OMOI.md
@@ -1,0 +1,91 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	static int[] C;
+	static List<Integer>[] V;
+	static int N;
+	static int[] cnt, mn;
+	static long[] sum;
+	static long ans = 0;
+	
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+	}
+	
+	static void ready() throws Exception{
+
+		N = Integer.parseInt(br.readLine());
+		V = new List[N+1];
+		for(int i=1;i<=N;i++) V[i] = new ArrayList<>();
+		C = new int[N+1];
+		cnt = new int[N+1];
+		mn = new int[N+1];
+		sum = new long[N+1];
+		
+		nextLine();
+		for(int i=2;i<=N;i++) V[nextInt()].add(i);
+		nextLine();
+		for(int i=2;i<=N;i++) C[i] = nextInt();
+		
+	}
+	
+	static void solve() throws Exception{
+
+		dfs(1);
+		bw.write(ans+"\n");
+		
+	}
+	
+	static void dfs(int n) {
+		mn[n] = Integer.MAX_VALUE;
+		cnt[n] = 1;
+		sum[n] = C[n];
+		int mxCnt = 0;
+		for(int i:V[n]) {
+			dfs(i);
+			cnt[n] += cnt[i];
+			sum[n] += sum[i];
+			mxCnt = Math.max(mxCnt, cnt[i]);
+			mn[n] = Math.min(mn[n], mn[i]);
+		}
+		ans += sum[n] - C[n];
+		if(mxCnt > cnt[n]-1-mxCnt) {
+			long rem = cnt[n]-1 - (cnt[n]-1-mxCnt)*2;
+			int minValue = Integer.MAX_VALUE;
+			for(int i:V[n]) {
+				if(cnt[i] == mxCnt) continue;
+				minValue = Math.min(minValue, mn[i]);
+			}
+			ans += rem * minValue;
+		}
+		else {
+			if((cnt[n]-1) % 2 != 0) {
+				ans += mn[n];
+			}
+		}
+		mn[n] = Math.min(mn[n], C[n]);
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/30745

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
루트가 1인 트리가 있고, 각 점 $i$는 $c[i]$라는 값을 가진다.

어떤 두 점 $u, v$에 대해, 서로 조상-자식의 관계가 아니라면, 둘은 논쟁을 할 수 있다.
이 때 intensity값은 $c[u] + c[v]$이다.

트리의 tension이란, 존재하는 argument의 intensity의 합이다.

각 점 $i$는 다음 조건을 만족할 때 **매니저**라고 불린다.
- 자신 아래에 존재하는 모든 점이 각각 논쟁을 한 번 이상 진행했을 경우

모든 점이 **매니저**일 때, 가능한 tension의 최솟값을 구해보자.

## 🔍 풀이 방법
어떤 점 $i$에 대해, $i$ 아래에 존재하는 점들을 한 번씩 논쟁시켜야 하는데, 서로 조상-자식의 관계면 논쟁할 수 없다.
-> 당연히 $i$의 자식들을 각각 루트로 하는 서브트리에서 하나씩 꺼내서 논쟁시키는 것이 이득이다.

이 때, 자식들 서브트리의 크기를 큰 순서대로 $cnt_1, cnt_2, \cdots, cnt_k$라고 할 때, $cnt_1$이 나머지 $cnt$의 합보다 작거나 같으면, 그냥 $i$ 서브트리의 합과 동일하거나, 개수가 홀수면 최솟값 한 번만 더해주면 된다.

$cnt_1$이 나머지들의 개수보다 많으면, 넘치는 수만큼 $cnt_1$에 속하지 않은 최솟값을 더해주면 된다.

## ⏳ 회고
영어 지문이라 문제를 이해하는 데만 20분이 걸렸다.