### PR TITLE
[20250225] BOJ / S2 / 창고 다각형 / 권혁준

### DIFF
--- a/khj20006/202502/25 BOJ S2 창고 다각형.md
+++ b/khj20006/202502/25 BOJ S2 창고 다각형.md
@@ -1,0 +1,30 @@
+```cpp
+
+#include <iostream>
+#include <algorithm>
+using namespace std;
+
+int main()
+{
+	cin.tie(0)->sync_with_stdio(0);
+
+	int N, Y[1001]{}, Z[1001]{};
+	cin >> N;
+	for (int i = 0, a, b; i < N; i++) {
+		cin >> a >> b;
+		Y[a] = b;
+	}
+
+	for (int i = 1; i <= 1000; i++) Z[i] = max(Z[i - 1], Y[i]);
+
+	int ans = 0, from_right = 0;
+	for (int i = 1000; i >= 1; i--) {
+		from_right = max(from_right, Y[i]);
+		Z[i] = min(Z[i], from_right);
+		ans += Z[i];
+	}
+	cout << ans;
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2304

## 🧭 풀이 시간
4분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
- 폭이 1m인 N개의 기둥이 세워져 있다.
- 다음 규칙에 따라 지붕을 만들려 한다.
1. 지붕은 수평 부분과 수직 부분으로 구성되며, 모두 연결되어야 한다.
2. 지붕의 수평 부분은 반드시 어떤 기둥의 윗면과 닿아야 한다.
3. 지붕의 수직 부분은 반드시 어떤 기둥의 옆면과 닿아야 한다.
4. 지붕의 가장자리는 땅에 닿아야 한다.
5. 비가 올 때 물이 고이지 않도록 지붕의 어떤 부분도 오목하게 들어간 부분이 없어야 한다.
- 지붕의 넓이를 최소로 해보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- 구현
- 브루트포스 알고리즘
---
- 폭이 1이라서, 배열 1000짜리를 만들어 각 x좌표 별로 높이를 저장했다.
- 각 x좌표 별 지붕의 높이를 구할 때는 min(왼쪽에서 오는 최대 높이, 오른쪽에서 오는 최대 높이)로 해결했다.

## ⏳ 회고
- 재밌는 문제