### PR TITLE
[20250220] BOJ / G2 / 기지국 / 권혁준

### DIFF
--- a/khj20006/202502/20 BOJ G2 기지국.md
+++ b/khj20006/202502/20 BOJ G2 기지국.md
@@ -1,0 +1,38 @@
+```cpp
+
+#include <iostream>
+#include <vector>
+#include <algorithm>
+using namespace std;
+using ll = long long;
+
+int main()
+{
+	cin.tie(0)->sync_with_stdio(0);
+
+	int N;
+	ll inf = 1e18;
+	cin >> N;
+	vector<pair<ll, ll>> A(N);
+	for (auto &[x, y] : A) cin >> x >> y;
+	sort(A.begin(), A.end());
+
+	vector<ll> dp(10000, inf);
+	dp[0] = abs(A[0].second) * 2;
+	for (int i = 1; i < N; i++) {
+		int p = i;
+		ll maxabs = -1;
+		while (i < N && A[p].first == A[i].first) maxabs = max(maxabs, abs(A[i++].second));
+		i--;
+		for (int j = p - 1; j >= 0; j--) {
+			maxabs = max(maxabs, abs(A[j+1].second));
+			dp[i] = min(dp[i], dp[j] + max(maxabs * 2, A[i].first - A[j + 1].first));
+		}
+		maxabs = max(maxabs, abs(A[0].second));
+		dp[i] = min(dp[i], max(maxabs * 2, A[i].first - A[0].first));
+	}
+	cout << dp[N - 1];
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2300

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 2차원 좌표평면에 $N$개의 기지국을 설치하려 한다.
- 기지국들을 모두 중심이 x축 위에 존재하는 몇몇 정사각형들의 통신범위 내에 있게 하려 한다.
- 정사각형들 변의 길이 합을 최소로 해보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- 정렬
- DP
---
- $DP[i] = $`i번째 기지국까지 설치했을 때, 길이 합의 최솟값`으로 정의한다.
- $DP[i] = \min(DP[i-j] + \max(2{|Y_k|}, X_i - X_{i-j+1}))$이다.
- 좌표의 오름차순으로 **정렬**되어 있어야 함은 자명하다.

## ⏳ 회고
- 저 dp식에서 곱하기 2 부분을 깜빡하고 안 써준 부분이 있었는데, 그걸 20분동안 못 찾고 있었다