### PR TITLE
[20250214] BOJ / G2 / 카누 선수 / 권혁준

### DIFF
--- a/khj20006/202502/14 BOJ G2 카누 선수.md
+++ b/khj20006/202502/14 BOJ G2 카누 선수.md
@@ -1,0 +1,47 @@
+```cpp
+
+#include <iostream>
+#include <vector>
+#include <algorithm>
+using namespace std;
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	int T;
+	for (cin >> T; T--;) {
+		int K, N;
+		cin >> K >> N;
+		vector<int> A(N), B(N), C(N), D(N);
+		vector<int> R1, R2;
+		for (int &i : A) cin >> i;
+		for (int &i : B) cin >> i;
+		for (int &i : C) cin >> i;
+		for (int &i : D) cin >> i;
+		for (int i : A)for (int j : B) R1.push_back(i + j);
+		for (int i : C)for (int j : D) R2.push_back(i + j);
+
+
+		int ans = 2e9, diff = 2e9;
+		sort(R2.begin(), R2.end());
+		for (int i : R1) {
+			int p = lower_bound(R2.begin(), R2.end(), K - i) - R2.begin();
+			
+			if (p < R2.size()) {
+				int v = abs(R2[p] + i-K);
+				if (v < diff) diff = v, ans = R2[p] + i;
+                else if(v == diff) ans = min(ans, R2[p] + i);
+			}
+			if (0 <= p-1 && p-1 <= R2.size()) {
+				int v = abs(R2[p - 1] + i-K);
+				if (v < diff) diff = v, ans = R2[p-1] + i;
+                else if(v == diff) ans = min(ans, R2[p-1] + i);
+			}
+		}
+		cout << ans << '\n';
+
+	}
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/9007

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
- 길이가 모두 $N$인 수열 $A, B, C, D$와, 정수 $K$가 주어진다.
- 각 수열에서 원소를 하나씩 골라 더했을 때 $K$에 최대한 가깝게 만들어보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- 중간에서 만나기 (meet in the middle), 정렬, 이분 탐색
---
- $N \le 1 \, 000$이라서 수열 두 개에서 가능한 합의 가짓수는 $1 \, 000 \, 000$ 이하이다.
- $A, B$에서 가능한 합의 배열 $R_1$을 구하고, $C, D$에서 가능한 합의 배열 $R_2$를 구한다.
- $R_1$에서 각 원소를 골랐을 때 최적이 되는 $R_2$의 원소는 $O(\log{ |R_2| })$에 구할 수 있다.

## ⏳ 회고
이거랑 거의 똑같은 문제를 풀었던 적이 있어서 수월했다.
-> https://www.acmicpc.net/problem/7453