### PR TITLE
[20250220] BOJ / G4 / 같은 수로 만들기 / 권혁준

### DIFF
--- a/khj20006/202502/20 BOJ G4 같은 수로 만들기.md
+++ b/khj20006/202502/20 BOJ G4 같은 수로 만들기.md
@@ -1,0 +1,36 @@
+```cpp
+
+#include <iostream>
+#include <algorithm>
+#include <stack>
+using namespace std;
+using ll = long long;
+
+int main()
+{
+	cin.tie(0)->sync_with_stdio(0);
+
+	ll N, ans = 0;
+	stack<ll> S;
+	cin >> N;
+	for (int i = 1; i <= N; i++) {
+		ll a;
+		cin >> a;
+		if (!S.empty() && S.top() < a) {
+			ll t = S.top();
+			while (!S.empty() && S.top() < a) S.pop();
+			ans += a - t;
+		}
+		S.push(a);
+	}
+
+	ans -= S.top();
+	ll mx = 0;
+	while (!S.empty()) mx = S.top(), S.pop();
+	ans += mx;
+	
+	cout << ans;
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2374

## 🧭 풀이 시간
32분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
- 길이 $N$인 배열 A가 있다.
- `Add연산`을 한 번 하면, 어떤 원소에 대해, 좌우로 같은 값을 가지는 모든 원소에 1씩 더한다.
(ex. {1,3,3,3,4} 에서 원소 3에 `Add연산`을 하면 {1,4,4,4,4}가 된다.)
- 모든 수를 같게 하기 위한 연산의 최소 횟수를 구해보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- 스택
- 그리디
---
- 스택을 내림차순으로 관리한다. (monotone stack)
- 만약 비내림차순인 관계가 스택에 들어오면, 적절한 `Add연산`으로 스택을 내림차순으로 만들어줄 수 있다.
- 예를 들면, 지금 스택에 있는 수가 {6, 4, 4, 4, 2}이고 스택에 넣으려는 수가 5라고 가정하자.
- 스택에 있는 수 중, 최솟값부터 `Add연산`을 수행해서 5까지 **최적의 방법으로** 올릴 수 있다. 작업을 마치면 스택은 {6, 5}가 된다.

## ⏳ 회고
- 스택에서 수를 꺼낼 때 조건을 잘못 써줘서 틀렸다.
- $N$제한이 더 큰 Hard버전 느낌의 문제를 옛날에 풀었었는데, 그리디 문제라 떠올리는게 여전히 쉽지 않았다.
https://www.acmicpc.net/problem/13146