### PR TITLE
[20250225] BOJ / G3 / 양 구출 작전 / 권혁준

### DIFF
--- a/khj20006/202502/25 BOJ G3 양 구출 작전.md
+++ b/khj20006/202502/25 BOJ G3 양 구출 작전.md
@@ -1,0 +1,35 @@
+```cpp
+
+#include <iostream>
+#include <vector>
+#include <algorithm>
+using namespace std;
+using ll = long long;
+
+int N;
+vector<vector<int>> V(123457);
+ll C[123457]{};
+
+ll dfs(int n) {
+	ll res = C[n];
+	for (int i : V[n]) res += dfs(i);
+	return max(res, 0LL);
+}
+
+int main()
+{
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin >> N;
+	for (int i = 2, a, b; i <= N; i++) {
+		char o;
+		cin >> o >> a >> b;
+		V[b].push_back(i);
+		C[i] = a * (o == 'S' ? 1 : -1);
+	}
+
+	cout << dfs(1);
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16437

## 🧭 풀이 시간
7분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 루트가 1이고 정점이 N개인 트리의 각 정점에 양 혹은 늑대들이 살고 있다.
- 늑대는 양 한마리를 잡아먹을 수 있다.
- 1번 섬에 도달할 수 있는 양은 최대 몇 마리인지 구해보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- DFS in Tree
---
- `늑대가 a마리 살고 있다 -> 양이 -a마리 살고 있다` 라고 바꿔서 생각했다.
- DFS 돌면서 각 서브트리 별로, 양이 몇 마리 모이는 지 구하고, 음수이면 0으로 바꿔준다.

## ⏳ 회고
- 풀이 아이디어가 참신하다