### PR TITLE
[20250218] BOJ / G4 / 키 순서 / 권혁준

### DIFF
--- a/khj20006/202502/18 BOJ G4 키 순서.md
+++ b/khj20006/202502/18 BOJ G4 키 순서.md
@@ -1,0 +1,80 @@
+### 플로이드
+
+```cpp
+
+#include <iostream>
+#include <vector>
+using namespace std;
+int main()
+{
+	int N, M;
+	cin >> N >> M;
+	vector<vector<bool>> D(N + 1, vector<bool>(N + 1));
+	for (int i = 1; i <= N; i++) D[i][i] = 1;
+	for (int i = 0, a, b; i < M; i++) {
+		cin >> a >> b;
+		D[a][b] = 1;
+	}
+
+	for (int i = 1; i <= N; i++) for (int j = 1; j <= N; j++) for (int k = 1; k <= N; k++) {
+		if (D[j][i] && D[i][k]) D[j][k] = 1;
+	}
+
+	int ans = 0;
+	for (int i = 1; i <= N; i++) {
+		int res = 0;
+		for (int j = 1; j <= N; j++) res += D[i][j] + D[j][i];
+		ans += res == N + 1;
+	}
+	cout << ans;
+
+}
+
+```
+
+### 위상 정렬
+
+```cpp
+
+#include <iostream>
+#include <vector>
+#include <queue>
+using namespace std;
+
+int main()
+{
+	int N, M;
+	cin >> N >> M;
+	vector<vector<int>> V(N + 1);
+	vector<vector<bool>> D(N + 1, vector<bool>(N + 1));
+	vector<int> in(N + 1);
+	for (int i = 1; i <= N; i++) D[i][i] = 1;
+	for (int i = 0, a, b; i < M; i++) {
+		cin >> a >> b;
+		V[a].push_back(b);
+		in[b]++;
+	}
+
+	queue<int> Q;
+	for (int i = 1; i <= N; i++) if (!in[i]) Q.push(i);
+
+	while (!Q.empty()) {
+		int x = Q.front();
+		Q.pop();
+		for (int i : V[x]) {
+			for (int j = 1; j <= N; j++) if (D[j][x]) D[j][i] = 1;
+			if (!(--in[i])) Q.push(i);
+		}
+	}
+
+	int ans = 0;
+	for (int i = 1; i <= N; i++) {
+		int res = 0;
+		for (int j = 1; j <= N; j++) res += D[i][j] + D[j][i];
+		ans += res == N + 1;
+	}
+	cout << ans;
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2458

## 🧭 풀이 시간
30분 + 60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 학생들의 키 대소 관계가 주어지면, 등수가 확정되는 학생 수를 구해보자.

## 🔍 풀이 방법

### 플로이드

- `D[i][j] = i에서 j로 갈 수 있으면 1, 아니면 0` 으로 정의하면, 키의 대소 관계 (a,b)를 간선으로 보고 플로이드를 돌리면 된다.

### 위상 정렬

- 위의 배열 D의 정의는 같다.
- 위상 정렬하며, 현재 꺼낸 정점 x와 현재 보고있는 간선 (x,y)에 대해, D[i][x] = 1인 점들을 찾아 D[i][y] = 1로 갱신해준다.

## ⏳ 회고
시험 보는 내내 시간 초과날까봐 불안했다 (지금도)