### PR TITLE
[20250218] BOJ / 골드5 / 디저트 / 설진영

### DIFF
--- a/Seol-JY/202502/18 BOJ G5 디저트.md
+++ b/Seol-JY/202502/18 BOJ G5 디저트.md
@@ -1,0 +1,48 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static int N;
+    static int M;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = nextInt(st);
+        M = nextInt(st);
+        int[][] arr = new int[M][N];
+        int[][] dp = new int[M][N];
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                arr[i][j] = nextInt(st);
+                if (j == 0) {
+                    dp[i][0] = arr[i][j];
+                }
+            }
+        }
+        for (int i = 1; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                int max = Integer.MIN_VALUE;
+                for (int k = 0; k < M; k++) {
+                    if (k == j) max = Math.max(max, dp[k][i-1] + arr[j][i]/2);
+                    else max = Math.max(max, dp[k][i-1] + arr[j][i]);
+                }
+                dp[j][i] = max;
+            }
+        }
+
+        int answer = Integer.MIN_VALUE;
+        for (int i = 0; i < M; i++) {
+            answer = Math.max(answer, dp[i][N-1]);
+        }
+        System.out.println(answer);
+    }
+
+    private static int nextInt(StringTokenizer st) {
+        return Integer.parseInt(st.nextToken());
+    }
+}
+```
+


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17953
## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
각 디저트에 대한 만족감이 각 날마다 정의되어 있고, 전날과 같은 디저트를 먹는 경우 만족감에 패널티(만족도 반감)이 있을 때,  만족감의 최대치 구하기
## 🔍 풀이 방법
2차원 DP 배열을 만들고, 매 날마다 각 디저트를 먹을 때 누적 최대 만족감을 구한다. 전날과 같은 디저트를 먹을 때는 만족도가 반감되는것을 고려하고 개중 최댓값을 각각 저장.

## ⏳ 회고
DP로 풀어야 된다는 것만 알게되면 쉽게 풀 수 있을듯. 반복문 돌릴때 인덱스 관리 잘하기