### PR TITLE
[20250221] BOJ / P3 / 스티커 수집 / 권혁준

### DIFF
--- a/khj20006/202502/21 BOJ P3 스티커 수집.md
+++ b/khj20006/202502/21 BOJ P3 스티커 수집.md
@@ -1,0 +1,74 @@
+```cpp
+
+#include <iostream>
+#include <queue>
+#include <tuple>
+#include <algorithm>
+using namespace std;
+
+int N, K, M;
+int price[32]{}, value[32]{}, ex[32]{};
+vector<pair<int, int>> A;
+vector<int> X;
+
+int main()
+{
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin >> N;
+	for (int i = 0; i < N; i++) cin >> price[i];
+	for (int i = 0; i < N; i++) cin >> value[i];
+	for (cin >> K >> M; M--;) {
+		int a;
+		cin >> a;
+		ex[a]++;
+	}
+
+	if (N > 16) {
+		for (int i = 0; i < (1 << (N - 16)); i++) {
+			int p = 0, v = 0;
+			for (int k = 0; k < N - 16; k++) {
+				if (i & (1 << k)) {
+					v += value[k + 16];
+					if (!ex[k + 16]) p += price[k + 16];
+				}
+				else if (ex[k + 16]) p -= price[k + 16];
+			}
+			A.emplace_back(v, p);
+		}
+		sort(A.begin(), A.end());
+		X.resize(A.size());
+
+		int mn = A.back().second;
+		for (int i = A.size() - 1; i >= 0; i--) {
+			mn = min(mn, A[i].second);
+			X[i] = mn;
+		}
+	}
+
+
+
+	int ans = -2e9;
+	for (int i = 0; i < (1 << min(N, 16)); i++) {
+		int p = 0, v = 0;
+		for (int k = 0; k < min(N, 16); k++) {
+			if (i & (1 << k)) {
+				v += value[k];
+				if (!ex[k]) p += price[k];
+			}
+			else if (ex[k]) p -= price[k];
+		}
+		if (N <= 16) {
+			if (v >= K) ans = ans == -2e9 ? p : min(p, ans);
+		}
+		else {
+			int j = lower_bound(A.begin(), A.end(), make_pair(K - v, 0)) - A.begin();
+			if (j == A.size()) continue;
+			ans = ans == -2e9 ? p + X[j] : min(ans, p + X[j]);
+		}
+	}
+	cout << (ans == -2e9 ? -1 : max(0, ans));
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1093

## 🧭 풀이 시간
26분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 서로 다른 스티커가 각각 하나씩 총 $N$개 있고, 각 스티커는 가격과 가치가 있다.
- 영훈이는 몇 개의 스티커를 가지고 있다.
- 스티커를 적절히 사고 팔아서, 가지고 있는 스티커의 가치 합이 K 이상이 되게 하려 한다.
- 처음에 가지고 있어야 하는 돈의 최솟값을 구해보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- 중간에서 만나기
---
- 일단, $N \le 32$제한만 보고 `중간에서 만나기`를 풀이의 후보로 떠올릴 수 있어야 한다.
- 주어진 스티커들을 반씩 나눠서, 완탐으로 각 조합 별 가치합, 가격합을 구한다. (이 때, 처음 가지고 있던 스티커를 고려해서 구해야 하니 주의)
- 한 쪽을 가치 순으로 정렬시켜놓고, 필요한 가치 별 최소 가격을 역순회해서 구한다.
- 이분 탐색으로 반씩 나눈 걸 합쳐 최솟값을 구한다.

## ⏳ 회고
- 처음에 스티커를 몇 개 가지고 시작하니까 좀 헷갈렸다.