### PR TITLE
[20250212] BOJ / G5 / 카드게임 / 권혁준

### DIFF
--- a/khj20006/202502/12 BOJ G5 카드게임.md
+++ b/khj20006/202502/12 BOJ G5 카드게임.md
@@ -1,0 +1,76 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	static int[][] dp;
+	static int[] A, B;
+	static int N;
+	static final int INF = (int)1e9 + 1;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+	}
+	
+	static void ready() throws Exception{
+
+		N = Integer.parseInt(br.readLine());
+		A = new int[N+1];
+		B = new int[N+1];
+		dp = new int[N+2][N+2];
+		for(int i=0;i<N+2;i++) Arrays.fill(dp[i], INF);
+		
+		nextLine();
+		for(int i=1;i<=N;i++) A[i] = nextInt();
+		nextLine();
+		for(int i=1;i<=N;i++) B[i] = nextInt();
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		dp[0][0] = 0;
+		for(int i=1;i<=N+1;i++) for(int j=1;j<=N+1;j++) {
+			if(dp[i-1][j] != INF) {
+				if(dp[i][j] == INF) dp[i][j] = dp[i-1][j];
+				else dp[i][j] = Math.max(dp[i][j], dp[i-1][j]);
+			}
+			if(dp[i-1][j-1] != INF) {
+				if(dp[i][j] == INF) dp[i][j] = dp[i-1][j-1];
+				else dp[i][j] = Math.max(dp[i][j], dp[i-1][j-1]);
+			}
+			if(i<=N && j>1 && A[i] > B[j-1] && dp[i][j-1] != INF) {
+				if(dp[i][j] == INF) dp[i][j] = dp[i][j-1] + B[j-1];
+				else dp[i][j] = Math.max(dp[i][j], dp[i][j-1] + B[j-1]);
+			}
+		}
+		int ans = 0;
+		for(int i=1;i<=N+1;i++) {
+			if(dp[i][N+1] != INF) ans = Math.max(ans, dp[i][N+1]);
+			if(dp[N+1][i] != INF) ans = Math.max(ans, dp[N+1][i]);
+		}
+		bw.write(ans+"\n");
+		
+			
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/10835

## 🧭 풀이 시간
22분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 카드 뭉치 두 개가 있고, 각 뭉치에는 자연수가 적힌 $N$장의 카드들이 아래에서 위로 쌓여있다.
- 왼쪽 뭉치를 `left`, 오른쪽 뭉치를 `right`라 하면, 한 차례에 세 가지 행동 중 하나를 할 수 있다.
1. `left`의 맨 위 카드를 없앤다.
2. `left`와 `right`의 맨 위 카드를 없앤다.
3. 만약 `left의 맨 위에 적힌 수 > right의 맨 위에 적힌 수` 이면, right의 맨 위에 적힌 수만큼 점수에 더하고 그 카드를 없앤다.
- 한 쪽 뭉치가 빌 때까지 행동을 반복했을 때, 나올 수 있는 점수의 최댓값을 구해보자

## 🔍 풀이 방법
- dp[i][j] = left의 맨 위 카드가 $i$번째 카드이고, right의 맨 위 카드가 $j$번째 카드일 때 점수 최댓값
- 인접 세 방향의 dp값을 고려하는 식으로 해결할 수 있다.

## ⏳ 회고
불가능한 경우에 대해 처리를 따로 안해주니까 40%쯤에서 계속 틀렸다.