### PR TITLE
[20250221] BOJ / G2 / 확장 게임 / 권혁준

### DIFF
--- a/khj20006/202502/21 BOJ G2 확장 게임.md
+++ b/khj20006/202502/21 BOJ G2 확장 게임.md
@@ -1,0 +1,60 @@
+```cpp
+
+#include <iostream>
+#include <tuple>
+#include <queue>
+using namespace std;
+
+int N, M, P, A[1000][1000]{}, S[10]{};
+int dx[4] = { 1,0,-1,0 };
+int dy[4] = { 0,1,0,-1 };
+
+int main()
+{
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin >> N >> M >> P;
+	for (int i = 1; i <= P; i++) cin >> S[i];
+	for (int i = 0; i < N; i++) for (int j = 0; j < M; j++) {
+		char a;
+		cin >> a;
+		if (a == '.') continue;
+		if (a == '#') A[i][j] = -1;
+		else A[i][j] = a - '0';
+	}
+
+	queue<tuple<int, int, int>> Q[10]{};
+	for (int p = 1; p <= P; p++) {
+		for (int i = 0; i < N; i++) for (int j = 0; j < M; j++) if (A[i][j] == p) Q[p].emplace(i, j, S[p]);
+	}
+
+	while (true) {
+
+		bool change = false;
+		queue<tuple<int, int, int>> NQ[10]{};
+		for (int p = 1; p <= P; p++) {
+			while (!Q[p].empty()) {
+				auto[x, y, t] = Q[p].front();
+				Q[p].pop();
+				for (int k = 0; k < 4; k++) {
+					int xx = x + dx[k], yy = y + dy[k];
+					if (xx < 0 || xx >= N || yy < 0 || yy >= M || A[xx][yy]) continue;
+					change = true;
+					A[xx][yy] = p;
+					if (t > 1)	Q[p].emplace(xx, yy, t - 1);
+					else NQ[p].emplace(xx, yy, S[p]);
+				}
+			}
+		}
+		if (!change) break;
+		for (int p = 1; p <= P; p++) Q[p] = NQ[p];
+
+	}
+
+	int cnt[10]{};
+	for (int i = 0; i < N; i++) for (int j = 0; j < M; j++) for (int p = 1; p <= P; p++) cnt[p] += A[i][j] == p;
+	for (int i = 1; i <= P; i++) cout << cnt[i] << ' ';
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16920

## 🧭 풀이 시간
35분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- $N \times M$ 격자판에 $P$명의 플레이어가 각자의 성을 확장시키려 한다.
- 한 턴에는 $1$부터 $P$까지 플레이어가 차례대로 확장을 시도한다.
- 각 플레이어 $p$는 자신의 성이 있는 곳에서부터 최대 $S_p$만큼 이동할 수 있는 칸들 중, 벽이나 다른 플레이어의 성이 없는 곳에 자신의 성을 짓는다.
- 충분한 턴이 지난 후, 각 플레이어가 몇 개의 성을 가지게 되는지 구해보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- BFS
---
- 각 플레이어마다 BFS를 돌릴 큐를 따로따로 관리하면, 단순히 1번 플레이어의 큐부터 P번 플레이어의 큐까지 BFS를 싹 돌리면 된다.

## ⏳ 회고
- 처음엔 큐를 따로 두는 게 아니라 덱 하나로 BFS를 돌렸는데, 확장이 제대로 안 되는 문제가 있었다.
- 반례 케이스를 못 찾겠어서 게시판에서 찾아봤다.
```
3 4 2
2 1
1...
1..2
....
=== Output
8 4
=== Answer
9 3
```
- 코드를 고치려는데 덱으로는 안될 것 같아 풀이를 갈아엎었다.