### PR TITLE
[20250212] BOJ / 골드3 / K진 트리 / 이강현

### DIFF
--- a/lkhyun/202502/12 BOJ 골드3 K진 트리.md
+++ b/lkhyun/202502/12 BOJ 골드3 K진 트리.md
@@ -1,0 +1,58 @@
+```java
+import java.util.*;
+import java.io.*;
+public class Main{
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        long N = Long.parseLong(st.nextToken());
+        long K = Integer.parseInt(st.nextToken());
+        long Q = Integer.parseInt(st.nextToken());
+
+        for(int i=0;i<Q;i++){
+            st = new StringTokenizer(br.readLine());
+            long x = Long.parseLong(st.nextToken());
+            long y = Long.parseLong(st.nextToken());
+            long start = Math.min(x,y); //start를 작은걸로
+            long end = Math.max(x,y);   //end를 큰걸로 고정
+            if(K == 1){
+                bw.write((end-start)+"\n");
+                continue;
+            }
+            long startdepth = findDepth(start,K);
+            long enddepth = findDepth(end,K);
+            long depthDiff = enddepth - startdepth;
+            long dist = 0;
+            for(int j=0;j<depthDiff;j++){
+                end = findParent(end, K);
+                dist++;
+            }
+            while(start!=end){
+                start = findParent(start, K);
+                end = findParent(end, K);
+                dist+=2;
+            }
+            bw.write(dist+"\n");
+        }
+        bw.flush();
+    }
+    public static long findDepth(long x,long K){
+        long finder = 1;
+        long depth = 1;
+        while(x > finder){
+            finder *= K;
+            finder += 1;
+            depth++;
+        }
+        return depth;
+    }
+    public static long findParent(long x,long K){
+        if(x%K==0 || x%K==1){
+            return x/K;
+        }else{
+            return x/K + 1;
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11812
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [X] 중
- [ ] 하
## ✏️ 문제 설명
자식을 K개 갖는 K진 트리에서 특정 노드 두 개의 값이 주어질때 그 두 노드 사이의 거리를 출력하는 문제.
## 🔍 풀이 방법
2,3,4진 트리를 각각 depth 3까지 그려보고 x가 주어질때 부모노드를 찾는 함수, x가 주어질때 깊이를 알려주는 함수 두 개를 구현했다. 이후 두 노드의 깊이 차이를 구해서 더 깊은 노드를 같은 깊이까지 맞춘 후 함께 올라오면서 부모가 같아질때까지의 거리를 계산했다.
## ⏳ 회고
처음에 number format exception이 생겨서 int가 아닌 long을 써야함을 알았고 큰 값이 들어오는 것을 의식해서 큰 값을 넣어보던 중 계산이 너무 오래 걸리는 테스트 케이스가 있었는데 1진 트리인 경우 노드의 개수가 곧 실행시간이라서 노드의 차를 바로 반환하도록 예외처리를 해주어야 했다. k진 트리의 특성을 알게 되었다.