### PR TITLE
[20250212] BOJ / G5 / 창영이와 커피 / 권혁준

### DIFF
--- a/khj20006/202502/12 BOJ G5 창영이와 커피.md
+++ b/khj20006/202502/12 BOJ G5 창영이와 커피.md
@@ -1,0 +1,56 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	static int[] dp;
+	static int N, K;
+	
+	public static void main(String[] args) throws Exception {
+		
+		//ready();
+		solve();
+	
+		bwEnd();
+	}
+	
+	static void ready() throws Exception{
+
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		nextLine();
+		N = nextInt();
+		K = nextInt();
+		dp = new int[100001];
+		Arrays.fill(dp, Integer.MAX_VALUE-1);
+		dp[0] = 0;
+		nextLine();
+		while(N-- > 0) {
+			int now = nextInt();
+			for(int j=100000;j>now;j--) if(dp[j-now] != 0) dp[j] = Math.min(dp[j-now]+1, dp[j]);
+			dp[now] = 1;
+		}
+		bw.write((dp[K] == Integer.MAX_VALUE-1 ? -1 : dp[K]) + "\n");
+		
+			
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/22115

## 🧭 풀이 시간
5분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
- 카페인 함유량이 각각 $c_i$인 커피 $N$개가 주어진다.
- 카페인을 정확히 $K$만큼 섭취할 수 있는 최소 커피 수 구하기

## 🔍 풀이 방법
**배낭 문제**의 정석

## ⏳ 회고
기초 다지기 좋은 문제