### PR TITLE
[20250226] BOJ / 골드2 / 피보나치 수 6 / 김수연

### DIFF
--- a/suyeun84/202502/26 BOJ G2 피보나치 수 6.md
+++ b/suyeun84/202502/26 BOJ G2 피보나치 수 6.md
@@ -1,0 +1,39 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+	final static int mod = 1000000007;
+	static HashMap<Long, Long> map;
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		long N = Long.parseLong(br.readLine());
+		map = new HashMap<>();
+		
+		map.put((long) 1, (long) 1);
+		map.put((long) 2, (long) 1);
+		
+		long answer = fibo(N);
+		
+		System.out.println(answer);
+	}
+	
+	static long fibo(long N) {
+		if (map.containsKey(N)) return map.get(N);
+		long a, b, c;
+		if (N % 2 == 1) {
+			a = fibo(N/2 + 1);
+			b = fibo(N/2);
+			map.put(N, ((a%mod)*(a%mod)%mod+(b%mod)*(b%mod)%mod)%mod);
+		} else {
+			a = fibo(N/2 + 1);
+			b = fibo(N/2);
+			c = fibo(N/2 - 1);
+			map.put(N, ((a%mod)*(b%mod)%mod+(b%mod)*(c%mod)%mod)%mod);
+		}
+
+		return map.get(N);
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11444
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
n이 1,000,000,000,000,000,000보다 작거나 같은 자연수일 때,
F(n)의 피보나치 수 구하기
## 🔍 풀이 방법
![image](https://github.com/user-attachments/assets/9bc21a78-88e7-4bc3-88fc-a5e20dac6fd7)
행렬 점화식을 이용해서 분할정복으로 풀어야 한다.
## ⏳ 회고
공식..어렵당....