### PR TITLE
[20250213] BOJ / 골드4 / 연산자 끼워넣기 / 이강현

### DIFF
--- a/lkhyun/202502/13 BOJ 골드4 연산자 끼워넣기(3).md
+++ b/lkhyun/202502/13 BOJ 골드4 연산자 끼워넣기(3).md
@@ -1,0 +1,88 @@
+```java
+import java.util.*;
+import java.io.*;
+public class Main{
+    static int N;
+    static int[] numbers;
+    static int[] operator = new int[4];
+    static int max = Integer.MIN_VALUE;
+    static int min = Integer.MAX_VALUE;
+    static ArrayDeque<Integer> operation = new ArrayDeque<>();
+
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        N = Integer.parseInt(br.readLine());
+        numbers = new int[N];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for(int i=0;i<N;i++){
+            numbers[i] = Integer.parseInt(st.nextToken());
+        }
+        st = new StringTokenizer(br.readLine());
+        for(int i=0;i<4;i++){
+            operator[i] = Integer.parseInt(st.nextToken());
+        }
+        findMaxMin(0);
+        bw.write(max+"\n");
+        bw.write(min+"\n");
+        bw.flush();
+    }
+
+    public static void findMaxMin(int depth){
+        if(depth == N-1){
+            int total = 0;
+            int lastElement = numbers[depth];
+            ArrayDeque<Integer> operandStk = new ArrayDeque<>();
+            ArrayDeque<Integer> operatorStk = new ArrayDeque<>();
+            ArrayDeque<Integer> provider = operation.clone();
+            while(!provider.isEmpty()){
+                if(!operandStk.isEmpty() && !operatorStk.isEmpty() && operatorStk.getLast()>=2){
+                    int operand = operandStk.pollLast();
+                    int opcode = operatorStk.pollLast();
+                    int result = calculate(operand, provider.pollFirst(), opcode);
+                    operandStk.addLast(result);
+                    operatorStk.addLast(provider.pollFirst());
+                }else{
+                    operandStk.addLast(provider.pollFirst());
+                    operatorStk.addLast(provider.pollFirst());
+                }
+            }
+            if(!operatorStk.isEmpty() && operatorStk.getLast()>=2){
+                lastElement = calculate(operandStk.pollLast(), lastElement, operatorStk.pollLast());
+            }
+            operandStk.addLast(lastElement);
+            total = operandStk.pollFirst();
+            while(!operandStk.isEmpty() && !operatorStk.isEmpty()){
+                total = calculate(total, operandStk.pollFirst(), operatorStk.pollFirst());
+            }
+            max = Math.max(max,total);
+            min = Math.min(min,total);
+            return;
+        }
+        
+        for(int i=0;i<4;i++){
+            if(operator[i] > 0){
+                operation.addLast(numbers[depth]);
+                operation.addLast(i);
+                operator[i]--;
+                findMaxMin(depth+1);
+                operator[i]++;
+                operation.pollLast();
+                operation.pollLast();
+            }
+        }
+    }
+    public static int calculate(int x, int y, int op){// 0:+ 1:- 2:x 3:/
+        if(op==0){
+            return x+y;
+        }else if(op==1){
+            return x-y;
+        }else if(op==2){
+            return x*y;
+        }else if(op==3){
+            return x/y;
+        }
+        return 0;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/15659
## 🧭 풀이 시간
120분

## 👀 체감 난이도
- [ ] 상
- [X] 중
- [ ] 하
## ✏️ 문제 설명
순서가 정해져 있는 N개의 수 사이에 입력으로 주어진 N-1 개의 연산자를 끼워넣었을 때 최댓값과 최솟값을 구하는 문제
## 🔍 풀이 방법
백트래킹을 이용해서 수식이 만들어지는 모든 경우의 수를 구하고 이를 계산한다. 스택을 이용하여 연산자 우선순위를 고려한다.
## ⏳ 회고
문제 자체는 크게 어렵진 않은 거 같은데 연산자 우선순위가 존재해서 중간 중간 스택을 잘 이용해서 수식을 최적화 해야 했는데 지금 타이밍에서 앞에서 빼야하는지 뒤에서 빼야하는지가 자꾸 헷갈려서 오래 걸렸다....