### PR TITLE
[20250225] BOJ / G4 / 줄세우기 / 권혁준

### DIFF
--- a/khj20006/202502/25 BOJ G4 줄세우기.md
+++ b/khj20006/202502/25 BOJ G4 줄세우기.md
@@ -1,0 +1,22 @@
+```cpp
+
+#include <iostream>
+#include <algorithm>
+using namespace std;
+
+int main()
+{
+	cin.tie(0)->sync_with_stdio(0);
+
+	int N, arr[202]{}, dp[202]{}, ans = 0;
+	cin >> N;
+	for (int i = 1; i <= N; i++) {
+		cin >> arr[i];
+		for (int j = 0; j < i; j++) if (arr[i] > arr[j]) dp[i] = max(dp[i], dp[j] + 1);
+		ans = max(ans, dp[i]);
+	}
+	cout << N - ans;
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2631

## 🧭 풀이 시간
80분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
- 1부터 N까지 번호가 적인 아이들이 줄을 서 있다.
- 번호 순으로 서게 하려 할 때, 옮겨야 하는 아이의 수를 최소로 해보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- DP
---
- 가장 긴 증가하는 부분 수열(LIS)을 골라내면, 얘네들은 이미 정렬되어 있음.
- LIS에 속하지 않는 애들만 적절히 옮겨주면 정렬시킬 수 있음

## ⏳ 회고
- 원래 DP식을 아예 다르게 짜서 풀려고 했는데 계속 틀렸다.
- LIS 문제인 걸 알고 풀면 쉽겠는데, 절대 생각이 안 난다. 너무 어려움