### PR TITLE
[20250212] BOJ / P3 / 얼룩말 아트 / 권혁준

### DIFF
--- a/khj20006/202502/12 BOJ P3 얼룩말 아트.md
+++ b/khj20006/202502/12 BOJ P3 얼룩말 아트.md
@@ -1,0 +1,166 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	static int[][] SQ, arr;
+	static int W, H, K;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+	}
+	
+	static void ready() throws Exception{
+
+		nextLine();
+		H = nextInt();
+		W = nextInt();
+		K = nextInt();
+		SQ = new int[W+2][H+2];
+		arr = new int[W+2][H+2];
+		
+	}
+	
+	static void solve() throws Exception{
+
+		while(K-- > 0) {
+			nextLine();
+			int op = nextInt(), py = nextInt(), px = nextInt();
+			px++;
+			py++;
+			if(op == 1) {
+				int qy = nextInt(), qx = nextInt();
+				qx++;
+				qy++;
+				Square(px,py,qx,qy);
+			}
+			else {
+				int r = nextInt();
+				if(r == 1) {
+					arr[px][py]++;
+					arr[px+1][py]++;
+					arr[px-1][py]++;
+					arr[px][py+1]++;
+					arr[px][py-1]++;
+				}
+				else {
+					RightUp(px-1,py+1,r-2);
+					RightDown(px+1,py+1,r-2);
+					LeftUp(px-1,py-1,r-2);
+					LeftDown(px+1,py-1,r-2);
+					Square(px-r,py,px+r,py);
+					Square(px,py-r,px,py+r);
+					arr[px][py]--;
+				}
+			}
+		}
+		
+		for(int i=1;i<=W;i++) {
+			int s = 0;
+			for(int j=1;j<=H;j++) {
+				SQ[i+1][j] += SQ[i][j];
+				s += SQ[i][j];
+				arr[i][j] += s;
+				bw.write(arr[i][j]%2 == 0 ? '.' : '#');
+			}
+			bw.write("\n");
+		}
+		
+		
+	}
+	
+	static void Square(int px, int py, int qx, int qy) {
+		SQ[px][py]++;
+		SQ[qx+1][py]--;
+		SQ[px][qy+1]--;
+		SQ[qx+1][qy+1]++;
+	}
+	
+	static void RightUp(int x, int y, int r) {
+		if(r == 0) {
+			arr[x][y]++;
+			return;
+		}
+		if(r == 1) {
+			arr[x][y]++;
+			arr[x-1][y]++;
+			arr[x][y+1]++;
+			return;
+		}
+		int nr = r/2;
+		Square(x-nr,y,x,y+nr);
+		RightUp(x-nr-1,y,(r-1)/2);
+		RightUp(x,y+nr+1,(r-1)/2);
+	}
+	
+	static void RightDown(int x, int y, int r) {
+		if(r == 0) {
+			arr[x][y]++;
+			return;
+		}
+		if(r == 1) {
+			arr[x][y]++;
+			arr[x+1][y]++;
+			arr[x][y+1]++;
+			return;
+		}
+		int nr = r/2;
+		Square(x,y,x+nr,y+nr);
+		RightDown(x+nr+1,y,(r-1)/2);
+		RightDown(x,y+nr+1,(r-1)/2);
+	}
+	
+	static void LeftUp(int x, int y, int r) {
+		if(r == 0) {
+			arr[x][y]++;
+			return;
+		}
+		if(r == 1) {
+			arr[x][y]++;
+			arr[x-1][y]++;
+			arr[x][y-1]++;
+			return;
+		}
+		int nr = r/2;
+		Square(x-nr,y-nr,x,y);
+		LeftUp(x-nr-1,y,(r-1)/2);
+		LeftUp(x,y-nr-1,(r-1)/2);
+	}
+	
+	static void LeftDown(int x, int y, int r) {
+		if(r == 0) {
+			arr[x][y]++;
+			return;
+		}
+		if(r == 1) {
+			arr[x][y]++;
+			arr[x+1][y]++;
+			arr[x][y-1]++;
+			return;
+		}
+		int nr = r/2;
+		Square(x,y-nr,x+nr,y);
+		LeftDown(x+nr+1,y,(r-1)/2);
+		LeftDown(x,y-nr-1,(r-1)/2);
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16436

## 🧭 풀이 시간
60+분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
- 모든 칸이 흰색인 $H \times W$ 크기의 2차원 격자 칸에 그림을 그리려 한다.
- 그림은 두 가지 중 하나이다.
1. 왼쪽 위 칸이 (px,py) 이고, 오른쪽 아래 칸이 (qx,qy)인 직사각형 범위의 색을 반전시킨다.
2. 중심점 (px,py)로부터 거리가 r 이내인 칸들의 색을 반전시킨다.
- 색 반전이란, 흰 칸을 검은 칸으로, 검은 칸을 흰 칸으로 바꾸는 걸 말한다.
- 그림을 다 그린 후의 격자 모습을 출력해보자.

## 🔍 풀이 방법
- 그림의 개수가 많아서, 각 그림마다 직접 모든 칸을 방문할 수는 없다.
- 2차원 배열 SQ를 정의해서, SQ[i][j]에 적힌 수만큼 직사각형 (i,j) ~ (H,W)에 그림을 그린다는 의미로 사용할 것이다.
- 직사각형 모양의 그림 (px,py), (qx,qy)가 주어지는 경우에는 쉽게 처리할 수 있다.
- `SQ[px][py]++, SQ[qx+1][py]--, SQ[px][qy+1]--, SQ[qx+1][qy+1]++`
- 이는 2차원 상에서의 누적 합을 떠올려보면 된다.
- 1번 그림을 한 번 그리는 시간복잡도는 $O(1)$이 되었다.
---
- 문제는, 2번 그림이다.
- 먼저, (px,py)를 관통하는 십자 모양의 범위는 앞선 SQ배열의 직사각형 처리로 구현 가능하니, 십자 모양은 제외하고 생각한다.
- 그러면 네 개의 계단 모양이 남게 되는데, 돌리면 모두 같은 모양이니까 하나의 경우로 일반화해서 생각해보려 한다.
![image](https://github.com/user-attachments/assets/8c00394e-19af-4b64-8558-70c2995a525b)
- 위처럼, (x,y)부터 r만큼 떨어진 계단 모양을 채우는 함수를 Stair라고 가정한다.
- Stair(x,y,r)에서는, 크기가 r/2인 정사각형 모양을 채우고 나면, 너비가 절반으로 줄어든 계단 두 개로 나뉜다.
- 이처럼 재귀적으로 Stair함수를 통해 그림을 그리도록 구성해 주었다.
- 이 2번 그림을 한 번 그리는 시간복잡도는 $O(r \log{r})$이고, $r$의 최댓값을 $R$이라 하면 그림을 $K$개 처리하는데는 $O(KR\log{R})$이다.

## ⏳ 회고
난 저 시간복잡도면 통과할 줄 알았는데
안 된다.
저거 말고 다른 방법이 안 떠오른다 전혀