### PR TITLE
[20250223] BOJ / 플래5 / 배열에서 이동 / 설진영

### DIFF
--- a/Seol-JY/202502/23 BOJ P5 배열에서 이동.md
+++ b/Seol-JY/202502/23 BOJ P5 배열에서 이동.md
@@ -1,0 +1,103 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static final int[] dr = {-1, 1, 0, 0};
+    static final int[] dc = {0, 0, 1, -1};
+    static int N;
+    static int[][] map;
+    static boolean[][] visited;
+    static int minValue, maxValue;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        N = Integer.parseInt(br.readLine());
+        map = new int[N][N];
+        visited = new boolean[N][N];
+
+        minValue = 201;
+        maxValue = 0;
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+                minValue = Math.min(minValue, map[i][j]);
+                maxValue = Math.max(maxValue, map[i][j]);
+            }
+        }
+
+        System.out.println(solve());
+    }
+
+    private static int solve() {
+        int left = 0;
+        int right = maxValue - minValue;
+        int result = right;
+
+        while (left <= right) {
+            int mid = (left + right) / 2;
+
+            if (isPossible(mid)) {
+                result = mid;
+                right = mid - 1;
+            } else {
+                left = mid + 1;
+            }
+        }
+
+        return result;
+    }
+
+    private static boolean isPossible(int diff) {
+        for (int min = minValue; min <= maxValue - diff; min++) {
+            int max = min + diff;
+            if (map[0][0] < min || map[0][0] > max) continue;
+
+            for (int i = 0; i < N; i++) {
+                Arrays.fill(visited[i], false);
+            }
+
+            if (bfs(min, max)) return true;
+        }
+        return false;
+    }
+
+    private static boolean bfs(int min, int max) {
+        ArrayDeque<Position> deque = new ArrayDeque<>();
+        deque.offer(new Position(0, 0));
+        visited[0][0] = true;
+
+        while (!deque.isEmpty()) {
+            Position target = deque.poll();
+
+            if (target.r == N-1 && target.c == N-1) return true;
+
+            for (int i = 0; i < 4; i++) {
+                int nr = target.r + dr[i];
+                int nc = target.c + dc[i];
+
+                if (nr < 0 || nc < 0 || nr >= N || nc >= N || visited[nr][nc]) continue;
+                if (map[nr][nc] < min || map[nr][nc] > max) continue;
+
+                visited[nr][nc] = true;
+                deque.offer(new Position(nr, nc));
+            }
+        }
+
+        return false;
+    }
+
+    static class Position {
+        int r;
+        int c;
+
+        public Position(int r, int c) {
+            this.r = r;
+            this.c = c;
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1981
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
n×n 크기의 격자에서 (1,1)에서 (n,n)까지 상하좌우로만 이동할 수 있음, 이동 경로에서 만나는 숫자들 중
최댓값과 최솟값의 차이가 최소가 되는 경로를 찾아 그 차이값을 출력
## 🔍 풀이 방법
이진 탐색을 활용하여 "최댓값-최솟값의 차이"를 찾음. 이 차이를 mid로 두고, 해당 차이로 도착지점까지 도달할 수 있는지 확인
배열의 최솟값부터 시작해서 [min, min+diff] 범위 내의 숫자들만 사용하여
BFS로 (0,0)에서 (N-1,N-1)까지 도달할 수 있는지를 확인
도달할 수 있다면 더 작은 차이값도 가능한지 탐색하고, 불가능하다면 더 큰 차이값을 확인
도달하지 않는 경우는 없음

## ⏳ 회고
처음에는 dfs 백트래킹 사용해서 확인하려 했지만 시간초과 날거같아서 안함.
단순 bfs로 한번에 하려 하니 방문관리도 어렵고 경로가 직관적이지 않았음 -> 불가능한듯..?
가능한 diff에 대해서 모두 bfs를 돌리기에는 시간초과 날거 같았음
문제 알고리즘 유형에 이진 탐색이 있어 확인하고 해결

이런식으로 최적화 문제를 결정 문제로 바꿔서 해결하는걸 파라매트릭 서치.. 라고 한다네요?