### PR TITLE
[20250211] BOJ / 골드5 / 창영이와 커피 / 신동윤

### DIFF
--- a/03do-new30/202502/11 BOJ G5 창영이와 커피.md
+++ b/03do-new30/202502/11 BOJ G5 창영이와 커피.md
@@ -1,6 +1,4 @@
 ```java
-package BOJ;
-
 import java.io.*;
 import java.util.*;
 
@@ -36,21 +34,16 @@ public class Main {
 
         for (int caffeine = 1; caffeine < K+1; caffeine++) {
             for (int coffee = 1; coffee < N+1; coffee++) {
+                // (default) coffee번째 커피를 마시지 않는다면, caffine을 채우기 위해 coffee-1번째 커피까지 고려했을 때의 최소값이 dp[caffeine][coffee]가 됨
+                dp[caffeine][coffee] = dp[caffeine][coffee-1];
                 // coffee번째 커피를 마시는 경우
                 if (caffeine - cups[coffee] >= 0) {
                     dp[caffeine][coffee] = Integer.min(dp[caffeine][coffee], dp[caffeine-cups[coffee]][coffee-1] + 1);
                 }
-                // coffee번째 커피를 마시지 않는다면, caffine을 채우기 위해 coffee-1번째 커피까지 고려했을 때의 최소값이 dp[caffeine][coffee]가 됨
-                dp[caffeine][coffee] = Integer.min(dp[caffeine][coffee], dp[caffeine][coffee-1]);
             }
         }
 
-        int answer = maxCups;
-        for (int coffee = 1; coffee < N+1; coffee++) {
-            if (dp[K][coffee] < answer) {
-                answer = dp[K][coffee];
-            }
-        }
+        int answer = dp[K][N];
         if (answer == maxCups) {
             answer = -1;
         }


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/22115

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- K만큼의 카페인을 섭취하기 위한 최소 커피 잔 수 구하기

## 🔍 풀이 방법
- 배낭 문제와 유사하게 풀이!

## ⏳ 회고
- 출력 조건 잘 보기
- 유사 문제 풀이하기