### PR TITLE
[20250225] BOJ / S1 / 돌다리 / 권혁준

### DIFF
--- a/khj20006/202502/25 BOJ S1 돌다리.md
+++ b/khj20006/202502/25 BOJ S1 돌다리.md
@@ -1,0 +1,37 @@
+```cpp
+
+#include <iostream>
+#include <queue>
+#include <bitset>
+using namespace std;
+
+int main()
+{
+	cin.tie(0)->sync_with_stdio(0);
+
+	int A, B, N, M;
+	cin >> A >> B >> N >> M;
+	bitset<100001> v;
+	queue<pair<int, int>> Q;
+	Q.emplace(N, 0);
+	v[N] = 1;
+
+	int d[6] = { 1,-1,A,-A,B,-B };
+	while (!Q.empty()) {
+		auto[n, t] = Q.front();
+		Q.pop();
+		if (n == M) return cout << t, 0;
+		for (int i = 0; i < 6; i++) {
+			int x = n + d[i];
+			if (x < 0 || x > 100000 || v[x]) continue;
+			v[x] = 1;
+			Q.emplace(x, t + 1);
+		}
+		if (n*A <= 100000 && !v[n*A]) { v[n*A] = 1; Q.emplace(n*A, t + 1); }
+		if (n*B <= 100000 && !v[n*B]) { v[n*B] = 1; Q.emplace(n*B, t + 1); }
+	}
+
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/12761

## 🧭 풀이 시간
4분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
- 일직선 상의 돌 다리에 번호가 0부터 100,000까지 붙어있다.
- 현 위치에서 +1, -1, +A, -A, +B, -B, *A, *B 중 하나의 이동을 택할 수 있다.
- N번 돌에서 M번 돌까지 갈 때 최소 이동 횟수를 구해보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- BFS
---
- 1차원 BFS, 경계를 벗어나는 경우 주의하며 구현

## ⏳ 회고
..