### PR TITLE
[20250226] BOJ / P1 / Communism / 권혁준

### DIFF
--- a/khj20006/202502/26 BOJ P1 Communism.md
+++ b/khj20006/202502/26 BOJ P1 Communism.md
@@ -1,0 +1,61 @@
+```cpp
+
+#include <iostream>
+#include <algorithm>
+using namespace std;
+using ll = long long;
+
+int N;
+ll A[30]{}, D;
+
+ll R[14348907][3]{};
+int S[2]{};
+
+void half(int k, int s, int e) {
+	for (int i = s; i < e; i++) {
+		ll a = A[i];
+		int T = S[k];
+		int id = 0, id1 = 0, id2 = 0, id3 = 0;
+		while (id1 < T) {
+			ll r1 = R[id1][k] - a, r2 = R[id2][k], r3 = R[id3][k] + a, mn = min({ r1,r2,r3 });
+			R[id++][2] = mn;
+			if (mn == r1) id1++;
+			else if (mn == r2) id2++;
+			else id3++;
+		}
+		while (id2 < T) {
+			ll r2 = R[id2][k], r3 = R[id3][k] + a, mn = min(r2, r3);
+			R[id++][2] = mn;
+			if (mn == r2) id2++;
+			else id3++;
+		}
+		S[k] *= 3;
+		while (id3 < T) R[id++][2] = R[id3++][k] + a;
+		for (int j = 0; j < id; j++) R[j][k] = R[j][2];
+	}
+}
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin >> N;
+	for (int i = 0; i < N; i++) cin >> A[i];
+	cin >> D;
+
+	S[0] = S[1] = 1;
+	half(0, 0, N >> 1);
+	half(1, N >> 1, N);
+
+	ll ans = 0;
+	int s = S[1] - 1, e = S[1] - 1;
+	for (int i = 0; i < S[0]; i++) {
+		ll a = R[i][0];
+		while (s >= 0 && R[s][1] >= -D - a) s--;
+		while (e >= 0 && R[e][1] > D - a) e--;
+		ans += e - s;
+	}
+	cout << ans;
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14560

## 🧭 풀이 시간
120+분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
- N개의 일거리를 A, B, C 세 명에게 분배하려고 한다.
- 각 사람이 받는 일거리의 보수 합을 $S_A, S_B, S_C$라고 할 때, $| S_B - S_C |  \le D$가 되도록 일을 나누는 가짓수를 구해보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- 중간에서 만나기
- 정렬?
- 투 포인터
---
- N개의 일거리들을 반으로 가른 뒤, 나눠진 좌우 각각에서 가능한 $S_B - S_C$ 값들을 완탐으로 구한다.
- 왼쪽 부분의 결과물을 L, 오른쪽 부분의 결과물을 R이라 하면, L과 R을 정렬시켜서 투 포인터로 경우의 수를 모두 구할 수 있다.
- 근데 그냥 `sort()`로 정렬하면 시간 초과가 난다.

### 특수한 경우의 정렬
완탐을 돌릴 때, 각 스텝에서 중간 결과물에 일거리 하나를 추가시켜 다음 결과물을 도출한다.
이 때, 다음 결과물에 존재하는 값들은 모두 세 가지 경우 중 하나이다.
1. 중간 결과물 - 현재 일거리 보수
2. 중간 결과물 그대로
3. 중간 결과물 + 현재 일거리 보수

만약 중간 결과물이 정렬된 상태라 가정하면, 세 개의 포인터를 사용해 다음 결과물 또한 정렬된 상태로 만들 수 있다.

## ⏳ 회고
.....