### PR TITLE
[20250217] BOJ / P1 / C.S.G. / 권혁준

### DIFF
--- a/17 BOJ P1 C.S.G. .md
+++ b/17 BOJ P1 C.S.G. .md
@@ -1,0 +1,110 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	static int N, M, K;
+	static int[] C, A, L, D, R;
+	static List<Integer> G;
+	static int turnReverse;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		//solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		int T = Integer.parseInt(br.readLine());
+		while(T-- > 0) {
+			turnReverse = 0;
+			nextLine();
+			N = nextInt();
+			M = nextInt();
+			C = new int[N+1];
+			TreeSet<Integer> temp = new TreeSet<>();
+			
+			nextLine();
+			for(int i=0;i<M;i++) {
+				int a = nextInt(), origin = a;
+				if(a == 1) {
+					turnReverse ^= 1;
+					continue;
+				}
+				for(int j=2;j*j<=a;j++) {
+					if(a%j != 0) continue;
+					while(a%j == 0) a/=j;
+					temp.add(j);
+				}
+				if(a > 75) {
+					turnReverse ^= 1;
+					continue;
+				}
+				if(a != 1) temp.add(a);
+				C[origin]++;
+				
+			}
+			K = temp.size();
+			L = new int[K];
+			int idx = 0;
+			for(int i:temp) L[idx++] = i;
+			
+			G = new ArrayList<>();
+			for(int i=1;i<=N;i++) {
+				int res = 0;
+				if(C[i] == 0) continue;
+				for(int j=0;j<K;j++) if((i % L[j]) == 0) {
+					res |= (1<<j);
+				}
+				G.add(res);
+			}
+			
+			D = new int[1<<K];
+			
+			solve();
+			
+		}
+		
+	}
+	
+	static void solve() throws Exception{
+
+		R = new int[G.size()];
+		for(int i=0;i<G.size();i++) R[i] = G.get(i);
+		
+		Arrays.fill(D, -1);
+		bw.write(dp(0) == 1 ? "amsminn\n" : "bnb2011\n");
+		
+	}
+	
+	static int dp(int n) {
+		if(D[n] != -1) return D[n];
+		int can = 0;
+		for(int r:R) if((n&r) == 0) {
+			can++;
+			if(dp(n|r) == 0) return D[n] = 1;
+		}
+		return D[n] = can == 0 ? turnReverse : 0;
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/31007

## 🧭 풀이 시간
110분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
- $1$ 이상 $N$ 이하의 정수 중 하나가 적혀있는 카드 $M$개가 펼쳐져 있는 책상에서 `amsminn`와 `bnb2011`가 게임을 진행하며, 게임의 규칙은 다음과 같다.
1. 게임은 교대로 진행되며, `amsminn`이 먼저 게임을 시작한다.
2. 각 사람은 자기 차례가 왔을 때, 책상에 남아 있는 카드 중 하나를 가져간다. 이때, 가져간 카드는 이전까지 서로가 가져간 카드 전부와 서로소여야 한다. 그리고 가져간 카드는 책상에서 사라지게 된다.
3. 자신의 차례가 되었을 때 더 이상 카드가 존재하지 않거나, 규칙에 위배되지 않는 카드를 가져갈 수 없는 사람이 지게 된다.
- 서로 최선을 다할 때, 누가 이기는지 구해보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- bitmask dp
- 소수 판정
---
- 수의 종류가 많아야 150개이고, 잘 관찰하면 각 수를 소인수분해했을 때 가지게 되는 소인수의 종류만 알고있으면 된다.
- 이 때, 75를 넘는 소수들은 고정으로 1턴을 넘기는 카드로 쓰인다. 따라서, 이 수들이 주어질 때마다 선공을 바꿔주면 된다.
- 그러면, 고려해야 할 수는 75 이하의 소수들로 좁혀진다. (이 소수들의 수는 최대 21개이다.)
- 소수가 최대 21개 뿐이므로, $2^21$크기의 dp배열을 정의해서 top-down dp를 돌려주면 된다.

## ⏳ 회고
1이 주어지는 경우를 생각 못했다.
1도 결국 75 이상의 소수와 같은 역할을 한다.