### PR TITLE
[20250212] BOJ / 골드4 / 주사위 게임 / 이강현

### DIFF
--- a/lkhyun/202502/12 BOJ 골드4 주사위 게임.md
+++ b/lkhyun/202502/12 BOJ 골드4 주사위 게임.md
@@ -1,0 +1,23 @@
+```java
+import java.io.*;
+public class Main{
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        int N = Integer.parseInt(br.readLine());
+
+        double[] expectation = new double[N+1];
+
+        for(int i=1;i<=N;i++){
+            for(int k=1;k<=6;k++){
+                if(i-k >=0){
+                    expectation[i] += expectation[i-k];
+                }
+            }
+            expectation[i] = 1+(expectation[i]/6);
+        }
+        bw.write(expectation[N]+"");
+        bw.flush();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/13250
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [X] 중
- [ ] 하
## ✏️ 문제 설명
주사위를 여러 번 던지고 그 합을 통해 사탕 개수를 얻는다. 사탕 N을 구하기 위해 던져야하는 횟수의 기댓값을 출력.
## 🔍 풀이 방법
dp, k번 던질 때 그 이전 횟수를 이용.
## ⏳ 회고
기댓값에 대해 까먹어서 좀 찾아봤고 문제를 완벽히 이해해서 수식을 세웠다기 보다 예시를 이용해서 푼 느낌. 특정 순간의 기댓값을 구할때 주사위를 이미 한번 던져야 그 값을 논할 수 있다는 게 수식의 핵심이었다.