### PR TITLE
[20250212] BOJ / P3 / 별다줄 / 권혁준

### DIFF
--- a/khj20006/202502/12 BOJ P3 별다줄.md
+++ b/khj20006/202502/12 BOJ P3 별다줄.md
@@ -1,0 +1,99 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Node{
+	Node[] next;
+	int cnt;
+	Node(){
+		next = new Node[26];
+		cnt = 0;
+	}
+}
+
+class Trie{
+	Node root;
+	Trie(){
+		root = new Node();
+	}
+	void insert(String str) {
+		Node now = root;
+		for(char i:str.toCharArray()) {
+			if(now.next[i-'a'] == null) now.next[i-'a'] = new Node();
+			now = now.next[i-'a'];
+			now.cnt++;
+		}
+	}
+}
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	static Trie trie;
+	static int N;
+	static long[][] count;
+	static long[] dp;
+	static long mod = (long)1e9 + 7;
+	static String S;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+	}
+	
+	static void ready() throws Exception{
+
+		trie = new Trie();
+		N = Integer.parseInt(br.readLine());
+		for(int i=0;i<N;i++) trie.insert(br.readLine());
+		
+		S = br.readLine();
+		dp = new long[S.length()+1];
+		count = new long[S.length()+1][301];
+
+	}
+	
+	static void solve() throws Exception{
+
+		for(int i=1;i<=S.length();i++) {
+			
+			Node now = trie.root;
+			// i로 시작하는 문자열, 길이 300까지만
+			for(int j=1;i+j-2<S.length();j++) {
+				// count[i+j-1][j]
+				
+				int x = S.charAt(i+j-2)-'a';
+				if(now.next[x] == null) break;
+				now = now.next[x];
+				count[i+j-1][j] = now.cnt;
+				
+			}
+		}
+		
+		dp[0] = 1;
+		for(int i=1;i<=S.length();i++) for(int j=1;j<=Math.min(300, i);j++) {
+			dp[i] += (dp[i-j] * count[i][j]);
+			dp[i] %= mod;
+		}
+		bw.write(dp[S.length()]+"\n");
+		
+	}
+	
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17365

## 🧭 풀이 시간
35분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- $N$개의 단어가 주어지며, 각 단어의 길이는 300 이하이고 모든 단어의 길이 합은 $10^6$이하이다.
- 단어들을 아무렇게나 배치한 `문장`을 만들 수 있다.
- `문장`에 사용하지 않는 단어가 있어도 되고, 여러 번 쓰이는 단어가 있어도 된다.
- `문장`을 이루는 각 단어의 앞부분에서 한 글자 이상의 부분 문자열을 따서 이어붙여 `문장`을 줄일 수 있다.
- 길이 $200\,000$이하의 문자열 $S$가 주어지면, $S$로 줄일 수 있는 문장의 개수를 구해보자.

## 🔍 풀이 방법
- 각 단어의 길이 제한이 300이니, `dp[i] = S의 i번째 문자까지 고려했을 때의 문장 개수`로 정의하면, i 앞으로 최대 300글자만 보면 된다.
- S에 존재할 수 있는 모든 줄인 단어의 경우의 수를 구하면 된다.
- 효율적으로 구하기 위해 트라이를 사용했고, 트라이의 각 노드에는 길이 26짜리 배열을 저장해서 다음 알파벳으로 가는 길이 있는지 여부를 저장했다.
- 노드에 트라이의 루트부터 내려왔을 때 만들어지는 단어로 가능한 경우의 수를 같이 저장했다.
- count[i][j] = S의 i번째 글자에서 끝나는 길이 j인 단어로 가능한 경우의 수라고 하면, 미리 구성해둔 트라이를 이용해 count배열을 모두 구할 수 있다.
- dp[i] = dp[i-1] $\times$ count[i][1] + dp[i-2] $\times$ count[i][2] + ... 이다.

## ⏳ 회고
- 단어의 경우의 수를 구할 때 최적화를 위해 트라이를 사용해야 한다는 걸 캐치한 후로는 순조로웠다