### PR TITLE
[20250212] BOJ / G4 / 소수 게임 / 김수연

### DIFF
--- a/suyeun84/202502/12 BOJ G4 소수 게임.md
+++ b/suyeun84/202502/12 BOJ G4 소수 게임.md
@@ -1,0 +1,76 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class Solution
+{
+	static ArrayList<Integer> dList;
+	static ArrayList<Integer> gList;
+	static long dScore = 0;
+	static long gScore = 0;
+	static boolean[] prime = new boolean[5000001];
+	static boolean[] primeExist = new boolean[5000001];
+	public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        dList = new ArrayList<>();
+        gList = new ArrayList<>();
+        
+        primeNumber();
+        int N = Integer.parseInt(st.nextToken());
+        for (int i = 0; i < N; i++) {
+        	st = new StringTokenizer(br.readLine());
+        	int d = Integer.parseInt(st.nextToken());
+        	int g = Integer.parseInt(st.nextToken());
+        	//1. 소수 아닌 수 -> 상대방은 지금까지 상대방이 말한 소수 중 3번째로 큰 수만큼 점수 (3개 미만 -> 1000점)
+        	//2. 이미 등장한 소수 -> 해당 팀 -1000, 기록x
+        	if (prime[d]) { // 소수 아님
+        		if (gList.size() < 3) {
+        			gScore += 1000;
+        		} else if (gList.size() >= 3) {
+        			gScore += gList.get(0);
+        		}
+        	} else {
+        		if (primeExist[d]) dScore -= 1000;
+        		else {
+        			dList.add(d);
+        			primeExist[d] = true;
+        			Collections.sort(dList);
+        			if (dList.size() > 3) dList.remove(0);
+        		}
+        	}
+        	if (prime[g]) {
+        		if (dList.size() < 3) {
+        			dScore += 1000;
+        		} else if (dList.size() >= 3) {
+        			dScore += dList.get(0);
+        		}
+        	} else {
+        		if (primeExist[g]) gScore -= 1000;
+        		else {
+        			gList.add(g);
+        			primeExist[g] = true;
+        			Collections.sort(gList);
+        			if (gList.size() > 3) gList.remove(0);
+        		}
+        	}
+        }
+        if (dScore > gScore) System.out.println("소수의 신 갓대웅");
+        else if (dScore == gScore) System.out.println("우열을 가릴 수 없음");
+        else System.out.println("소수 마스터 갓규성");
+	}
+	
+	public static void primeNumber() { //소수 아닌게 true
+		prime[0] = true;
+		prime[1] = true;
+		for (int i = 2; i*i <= 5000000; i++) {
+			if (prime[i]) continue;
+			for (int j = i*2; j <= 5000000; j+=i) {
+				prime[j] = true;
+			}
+		}
+	}
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14622
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
두 사람이 번갈아 가면서 소수를 말하는데
1. 소수가 아닌 수를 부르는 경우 
    -> 상대방이 말한 소수중 3번째로 큰 수만큼 점수 얻음
    -> 상대방이 말한 소수 3개 미만이면 상대가 1000점 얻음
2. 지금까지 한번이라도 등장한 소수를 말할 경우
    -> 해당 소수 말한 팀 -1000점 얻고, 말한 소수로 기록되지 않음
## 🔍 풀이 방법
**소수인지 여부 ** 
**[에라토스테네스의 체]** 사용해서 5000000길이의 prime배열에 소수 여부 저장해둠.

**지금까지 등장한 소수인지 여부**
 5000000길이의 primeExist배열에 등장 여부 저장해둠.

**지금까지 상대방이 말한 소수 중 3번째로 큰 수**
ArrayList에 저장하되, 오름차순으로 정렬하고, 길이가 3이 넘어가면 바로 index 0 삭제하기
## ⏳ 회고
에라토스테네스의 체에 대해서 더 공부해야겠다..
그리고 소수여부, 등장한소수여부와 같은거는 그냥 배열 만들어서 저장해두는게 훨씬 빠르다.. 
(안하면 시간초과....난다....)