### PR TITLE
[20250212] BOJ / G2 / 불켜기 / 권혁준

### DIFF
--- a/khj20006/202502/12 BOJ G2 불켜기.md
+++ b/khj20006/202502/12 BOJ G2 불켜기.md
@@ -1,0 +1,119 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	static int[] d;
+	static boolean[] can;
+	static boolean[] on;
+	static int N, M;
+	static int[] root;
+	static int[] cnt;
+	static List<Integer>[] V;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+	}
+	
+	static void ready() throws Exception{
+
+		nextLine();
+		N = nextInt();
+		M = nextInt();
+		d = new int[] {-N,-1,1,N};
+		
+		can = new boolean[N*N];
+		on = new boolean[N*N];
+		root = new int[N*N];
+		cnt = new int[N*N];
+		V = new List[N*N];
+		for(int i=0;i<N*N;i++) {
+			root[i] = i;
+			V[i] = new ArrayList<>();
+		}
+		
+		for(int i=0;i<M;i++) {
+			nextLine();
+			int a = nextInt(), b = nextInt(), c = nextInt(), d = nextInt();
+			int from = coord(a-1,b-1), to = coord(c-1,d-1);
+			V[from].add(to);
+		}
+		
+	}
+	
+	static void solve() throws Exception{
+
+		cnt[0] = 1;
+		can[0] = true;
+		on[0] = true;
+		boolean change;
+		
+		do {
+			
+			change = false;
+
+			for(int i=0;i<N*N;i++) {
+				if(!can[i]) continue;
+				for(int j:V[i]) {
+					if(!on[j]) {
+						change = true;
+						on[j] = true;
+						for(int k=0;k<4;k++) {
+							int g = j+d[k];
+							if(0<=g&&g<N*N && adj(j,g) && on[g]) {
+								int x = f(j), y = f(g);
+								if(x != y) {
+									cnt[y] += cnt[x];
+									root[x] = y;
+								}
+							}
+						}
+					}
+				}
+			}
+			
+			for(int i=1;i<N*N;i++) {
+				if(!on[i] || can[i]) continue;
+				if(f(0) == f(i)) {
+					change = true;
+					can[i] = true;
+				}
+			}
+			
+		}while(change);
+
+		int ans = 0;
+		for(int i=0;i<N*N;i++) if(on[i]) ans++;
+		bw.write(ans+"\n");
+		
+	}
+	
+	static boolean adj(int x, int y) {
+		if(Math.abs(x-y) == 1) {
+			if(x/N != y/N) return false;
+		}
+		return true;
+	}
+	static int coord(int x, int y) {return x*N+y;}
+	static int f(int x) {return x==root[x] ? x : (root[x] = f(root[x]));}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11967

## 🧭 풀이 시간
60+분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
- $N \times N$ 격자에 (1,1)에만 불이 켜져있다.
- 각 칸의 불은 스위치를 이용해 켤 수 있고, 스위치의 정보는 (a,b,x,y)로 이루어져 (a,b)칸에 도달하면 (x,y)칸의 불을 켤 수 있다는 의미이다.
- (1,1)에서 출발하여 상하좌우의 불이 켜져있는 방으로만 이동 가능할 때, 켤 수 있는 불의 최대 개수를 구해보자.

## 🔍 풀이 방법
- 격자 칸을 1차원으로 압축하고, 각 스위치를 간선으로 갖는 그래프를 만들어 주었다.
- 두 개의 배열로 칸의 상태를 관리해 주었다.
1. 각 칸의 불이 켜져있는지를 나타내는 배열 on (on[i] = true이면 칸 i가 켜져있는 상태)
2. 각 칸에 도달 가능한지를 나타내는 배열 can (can[i] = true이면 칸 i로 이동 가능한 상태)
- 이를 이용해서 아래의 프로세스를 갱신 가능한 요소가 없을 때까지 반복했다.
1. 도달 가능한 모든 칸(can[i] = true인 곳)에서 간선을 한 번 타고 갈 수 있는 칸들의 불을 켠다.
2. 불을 킨 칸들의 상하좌우에 인접한 곳도 불이 켜져있다면, 분리 집합으로 이어준다.
3. 불이 켜져있고, 시작 칸(1,1)과 분리 집합 상에서 이어져있는 칸들을 can배열에서 모두 true로 바꿔준다.

- 마지막에 불이 켜져있는(on[i] = true인) 칸의 개수를 출력해주었다.

## ⏳ 회고
- 풀이를 총 세 번 갈아엎었다.
- 처음에는 2차원 그대로 분리 집합 없이 깡 완탐으로 돌렸다가 틀렸다.
- 두 번째 풀이는 2차원 그대로 분리 집합을 추가해서 풀었다가 틀렸다.
- 다음으로, 1차원 압축 후 분리 집합으로 풀었는데 또 틀렸다.
- 왜 틀렸는지 도저히 모르겠어서, 반례 게시판에서 반례 하나를 건져 왜 틀렸는지 분석했다.
- 확실하진 않지만, 도달 가능한 칸 처리를 잘못 진행했던 것 같다.