### PR TITLE
[20250213] BOJ / 골드4 / 오렌지 출하 / 설진영

### DIFF
--- a/Seol-JY/202502/13 BOJ G4 오렌지 출하.md
+++ b/Seol-JY/202502/13 BOJ G4 오렌지 출하.md
@@ -1,0 +1,38 @@
+```java
+import java.io.*;
+import java.util.StringTokenizer;
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        final int N = Integer.parseInt(st.nextToken());
+        final int M =Integer.parseInt(st.nextToken());
+        final int K = Integer.parseInt(st.nextToken());
+
+        int[] arr = new int[N];
+        long[] dp = new long[N+1];
+        for (int i = 0; i < N; i++) {
+            arr[i] = Integer.parseInt(br.readLine());
+        }
+
+        dp[1] = K;
+        for (int index = 1; index < N; index++) {
+            long min = Long.MAX_VALUE;
+            long max = Long.MIN_VALUE;
+
+            long finalMin = Long.MAX_VALUE;
+            for (int i = 0; i < M; i++) {
+                if(index - i - 1 < -1) break;
+                min = Math.min(min, arr[index - i]);
+                max = Math.max(max, arr[index - i]);
+                finalMin = Math.min(finalMin, dp[index - i] + K + (i + 1) * (max - min));           
+            }
+        
+            dp[index+1] = finalMin;
+        }
+        System.out.println(dp[N]);
+        
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11985
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명 
박스 비용 + 박스 내 오렌지 개수*(박스 내 오렌지 최대 크기 - 박스 내 오렌지 최소 크기)  공식이 주어지고, 박스에 담을 수 있는 오오렌지의 최대 개수가 주어질 때, 오렌지 포장 비용 최솟값 구하기

## 🔍 풀이 방법
DP로 푼다. 박스에 담을 수 있는 오렌지의 최대 개수만큼 반복을 돌리고, 바로 그 이전에 최소 비용을 더하는 방식으로 1차원 DP 배열을 만들어 마지막 값을 출력하면 된다.
## ⏳ 회고
DP는 점화식만 세울 수 있으면 쉬운듯(<<< 이게 제일 어려움)
반복 시작 전 초기값 결정이 어려웠는데, 배열 시작 지점 앞에 빈 칸이 있으면 코드가 훨씬 간결해진다.