### PR TITLE
[20250220] BOJ / G5 / 라그랑주의 네 제곱수 정리 / 권혁준

### DIFF
--- a/khj20006/202502/20 BOJ G5 라그랑주의 네 제곱수 정리.md
+++ b/khj20006/202502/20 BOJ G5 라그랑주의 네 제곱수 정리.md
@@ -1,0 +1,40 @@
+```cpp
+
+#include <iostream>
+#include <algorithm>
+#include <vector>
+using namespace std;
+
+int main()
+{
+	cin.tie(0)->sync_with_stdio(0);
+
+	int N;
+	for (cin >> N; N; cin >> N) {
+
+		vector<int> A;
+		int ans = 0;
+		for (int i = 1; i*i <= N; i++) A.push_back(i*i);
+		int M = A.size();
+
+		// 1
+		if (A.back() == N) ans++;
+		// 2
+		for (int i = 0; i < M; i++) for (int j = i; j < M; j++) if (A[i] + A[j] == N) ans++;
+		// 3
+		for (int i = 0; i < M; i++) for (int j = i; j < M; j++) {
+			if (A[i] + A[j] >= N) break;
+			ans += upper_bound(A.begin() + j, A.end(), N - A[i] - A[j]) - lower_bound(A.begin() + j, A.end(), N - A[i] - A[j]);
+		}
+		// 4
+		for (int i = 0; i < M; i++) for (int j = i; j < M; j++) for (int k = j; k < M; k++) {
+			if (A[i] + A[j] + A[k] >= N) break;
+			ans += upper_bound(A.begin() + k, A.end(), N - A[i] - A[j] - A[k]) - lower_bound(A.begin() + k, A.end(), N - A[i] - A[j] - A[k]);
+		}
+
+		cout << ans << '\n';
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/3933

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- $N$을 네 개 이하의 제곱수의 합으로 나타내는 방법의 수를 구해보자.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- 이분 탐색
---
- $N$이하의 오름차순 제곱수 목록 A를 만든다.

### 제곱수가 1개인 경우
- A의 끝 원소가 N인지 확인 -> $O(1)$
### 제곱수가 2개인 경우
- 완탐으로 확인 -> $O({|A|}^2)$
### 제곱수가 3개인 경우
- 제곱수를 두 개 합친 걸 완탐으로 찾고, 나머지 원소 하나는 이분 탐색으로 찾기 -> $O({|A|}^2 \log{|A|})$
### 제곱수가 4개인 경우
- 제곱수를 세 개 합친 걸 완탐으로 찾고, 나머지 원소 하나는 이분 탐색으로 찾기 -> $O({|A|}^3 \log{|A|})$

## ⏳ 회고
- 처음엔 DP로 풀려다가, 답이 계속 안 나와서 다른 방법으로 풀게 됨