### PR TITLE
[20250214] BOJ / G4 / 모자이크 / 권혁준

### DIFF
--- a/khj20006/202502/14 BOJ G4 모자이크.md
+++ b/khj20006/202502/14 BOJ G4 모자이크.md
@@ -1,0 +1,81 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+    static int N, M, C, K;
+	static List<int[]> wrong;
+    static boolean[] exist;
+    static int max_x = 0;
+
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+        nextLine();
+        N = nextInt();
+        M = nextInt();
+
+        C = Integer.parseInt(br.readLine());
+        K = Integer.parseInt(br.readLine());
+        wrong = new ArrayList<>();
+        exist = new boolean[M+1];
+
+        for(int i=0;i<K;i++){
+            nextLine();
+            int x = nextInt(), y = nextInt();
+            wrong.add(new int[]{x,y});
+            max_x = Math.max(max_x, x);
+            exist[y] = true;
+        }
+
+	}
+	
+	static void solve() throws Exception{
+
+        int s = max_x, e = M, m = (s+e) >> 1;
+        while(s < e){
+
+            // m 센티미터의 색종이들 C개로 다 가릴 수 있는지?
+            int cnt = 0;
+            int p = 1;
+            while(p <= M){
+                while(p <= M && !exist[p]) p++;
+                if(p > M) break;
+                cnt++;
+                p += m;
+            }
+
+            if(cnt > C) s = m+1;
+            else e = m;
+            m = (s+e)>>1;
+
+        }
+
+        bw.write(m+"\n");
+
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2539

## 🧭 풀이 시간
45분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
- $N$행 $M$열의 도화지에 잘못 칠해진 칸이 $K$개 존재한다.
- 변의 길이가 정수인 정사각형 색종이를 최대 $C$개 붙여서 잘못 칠해진 칸을 모두 덮으려 한다.
- 색종이의 한 변이 반드시 **도화지의 가장 밑 변**에 닿도록 붙여야 하고, 색종이끼리 겹쳐도 된다.
- 이 때, 가능한 색종이의 변 길이 중 최솟값을 구해보자.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- 매개 변수 탐색
- 이분 탐색
---
- 색종이를 밑변에 맞추어 놓아야 하기 때문에, 잘못 칠해진 칸 중에서 행 높이가 가장 높은 칸까지는 덮을 수 있어야 한다.
- 또, 가능한 색종이의 최대 크기는 당연히 열 길이이다.
- 색종이 변 길이를 정해놓으면 결정 문제로 바뀐다. (매개 변수 탐색)
- 색종이의 변 길이로 이분 탐색하며 결정 문제의 답이 Yes가 되는 최소 길이를 구했다.

## ⏳ 회고
- 처음에 문제를 잘못 읽어서, 색종이가 밑 변에 닿아야 한다는 걸 못 보고 풀었다.
- 진짜 모르겠어서 반례 찾으러 게시판을 들어갔는데 밑변에 맞추어 붙여야 한다는 걸 못 본 사람이 많은 듯하다...ㅋㅋ