### PR TITLE
[20250219] BOJ / G4 / 페그 솔리테어 / 권혁준

### DIFF
--- a/khj20006/202502/19 BOJ G4 페그 솔리테어.md
+++ b/khj20006/202502/19 BOJ G4 페그 솔리테어.md
@@ -1,0 +1,66 @@
+```cpp
+
+#include <iostream>
+#include <vector>
+using namespace std;
+
+int dx[4] = {1,0,-1,0};
+int dy[4] = {0,1,0,-1};
+char A[5][9]{};
+vector<pair<int,int>> P;
+bool vis[8]{};
+int cnt, mv;
+
+bool ok(int x, int y) {return 0<=x&&x<5 && 0<=y&&y<9;}
+bool isNumber(int x, int y) {return '0'<=A[x][y] && A[x][y]<='9';}
+
+void bck(int c, int m){
+    if(c < cnt || (c == cnt && m < mv)) cnt = c, mv = m;
+    if(!c) return;
+    for(int i=0;i<P.size();i++) if(!vis[i]){
+        auto &[x,y] = P[i];
+        int px = x, py = y;
+        for(int k=0;k<4;k++){
+            int nx = x+dx[k], ny = y+dy[k];
+            if(!ok(nx,ny) || !isNumber(nx,ny)) continue;
+            int nnx = nx+dx[k], nny = ny+dy[k];
+            if(!ok(nnx,nny) || A[nnx][nny] != '.') continue;
+
+            int rem = A[nx][ny] - '0';
+            vis[rem] = 1;
+            A[nnx][nny] = A[x][y];
+            A[nx][ny] = '.';
+            A[x][y] = '.';
+            x = nnx, y = nny;
+            bck(c-1, m+1);
+            x = px, y = py;
+            vis[rem] = 0;
+            A[x][y] = A[nnx][nny];
+            A[nx][ny] = '0' + rem;
+            A[nnx][nny] = '.';
+        }
+    }
+}
+
+int main(){
+    cin.tie(0)->sync_with_stdio(0);
+
+    int T;
+    for(cin>>T;T--;){
+        cnt = 0, mv = 0;
+        P = vector<pair<int, int>>();
+        for(int i=0;i<8;i++) vis[i]=0;
+        for(int i=0;i<5;i++) for(int j=0;j<9;j++) {
+            cin>>A[i][j];
+            if(A[i][j] == 'o') {
+                P.emplace_back(i,j), A[i][j] = '0' + (cnt);
+                cnt++;
+            }
+        }
+        bck(cnt, 0);
+        cout<<cnt<<' '<<mv<<'\n';
+    }
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/9207

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
- 페그 솔리테어는 구멍이 뚫려있는 이차원 게임판에서 하는 게임이다. 각 구멍에는 핀을 하나 꽂을 수 있다.
- 핀은 수평, 수직 방향으로 인접한 핀을 뛰어넘어서 그 핀의 다음 칸으로 이동하는 것만 허용된다. 인접한 핀의 다음 칸은 비어있어야 하고 그 인접한 핀은 제거된다.
- 현재 게임판에 꽂혀있는 핀의 상태가 주어진다. 이때, 핀을 적절히 움직여서 게임판에 남아있는 핀의 개수를 최소로 하려고 한다. 또, 그렇게 남기기 위해 필요한 최소 이동횟수를 구하는 프로그램을 작성하시오.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- 백트래킹
---
- 핀의 개수가 최대 8이라서 직접 핀을 옮기는 작업을 반복해도 괜찮다.
- 각 핀에 고유한 수를 부여해서 백트래킹 돌릴 때 사라진 핀에 대한 관리를 bool 배열로 관리해 주었다.

## ⏳ 회고
- 자바로 하다가 다시 C++ 쓰려니 그새 자바가 습관이 된 건지, bool을 자꾸 boolean이라 쓴다. 