### PR TITLE
[20250217] BOJ / 골드4 / 테트로미노 / 설진영

### DIFF
--- a/Seol-JY/202502/17 BOJ G4 테트로미노.md
+++ b/Seol-JY/202502/17 BOJ G4 테트로미노.md
@@ -1,0 +1,83 @@
+```java
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class Main {
+    static int[] dx = {-1, 1, 0, 0};
+    static int[] dy = {0, 0, -1, 1};
+
+    static int R, C;
+    static int[][] map;
+    static int answer = Integer.MIN_VALUE;
+    
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        R = Integer.parseInt(st.nextToken());
+        C = Integer.parseInt(st.nextToken());
+
+        map = new int[R][C];
+
+        for (int i = 0; i < R; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < C; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        for (int i = 0; i < R; i++) {
+            for (int j = 0; j < C; j++) {
+                dfs(0, map[i][j], i, j, 0);
+            }
+        }
+
+        System.out.println(answer);
+    }
+
+    private static void dfs(int length, int sum, int x, int y, int direction) {
+        if (length == 3) {
+            answer = Math.max(answer, sum);
+            return;
+        }
+
+        if (length == 1) {
+            // ㅗ 모양 처리
+            if (direction == 0 || direction == 1) {  // 위/아래로 움직인 경우
+                int nx1 = x + dx[2];
+                int ny1 = y + dy[2];
+                int nx2 = x + dx[3];
+                int ny2 = y + dy[3];
+                if (!cannotMove(nx1, ny1) && !cannotMove(nx2, ny2)) {
+                    answer = Math.max(answer, sum + map[nx1][ny1] + map[nx2][ny2]);
+                }
+            } else if (direction == 2 || direction == 3) {  // 좌/우로 움직인 경우
+                int nx1 = x + dx[0];
+                int ny1 = y + dy[0];
+                int nx2 = x + dx[1];
+                int ny2 = y + dy[1];
+                if (!cannotMove(nx1, ny1) && !cannotMove(nx2, ny2)) {
+                    answer = Math.max(answer, sum + map[nx1][ny1] + map[nx2][ny2]);
+                }
+            }
+        }
+
+        for (int i = 0; i < 4; i++) {
+            if (length != 0) {
+                if (i == 0 && direction == 1) continue;
+                if (i == 1 && direction == 0) continue;
+                if (i == 2 && direction == 3) continue;
+                if (i == 3 && direction == 2) continue;
+            }
+            int nx = x + dx[i];
+            int ny = y + dy[i];
+            if (cannotMove(nx, ny) ) continue;
+
+            dfs(length + 1, sum + map[nx][ny], nx, ny, i);
+        }
+    }
+
+    private static boolean cannotMove(int nx, int ny) {
+        return (nx < 0 || ny < 0 || nx >= R || ny >= C);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14500
## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
테트로미노 블록을 특정 배열에 뒀을때, 바로 아래 깔리는 숫자들의 합이 최대가 되도록 할 때, 그값은?
## 🔍 풀이 방법
어렵게 생각할 필요 없이, 최대 길이를 4로 제한하고 전 방향을 그래프 탐색하듯이 탐색하면 된다. 그런데 여기서 중요한 것은 두번째 블럭 이후에는 한쪽 방향이 아니라 좌우 하나씩 가는 경우도 있음을 고려해야 한다.
나는 최대 길이가 4이기 때문에(4일때는 왔던 방향으로만 가지 않으면 만날 일이 없으므로)방문 배열을 사용하지 않고 이전 방향을 인자로 받아 재귀를 돌리는 방법으로 구현했는데, 그것보다 정석적으로 방문 배열을 만들고 그리고 2에서도 재귀를 다시 돌리는 방향으로 구현하는 것이 더 깔끔한 것 같다.
## ⏳ 회고
분명 옛날에 봤던 문제인것 같기도 하고.. 그리고 이상하게 풀려고 하지 말고 정석 풀이를 좀 익혀야겠다..