### PR TITLE
[20250214] BOJ / G4 / 어드벤처 게임 / 권혁준

### DIFF
--- a/khj20006/202502/14 BOJ G4 어드벤처 게임.md
+++ b/khj20006/202502/14 BOJ G4 어드벤처 게임.md
@@ -1,0 +1,102 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	static int N;
+	static int[] M;
+	static char[] T;
+	static boolean[][] V;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		//solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = Integer.parseInt(br.readLine());
+		while(N != 0) {
+			
+			M = new int[N+1];
+			T = new char[N+1];
+			V = new boolean[N+1][N+1];
+			
+			for(int i=1;i<=N;i++) {
+				
+				nextLine();
+				T[i] = st.nextToken().charAt(0);
+				M[i] = nextInt();
+				for(int a=nextInt();a!=0;a=nextInt()) V[i][a] = true;
+				
+			}
+			
+			solve();
+			
+			N = Integer.parseInt(br.readLine());
+		}
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		if(T[1] == 'T' && M[1] > 0) {
+			bw.write("No\n");
+			return;
+		}
+		PriorityQueue<int[]> PQ = new PriorityQueue<>((a,b) -> b[0]-a[0]);
+		PQ.offer(new int[] {M[1],1});
+		int[] D = new int[N+1];
+		Arrays.fill(D, -1);
+		D[1] = M[1];
+		
+		while(!PQ.isEmpty()) {
+			int[] now = PQ.poll();
+			int money = now[0], n = now[1];
+			if(n == N) {
+				bw.write("Yes\n");
+				return;
+			}
+			if(money < D[n]) continue;
+			for(int i=1;i<=N;i++) {
+				if(!V[n][i]) continue;
+				if(T[i] == 'T') {
+					if(money < M[i]) continue;
+					if(D[i] < money-M[i]) {
+						D[i] = money-M[i];
+						PQ.offer(new int[] {D[i],i});
+					}
+				}
+				else {
+					if(D[i] < Math.max(money, M[i])) {
+						D[i] = Math.max(money, M[i]);
+						PQ.offer(new int[] {D[i],i});
+					}
+				}
+			}
+		}
+		bw.write("No\n");
+		
+		
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2310

## 🧭 풀이 시간
15분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 어드벤처 게임을 하던 중, 1부터 n까지의 번호가 붙은 방을 지나가야 하는 마법의 미로를 마주쳤다. 각 방 안에는 번호가 붙은 문이 있을 수 있고, 각 문은 해당하는 번호의 방으로 통한다. 방 안에는 레프리콘이나 트롤이 있을 수도 있다.
- 레프리콘이 있는 방에 들어가면 레프리콘은 모험가의 소지금이 일정 양 이하로 떨어지지 않게 채워준다. 레프리콘은 모험가의 소지금이 일정량 미만일 때에는 그만한 양이 되도록 금화를 채워주고, 소지금이 일정량 이상일 때에는 그대로 둔다.
- 트롤이 있는 방에 들어가려면 일정량의 통행료를 지불해야 한다. 이는 맨 처음에 모험가가 1번 방에서 시작하려 할 때에도 마찬가지이다.
- 모험가는 소지금이 0인 상태에서 출발한다. 과연 모험가는 1번 방에서 출발해서 n번 방에 도착할 수 있을까?

## 🔍 풀이 방법
- 다익스트라 비슷하게 해결했다.
- 일반적인 다익스트라에서는 최소 힙을 두고 최소 거리부터 처리하는데, 이 문제에서는 최대 힙을 두고 최대 소지금의 경우부터 먼저 처리해주었다.

## ⏳ 회고
다익스트라 배열 초기 값을 0으로 두니까 소지금 0으로 도착하는 경우를 처리하지 못해서 틀렸었다.
헷갈리는 문제