### PR TITLE
[20250211] BOJ / 플래3 / XOR 합 / 권혁준

### DIFF
--- a/khj20006/202502/11 BOJ P3 XOR 합.md
+++ b/khj20006/202502/11 BOJ P3 XOR 합.md
@@ -1,0 +1,113 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Node{
+	int d;
+	Node l, r;
+	Node(int d){this.d = d;}
+}
+
+class Trie{
+	Node root;
+	Trie(){root = new Node(31);}
+	void insert(int x) {
+		Node now = root;
+		for(int i=30;i>=0;i--) {
+			int bit = x & (1<<i);
+			x -= bit;
+			if(bit == 0) {
+				if(now.l == null) now.l = new Node(i);
+				now = now.l;
+			}
+			else {
+				if(now.r == null) now.r = new Node(i);
+				now = now.r;
+			}
+		}
+	}
+	// x 와 xor했을 때 가장 큰 값 찾기
+	int find(int x) {
+		Node now = root;
+		int res = 0;
+		for(int i=30;i>=0;i--) {
+			int bit = x & (1<<i);
+			if(bit != 0) {
+				if(now.l == null) now = now.r;
+				else {
+					res += (1<<i);
+					now = now.l;
+				}
+			}
+			else {
+				if(now.r == null) now = now.l;
+				else {
+					res += (1<<i);
+					now = now.r;
+				}
+			}
+		}
+		return res;
+	}
+}
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	static Trie trie;
+	static int T, N;
+	static int[] S;
+	
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		//solve();
+	
+		bwEnd();
+	}
+	
+	static void ready() throws Exception{
+
+		T = Integer.parseInt(br.readLine());
+		while(T-- > 0) {
+			trie = new Trie();
+			
+			N = Integer.parseInt(br.readLine());
+			S = new int[N+1];
+
+			nextLine();
+			for(int i=1;i<=N;i++) {
+				S[i] = nextInt();
+				S[i] ^= S[i-1];
+			}
+			solve();
+		}
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		for(int i=1;i<=N;i++) trie.insert(S[i]);
+		
+		int ans = 0;
+		for(int i=0;i<N;i++) ans = Math.max(ans, trie.find(S[i]));
+		bw.write(ans+"\n");
+		
+	}
+	
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/13504

## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- $N$개의 수로 이루어진 수열 A가 주어진다.
- 수열 A에서 연속된 부분 수열을 고르려고 한다. 부분 수열의 XOR 합이란, 부분 수열에 들어있는 모든 원소를 XOR한 값을 의미한다.
- 수열 A가 주어졌을 때, XOR 합이 가장 큰 부분 수열을 찾는 프로그램을 작성하시오.

## 🔍 풀이 방법
- 문제를 조금 바꿔보자.
- 어떤 수열 B에서, 어떤 수 $x$와 XOR했을 때 가장 큰 값을 구하려고 한다. (즉, $\max(B_i \oplus x)$를 구하려고 한다.)
- 이 문제는, 이진수 트라이를 이용하면 가장 큰 값을 $O(\log{\max(B)})$의 시간에 구할 수 있다.
- 트라이의 최상위 노드(루트)를 깊이 31로 설정해놓고, 내려갈수록 깊이가 줄어든다고 하자.
- 각 노드는 왼쪽 자식 혹은 오른쪽 자식을 가질 수 있으며, 각각 비트 0 혹은 1을 의미한다.
- 수열의 원소를 트라이에 모두 삽입하고, 최댓값을 구할 때는 정수 x에 대해 트라이의 루트에서 출발하여, 최대한 다른 비트로 가도록 했을 때 나온 값이 답이 된다.

- 이 문제에서는, 연속 부분 수열의 최대 XOR을 찾아야 하고, XOR의 성질에 의해 $(A_1 \oplus \cdots \oplus A_i) \oplus (A_1 \oplus \cdots \oplus A_k) = A_{k+1} \oplus \cdots \oplus A_i$가 된다. (단, $k < i$)
- 수열 $S$를 새로 만들어 $S_i = A_1 \oplus \cdots \oplus A_i$로 정의하면, 수열 $S$에서 위 문제를 푸는 것과 동일하게 변한다.

## ⏳ 회고
이진수 트라이를 오랜만에 구현해서 좀 복잡하게 짠 것 같다. 분명히 더 쉽게 짜는 법이 있을 것 같은데 나중에 비슷한 문제가 나오면 더 최적화를 해봐야겠다