### PR TITLE
[20250214] BOJ / G3 / 행성 X3 / 권혁준

### DIFF
--- a/khj20006/202502/14 BOJ G3 행성 X3.md
+++ b/khj20006/202502/14 BOJ G3 행성 X3.md
@@ -1,0 +1,54 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	static long ans = 0;
+	static long[] cnt;
+	static long N;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+
+		cnt = new long[20];
+		N = Integer.parseInt(br.readLine());
+		for(int i=0;i<N;i++) {
+			int a = Integer.parseInt(br.readLine());
+			for(int j=0;j<20;j++) if((a & (1<<j)) != 0) cnt[j]++;
+		}
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		for(int i=0;i<20;i++) {
+			ans += (N-cnt[i]) * cnt[i] * (1<<i);
+		}
+		bw.write(ans+"\n");
+		
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2830

## 🧭 풀이 시간
8분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
길이 $N$인 수열 $A$가 주어지면, $\sum \limits_{i=1}^N {\sum \limits_{j=i+1}^N {A_i \oplus A_j}}$를 구해보자.
$\oplus$는 xor을 의미한다.

## 🔍 풀이 방법
- 두 수의 xor은 비트 별로 독립적으로 수행해도 된다.
- 각 비트에 대한 xor을 빠르게 구할 수 있다면, 이를 $O(\log{N})$번 반복해서 전체 문제를 풀 수 있다.
- xor의 성질에 따라 `비트가 켜져있는 수`에서 하나를 고르고, `비트가 꺼져있는 수`에서 하나를 골라야만 $0$이 아닌 수가 나온다.
- $N$개의 수 중, $i$번째 비트가 켜져있는 수의 개수를 $C_i$라고 정의하면, $i$번째 비트에 대한 답은 $C_i \times (N - C_i) \times 2^i$이다.
- 모든 비트에 대해 수행하면 정답을 구할 수 있다.

## ⏳ 회고
