### PR TITLE
[20250225] BOJ / G4 / 사전 순 최대 공통 부분 수열 / 권혁준

### DIFF
--- a/khj20006/202502/25 BOJ G4 사전 순 최대 공통 부분 수열.md
+++ b/khj20006/202502/25 BOJ G4 사전 순 최대 공통 부분 수열.md
@@ -1,0 +1,42 @@
+```cpp
+
+#include <iostream>
+#include <vector>
+using namespace std;
+
+int main()
+{
+	cin.tie(0)->sync_with_stdio(0);
+
+	int N, M;
+	cin >> N;
+	vector<int> A(N);
+	for (int &i : A) cin >> i;
+	cin >> M;
+	vector<int> B(M);
+	for (int &i : B) cin >> i;
+
+	vector<int> R;
+	int idxA = 0, idxB = 0;
+	while (idxA < N && idxB < M) {
+		bool suc = 0;
+		for (int x = 100; x >= 1; x--) {
+			int res = 0;
+			int new_idxA = idxA, new_idxB = idxB;
+			for (int i = idxA; i < N; i++) if (A[i] == x) { res++; new_idxA = i + 1; break; }
+			for (int i = idxB; i < M; i++) if (B[i] == x) { res++; new_idxB = i + 1; break; }
+			if (res == 2) {
+				idxA = new_idxA, idxB = new_idxB;
+				R.push_back(x);
+				suc = 1;
+				break;
+			}
+		}
+		if (!suc) break;
+	}
+	cout << R.size() << '\n';
+	for (int i : R) cout << i << ' ';
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/30805

## 🧭 풀이 시간
6분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
- 두 수열의 공통 부분 수열 중 사전 순으로 가장 나중인 수열을 구해보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- 그리디 알고리즘
---
- 두 수열에서 공통인 최댓값을 계속 뽑아내는 작업을 반복해서 해결했다.

## ⏳ 회고
- 제한이 작아서 그냥 반복문 여러 개로 풀었는데, 제한이 컸으면 어땠을까 싶다.