### PR TITLE
[20250226] BOJ / 골드3 / 색상환/ 신동윤

### DIFF
--- a/03do-new30/202502/26 BOJ G3 색상환.md
+++ b/03do-new30/202502/26 BOJ G3 색상환.md
@@ -1,0 +1,33 @@
+```java
+import java.util.*;
+
+public class Main {
+    final static int MOD = 1_000_000_003;
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+
+        int N = sc.nextInt();
+        int K = sc.nextInt();
+        
+        // dp[i][j] = i번째 색상까지 고려하여 j개를 뽑는 경우의 수
+        int[][] dp = new int[N+1][K+1];
+        for (int i = 1; i < N+1; i++) {
+            dp[i][0] = 1;
+            dp[i][1] = i;
+        }
+        for (int i = 3; i < N; i++) {
+            for (int j = 2; j < K+1; j++) {
+                dp[i][j] = (dp[i-1][j] + dp[i-2][j-1]) % MOD;
+            }
+        }
+        // 마지막 색상 처리
+        // dp[N - 2- 1][K-1] = 1번 색상을 제외하고 N-2 색상까지 K-1개의 색을 겹치지 않게 칠하는 경우
+        dp[N][K] = (dp[N - 2 - 1][K-1] + dp[N-1][K]) % MOD;
+        
+        int answer = dp[N][K];
+        System.out.println(answer);
+
+        sc.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2482
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N개의 색으로 구성된 색상환에서 인접한 두 색을 고르지 않으면서 K개의 색을 선택하는 경우를 구한다.
## 🔍 풀이 방법
- dp[i][j] = i번째 색까지 고려해서 j개를 뽑는 경우의 수
   - i번째 색을 뽑을 수 있는 경우의 수는 dp[i-2][j-1]
   - i번째 색을 뽑을 수 없는 경우의 수는 dp[i-1][j]
- 환형 구조이므로 마지막 색 처리 시 유의해야 함
   - 마지막 색을 뽑을 수 있는 경우의 수는 **첫 번째 색을 제외하고, 두 번째 색부터 N-2번째 색까지** j-1개를 뽑은 경우, 즉 dp[N-2-1][j-1]
   - 마지막 색을 뽑을 수 없는 경우의 수는 dp[N-1][j]
## ⏳ 회고
- B형 특강 강사님이 한국인은 양치기 잘해서 DP 잘 할 수 있다고 했다 ^^.,,..
- 많이 접해보고 고민해보자