### PR TITLE
[20250218] BOJ / 골드3 / 기숙사 재배정 / 김수연

### DIFF
--- a/suyeun84/202502/18 BOJ G3 기숙사 재배정.md
+++ b/suyeun84/202502/18 BOJ G3 기숙사 재배정.md
@@ -1,0 +1,36 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Solution {
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		int T = Integer.parseInt(st.nextToken());
+		int[] N = new int[T];
+		int maxN = 0;
+		for (int tc = 0; tc < T; tc++) {
+			st = new StringTokenizer(br.readLine());
+			N[tc] = Integer.parseInt(st.nextToken());
+			maxN = Math.max(maxN, N[tc]);
+		}
+		long[] dp = new long[maxN+1];
+		dp[2] = 1;
+		for (int i = 3; i <= maxN; i++) {
+			long total = 1;
+			long minus = 0;
+			long divide = 1;
+			for (int j = i; j > 2; j--) {
+				total *= j;
+				divide *= (i-j+1);
+				minus += total*dp[j-1]/divide;
+			}
+			dp[i] = total*2 - (minus+1);
+		}
+		for (int i = 0; i < T; i++) {
+			System.out.println(dp[N[i]]);
+		}
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/10978
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N명의 학생이 이전에 사용하던 기숙사와 같은 기숙사를 배정 받지 않도록 하는 경우의 수 구하기
## 🔍 풀이 방법
수학공식 활용해서 dp로 풀었다.
## ⏳ 회고
dp[i] = (dp[i-1] + dp[i-2]) * (i-1)
이게 짧은 점화식이라는데 이거 어케 생각해.................. 외워야겠다...............