### PR TITLE
[20250219] BOJ / 골드5 / 디저트 / 신동윤 

### DIFF
--- a/03do-new30/202502/19 BOJ G5 디저트.md
+++ b/03do-new30/202502/19 BOJ G5 디저트.md
@@ -2,7 +2,6 @@
 import java.util.*;
 import java.io.*;
 
-// [BOJ] 17953_디저트
 public class Main {
 	public static void main(String[] args) throws IOException {
 		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17953

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
- i번째 날에 먹는 특정 디저트의 만족감이 주어짐
- 전날에 먹은 디저트를 또 먹으면 만족감이 반으로 감소함
- 한 주기에 얻을 수 있는 최대 만족감을 구함

## 🔍 풀이 방법
- DP
- `dp[day][dessert]` dessert를 day일에 먹는 경우 최대 만족감
- 전날에 같은 디저트를 먹은 경우, 전날에 다른 디저트를 먹은 경우로 나누어 생각

## ⏳ 회고
- 첫 제출에 통과하지 못했는데, `dp[1][dessert]`의 값을 1일째에 먹는 해당 디저트의 만족감으로 초기화하는 걸 깜빡했다. 🤦‍♀️