### PR TITLE
[20250212] BOJ / P5 / 버스 노선 / 권혁준

### DIFF
--- a/khj20006/202502/12 BOJ P5 버스 노선.md
+++ b/khj20006/202502/12 BOJ P5 버스 노선.md
@@ -1,0 +1,71 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	static int N, M;
+	static List<int[]> arr;
+	static boolean[] del;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+	}
+	
+	static void ready() throws Exception{
+
+		N = Integer.parseInt(br.readLine());
+		M = Integer.parseInt(br.readLine());
+		arr = new ArrayList<>();
+		del = new boolean[M+1];
+		for(int i=1;i<=M;i++) {
+			nextLine();
+			int a = nextInt(), b = nextInt();
+			if(a < b) {
+				arr.add(new int[] {a,b,i});
+				arr.add(new int[] {N+a,N+b,i});
+			}
+			else {
+				arr.add(new int[] {a,N+b,i});
+			}
+		}
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		Collections.sort(arr, (a,b) -> {
+			if(a[0] == b[0]) return b[1]-a[1];
+			return a[0]-b[0];
+		});
+		
+		int mx = 0;
+		for(int[] now : arr) {
+			int l = now[0], r = now[1], x = now[2];
+			if(r<=mx) del[x] = true;
+			else mx = r;
+		}
+		for(int i=1;i<=M;i++) if(!del[i]) bw.write(i + " ");
+		
+		
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/10165

## 🧭 풀이 시간
15분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 원의 둘레에 버스 정류소 $N$개가 시계 방향으로 $0$번부터 $N-1$번까지 존재한다.
- $M$개의 버스 노선이 각각 $[l,r]$의 형태로 주어지고, $l$번 정류소부터 시계 방향으로 $r$번 정류소까지 잇는다.
- 어떤 노선이 다른 노선 안에 포함되면 그 노선을 제거한다고 할 때, 제거되지 않는 노선들을 모두 구해보자.

## 🔍 풀이 방법
- 노선을 시작점 기준으로 정렬해놓으면, $i < j$이면서 $r_j <= \max(r_1, \cdots, r_{j-1})$이면, 노선 $j$는 제거된다는 성질을 이용한다.
- 원형의 길을 일자로 편다고 생각하면, $l<r$인 노선 $[l,r]$에 대해서는 노선 $[N+l,N+r]$을 추가하면 된다.

## ⏳ 회고
원형 길을 일자로 만드는 발상을 못 떠올리면 어려울 것 같다.