### PR TITLE
[20250223] BOJ / 골드4 / 타일 채우기 3 / 설진영

### DIFF
--- a/Seol-JY/202502/23 BOJ G4 타일 채우기 3.md
+++ b/Seol-JY/202502/23 BOJ G4 타일 채우기 3.md
@@ -1,0 +1,24 @@
+```java
+import java.io.*;
+public class Main {
+	static int N;
+	static final int MOD = 1000000007;
+	static long[][] dp = new long[1000001][2];
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		N = Integer.parseInt(br.readLine());
+		dp[0][0] = 0;
+		dp[1][0] = 2;
+		dp[2][0] = 7;
+		dp[2][1] = 1;
+
+		for (int i = 3; i <= N; i++) {
+			dp[i][1] = (dp[i - 3][0] + dp[i - 1][1]) % MOD;  // i - 3 까지 누적합 + 1
+			dp[i][0] = (3 * (dp[i - 2][0]) + 2 * (dp[i - 1][0]) + 2 * dp[i][1]) % MOD;
+		}
+
+		System.out.println(dp[N][0]);
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14852
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
2×N 크기의 벽을 2×1, 1×2, 1×1 크기의 타일로 채우는 경우의 수를 구해보자.
## 🔍 풀이 방법
N이 증가할수록 N=3 일때부터 새로운 경우의수 두가지가 계속 나온다. 따라서 2차원 DP를 활용해 해당 경우를 반영해줘야 한다.
<img width="2307" alt="스크린샷 2025-02-23 오후 9 43 28" src="https://github.com/user-attachments/assets/1828744b-6245-45a3-ac8c-f65803e109a4" />

## ⏳ 회고
처음에 N=3까지인 경우에 대해서만 규칙을 찾아 좋다고 바로 풀었더니 틀림..
시간 초과가 날 수 있으므로 다른 DP 배열을 활용해 누적합을 저장해 주어야 한다.