### PR TITLE
[20250212] BOJ / P5 / 두 가중치 / 권혁준

### DIFF
--- a/khj20006/202502/12 BOJ P5 두 가중치.md
+++ b/khj20006/202502/12 BOJ P5 두 가중치.md
@@ -1,0 +1,87 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	static int[][] D;
+	static int[][] cost1;
+	static int[][] cost2;
+	
+	static int N;
+	static final int INF = (int)1e9 + 5;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+	}
+	
+	static void ready() throws Exception{
+
+		N = Integer.parseInt(br.readLine());
+		D = new int[N][N*9+1];
+		for(int i=0;i<N;i++) Arrays.fill(D[i], INF);
+		
+		cost1 = new int[N][N];
+		for(int i=0;i<N;i++) {
+			char[] arr = br.readLine().toCharArray();
+			for(int j=0;j<N;j++) {
+				if(arr[j] == '.') continue;
+				cost1[i][j] = arr[j]-'0';
+			}
+		}
+		
+		cost2 = new int[N][N];
+		for(int i=0;i<N;i++) {
+			char[] arr = br.readLine().toCharArray();
+			for(int j=0;j<N;j++) {
+				if(arr[j] == '.') continue;
+				cost2[i][j] = arr[j]-'0';
+			}
+		}
+		
+	}
+	
+	static void solve() throws Exception{
+
+		PriorityQueue<int[]> PQ = new PriorityQueue<>((a,b) -> a[0]-b[0]);
+		PQ.offer(new int[] {0,0,0});
+		D[0][0] = 0;
+		while(!PQ.isEmpty()) {
+			int[] now = PQ.poll();
+			int w = now[0], s = now[1], n = now[2];
+			if(w > D[n][s]) continue;
+			for(int i=0;i<N;i++) {
+				if(cost1[n][i] == 0) continue;
+				if(s+cost1[n][i] <= N*9 && D[i][s+cost1[n][i]] > w + cost2[n][i]) {
+					D[i][s+cost1[n][i]] = w + cost2[n][i];
+					PQ.offer(new int[] {w+cost2[n][i],s+cost1[n][i],i});
+				}
+			}
+		}
+		
+		int ans = INF;
+		for(int i=0;i<=N*9;i++) if(D[1][i] != INF) ans = Math.min(ans, D[1][i]*i);
+		bw.write((ans==INF ? -1 : ans) + "\n");
+		
+	}
+	
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/12930

## 🧭 풀이 시간
18분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- N개의 정점으로 이루어진 그래프 G가 있다. 그래프의 정점은 0번부터 N-1번까지 번호가 매겨져 있다.
- 그래프 G의 모든 간선은 가중치를 2개 가지고 있고, 각각을 가중치 1, 가중치 2라고 한다.
- 0번 정점에서 1번 정점으로 가는 최단 경로를 찾는 프로그램을 작성하시오. 경로의 비용은 경로에 있는 간선의 가중치 1을 모두 더한 값인 W1과 가중치 2를 모두 더한 값인 W2를 곱해서 구할 수 있다.

## 🔍 풀이 방법
- 최단 경로를 좀 더 세부적인 상태에 대해 구한다.
- 구체적으로, `D[i][s]`에는 i번 정점까지 오는 데 가중치 1의 합이 s인 경우의 가중치 2의 합 중 최솟값으로 정의한다.
- 0번 점에서 시작하는 다익스트라로 배열 `D`를 채울 수 있고, 답은 $D[1][i] \times i$ 중 제일 작은 값이 된다.

## ⏳ 회고
그동안 문제 풀면서 이 문제와 비슷한(상태를 세분화하는 유형)문제를 많이 접했었다.
연습해두면 좋을듯