### PR TITLE
[20250214] BOJ / G3 / 행성 X3 / 신동윤

### DIFF
--- a/03do-new30/202502/14 BOJ G3 행성 X3.md
+++ b/03do-new30/202502/14 BOJ G3 행성 X3.md
@@ -1,0 +1,52 @@
+```java
+import java.io.*;
+import java.math.BigInteger;
+
+public class Main {
+
+	static int MAX_IDX = 20; // 2의 20승이 1,000,000과 가장 가까움
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+		int N = Integer.parseInt(br.readLine());
+		int[][] arr = new int[N][MAX_IDX]; // N번째 숫자 이진수로 변환한 결과를 담는다. arr[i][j] = i번째 숫자의 j번째 비트
+
+		for (int i = 0; i < N; i++) {
+			String binary = Integer.toBinaryString(Integer.parseInt(br.readLine()));
+			// binary 문자열의 인덱스 역순으로 arr[i]에 담아준다.
+			int binaryLength = binary.length();
+			for (int j = 0; j < binaryLength; j++) {
+				arr[i][j] = binary.charAt(binaryLength - j - 1) - '0';
+			}
+		}
+
+		BigInteger answer = BigInteger.ZERO;
+		// 2^j + (j열에 있는 모든 1의 개수 * j열에 있는 모든 0의 개수)
+		for (int j = 0; j < MAX_IDX; j++) {
+			// j열에 있는 모든 1의 개수
+			int cntOne = 0;
+			// j열에 있는 모든 0의 개수
+			int cntZero = 0;
+			for (int i = 0; i < N; i++) {
+				if (arr[i][j] == 1) {
+					cntOne++;
+				} else {
+					cntZero++;
+				}
+			}
+			BigInteger tmp1 = BigInteger.valueOf((long) Math.pow(2, j));
+			BigInteger tmp2 = BigInteger.valueOf((long) cntOne * cntZero);
+			BigInteger result = tmp1.multiply(tmp2);
+			answer = answer.add(result);
+		}
+
+		bw.write(answer + "\n");
+
+		br.close();
+		bw.flush();
+		bw.close();
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2830

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- X와 Y의 친밀도는 `X^Y`로 구해진다.
- 행성 거주민들의 모든 친밀도의 합을 구한다.

## 🔍 풀이 방법
- 각 주민이 `0, 1, 1, 1, 0, 1`일 때, 모든 주민 간 친밀도의 합을 구해보자
- `xor 연산 결과가 1인 경우 == 1과 0이 페어가 되는 경우`라고 생각해도 된다.
- 따라서 위에서 모든 주민 간 친밀도의 합을 구할 때, `(0의 개수) * (1의 개수)`로 한 번에 구할 수 있다.
- 위 원리를 활용해 각 이진수 자리마다 `xor연산 결과가 1인 경우의 수 * 가중치`를 답에 더해간다.

## ⏳ 회고
- 수학과 친구랑 같이 고민했다 🍯
- 이번에도 `BigInteger` 사용해야 했음
