### PR TITLE
[20250227] BOJ / P3 / Starting a Scenic Railroad Service / 권혁준

### DIFF
--- a/khj20006/202502/27 BOJ P3 Starting a Scenic Railroad Service.md
+++ b/khj20006/202502/27 BOJ P3 Starting a Scenic Railroad Service.md
@@ -1,0 +1,95 @@
+```cpp
+
+#include <iostream>
+#include <vector>
+#include <algorithm>
+#include <set>
+#include <ext/pb_ds/assoc_container.hpp>
+#include <ext/pb_ds/tree_policy.hpp>
+using namespace std;
+using namespace __gnu_pbds;
+using ll = long long;
+
+int seg[262145][2]{};
+
+#define ordered_set tree<ll, null_type, less_equal<ll>, rb_tree_tag, tree_order_statistics_node_update>
+ordered_set os;
+
+void upt(int s, int e, int i, int n, int x) {
+	if (s == e) {
+		seg[n][x]++;
+		return;
+	}
+	int m = (s + e) >> 1;
+	if (i <= m) upt(s, m, i, n * 2, x);
+	else upt(m + 1, e, i, n * 2 + 1, x);
+	seg[n][x]++;
+}
+
+int find(int s, int e, int l, int r, int n, int x) {
+	if (l > r || l > e || r < s) return 0;
+	if (l <= s && e <= r) return seg[n][x];
+	int m = (s + e) >> 1;
+	return find(s, m, l, r, n * 2, x) + find(m + 1, e, l, r, n * 2 + 1, x);
+}
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	int N;
+	cin >> N;
+
+	vector<vector<int>> in(100001), out(100001);
+	int H[200001]{};
+
+	vector<pair<int, int>> V;
+	for (int i = 1, a, b; i <= N; i++) {
+		cin >> a >> b;
+		in[a].push_back(i);
+		out[b].push_back(i);
+		V.emplace_back(a, b);
+		upt(1, 100000, a, 1, 0);
+		upt(1, 100000, b, 1, 1);
+
+	}
+
+	int s1 = 0;
+	sort(V.begin(), V.end(), [](auto a, auto b) -> bool {
+		if (a.second == b.second) return a.first > b.first;
+		return a.second < b.second;
+	});
+
+	for (int i=0;i<V.size();i++) {
+	    while(i<V.size()-1 && V[i].first == V[i+1].first){
+	        os.insert(V[i++].first);
+	    }
+	    int a = V[i].first, b = V[i].second;
+		int res = find(1, 100000, a, b-1, 1, 0) + find(1, 100000, a+1, b, 1, 1) - 1;
+
+        
+		res -= (os.size() - os.order_of_key(a));
+		os.insert(a);
+
+		s1 = max(s1, res);
+	}
+
+
+	set<int> S = { 0 };
+	int s2 = 0, mex = 0;
+	for (int x = 1; x <= 100000; x++) {
+		for (int i : out[x]) {
+			S.erase(H[i]);
+			mex = min(mex, H[i]);
+		}
+		for (int i : in[x]) {
+			while (S.count(mex)) mex++;
+			S.insert(H[i] = mex++);
+		}
+		s2 = max(s2, *S.rbegin());
+	}
+
+	cout << s1 << ' ' << s2;
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/15337

## 🧭 풀이 시간
200분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
- 1부터 100,000까지 번호가 붙은 여행지가 번호 순서대로 일렬로 나열되어 있고, 기차 한 대가 1번에서 출발하여 100,000번까지 운행된다.
- 승객이 N명 있고, 각각 A[i]번 여행지에서 B[i]번 여행지까지 기차를 타고 가려 한다.
- 기차 좌석의 수를 정해야 하는데, 두 가지 정책이 있다.
### 정책 1
- 승객들은 임의의 순서대로 본인이 원하는 자리를 예약할 수 있다.
### 정책 2
- 승객들은 본인이 원하는 자리를 예약할 수 없고, 대신 철도공사에서 정해준 자리에 앉아야 한다.
---
- 두 정책에 필요한 좌석의 최소 개수를 각각 구해보자.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- 그리디 알고리즘
- 정렬
- 스위핑
- policy-based data structure
- 누적 합?
---
### 정책 2
- 이건 단순히 각 사람을 여행지 번호 순대로 정렬시켜놓고, 부여해줄 수 있는 좌석 번호 중 제일 작은 값을 배정해주면 된다.
- 구현하기 위해 set으로 사용 중인 좌석 번호들을 관리하며, 특정 사람에게 좌석을 부여할 때 set의 **mex값**을 구했다.

### 정책 1
- 각 사람의 출발 여행지와 도착 여행지를 지금부터는 하나의 `선분`으로 생각한다.
- 각 `선분`에 **적어도 길이 1이상 걸쳐있는 선분의 개수**가 곧 그 사람이 앉을 수 있는 좌석 번호 중 최댓값이다.
- 승객들의 예약 순서가 무작위이기 때문에, 위의 값이 곧 worst case에서의 최소 좌석 수가 됨을 알 수 있다.
- 각 선분 [s,e]에 대해 걸쳐있는 선분의 수를 구하는 방법은 다음과 같다.
1. 시작 여행지가 `s이상 e미만`인 승객의 수
2. 도착 여행지가 `s초과 e이하`인 승객의 수
3. 시작 여행지와 도착 여행지가 모두 [s,e] 안에 포함된 승객의 수

- (1) + (2) - (3)이 곧 그 선분에 걸쳐 있는 선분의 수가 된다.
- (1), (2)는 세그먼트 트리로 구해줬지만, 지금 생각해보니 단순 누적 합으로도 가능하다.
- (3) : 승객들을 미리 **도착 여행지가 작은 순으로** 정렬시켜놓고, policy-based data structure(pbds)를 이용해, pbds 내에 s이상의 원소 개수를 구한다.
---
- 위 방법대로 각 선분에서의 걸친 개수를 세어주고, 그 중 최댓값을 구해준다.

## ⏳ 회고
- 정책 2는 금방 해결했는데, 1이 너무 어려웠다...
- 