### PR TITLE
[20250218] BOJ / 골드4 / 키 순서 / 설진영

### DIFF
--- a/Seol-JY/202502/18 BOJ G4 키 순서.md
+++ b/Seol-JY/202502/18 BOJ G4 키 순서.md
@@ -1,0 +1,65 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static int N;
+    static int[][] arr;
+    static int[][] visited;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = nextInt(st);
+        int M = nextInt(st);
+
+        arr = new int[N][N];
+        visited = new int[N][N];
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            arr[nextInt(st) - 1][nextInt(st) - 1] = 1;
+        }
+
+        for (int i = 0; i < N; i++) {
+            bfs(i);
+        }
+
+        int answer = 0;
+        for (int i = 0; i < N; i++) {
+            boolean good = true;
+            for (int j = 0; j < N; j++) {
+                if (i  == j) continue;
+                if(visited[i][j] + visited[j][i] < 1) {
+                    good = false;
+                }
+            }
+            if (good) {
+                answer++;
+            }
+        }
+
+        System.out.println(answer);
+    }
+
+    private static void bfs(int start) {
+        Queue<Integer> queue = new LinkedList<>();
+        queue.add(start);
+
+        while (!queue.isEmpty()) {
+            int target = queue.poll();
+
+            for (int i = 0; i < N; i++) {
+                if (arr[target][i] == 1 && visited[start][i] != 1) {
+                    visited[start][i] = 1;
+                    queue.add(i);
+                }
+            }
+        }
+        
+    }
+
+    private static int nextInt(StringTokenizer st) {
+        return Integer.parseInt(st.nextToken());
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2458
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
학생들의 키 대소 관계가 주어지면, 등수가 확정되는 학생 수를 구해보자.

## 🔍 풀이 방법
BFS로 방향 그래프의 각 노드에 대해 방문할 수 있는 노드들을 모두 찾고,
[내가 갈 수 있는 노드] U [나에게 올 수 있는 노드] = [자신을 제외한 모든 노드]
인 노드들의 개수를 구한다.
## ⏳ 회고
플루이드 와샬로 풀면 더 나을듯?