### PR TITLE
[20250213] BOJ / G3 / K진 트리 / 권혁준

### DIFF
--- a/khj20006/202502/13 BOJ G3 K진 트리.md
+++ b/khj20006/202502/13 BOJ G3 K진 트리.md
@@ -1,0 +1,74 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	static long N, K, Q;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+	}
+	
+	static void ready() throws Exception{
+
+		nextLine();
+		N = nextLong();
+		K = nextLong();
+		Q = nextLong();
+
+	}
+	
+	static void solve() throws Exception{
+
+		while(Q-- > 0) {
+			nextLine();
+			long x = nextLong(), y = nextLong();
+			bw.write(dist(x-1,y-1) + "\n");
+		}
+		
+	}
+	
+	static long dist(long x, long y) throws Exception{
+		if(K == 1) return Math.abs(x-y);
+		List<Long> X = find(x), Y = find(y);
+		int i = X.size()-1, j = Y.size()-1;
+		
+		while(i>=0 && j>=0 && X.get(i).equals(Y.get(j))){
+			i--;
+			j--;
+		}
+		return i+j+2;
+	}
+	
+	static List<Long> find(long x){
+		List<Long> result = new ArrayList<>();
+		
+		result.add(x);
+		while(x > 0) {
+			x = (x-1)/K;
+			result.add(x);
+		}
+		return result;
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11812

## 🧭 풀이 시간
60+분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
점이 $N$개인 `완전 K진 트리`에서 두 점 사이의 거리를 $Q$번 구해보자.

## 🔍 풀이 방법
- 루트 번호가 1이면 불편해서 0으로 시작하는 걸로 가정하고, $x,y$ 쌍이 주어지면 1씩 빼서 계산을 진행했다.
1. K = 1인 경우
- 트리가 일자 형태라서 그냥 두 점 번호의 차이 구하기
2. K >= 2인 경우
- $x$의 부모 번호는 $\lfloor \frac{x-1}{K} \rfloor$라는 사실을 이용했다.
- 두 점 $x,y$가 각각 루트로 향하는 경로를 List로 $X,Y$에 저장했고, 두 List의 원소를 비교해가며 거리를 구해주었다.

## ⏳ 회고
- 진짜 뭐가 잘못됐는지 몰라서 50분 날리고 쥐피티님께 물어봤다.
- 비교할 때 `X.get(i) == Y.get(j)` 로 하니까 틀리고 `X.get(i).equals(Y.get(j))` 로 하니까 맞았다.
### 왜 틀렸지?
- `==` 연산자는 Primitive type에 대해서는 **값 비교**를 수행하고, Reference Type에 대해서는 **주소 비교**를 수행한다.
- Reference type의 `equals` 메소드는 객체에 대한 값 비교를 수행한다.
-> 경로 X, Y를 저장할 때 List의 타입을 Long으로 해줬고, Long은 Reference type이라 실제 값 비교가 제대로 되지 않은 듯하다.
- 앞으로 조심하자