### PR TITLE
[20250227] BOJ / 골드3 / 파티 / 김수연

### DIFF
--- a/suyeun84/202502/27 BOJ G3 파티.md
+++ b/suyeun84/202502/27 BOJ G3 파티.md
@@ -1,0 +1,68 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class boj1238 {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+	
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static void end() throws Exception {bw.flush();bw.close();br.close();}
+	
+	static ArrayList<ArrayList<Node>> graph = new ArrayList<>();
+	static int N, M, X;
+	
+	public static void main(String[] args) throws Exception {
+		nextLine();
+		N = nextInt();
+		M = nextInt();
+		X = nextInt();
+		int S, E, T, answer = 0;
+		for (int i = 0; i < N+1; i++) graph.add(new ArrayList<>());
+		
+		for (int i = 0; i < M; i++) {
+			nextLine();
+			S = nextInt();
+			E = nextInt();
+			T = nextInt();
+			graph.get(S).add(new Node(T, E));
+		}
+		
+		for (int i = 1; i < N+1; i++) {
+			answer = Math.max(answer, dijkstra(i, X) + dijkstra(X, i));
+		}
+		bw.write(answer+"\n");
+		end();
+	}
+	
+	static int dijkstra(int start, int target) {
+		if (start == target) return 0;
+		PriorityQueue<Node> pq = new PriorityQueue<>((o1, o2) -> o1.t-o2.t);
+		int[] dist = new int[N+1];
+		Arrays.fill(dist, Integer.MAX_VALUE);
+		dist[start] = 0;
+		pq.add(new Node(0, start));
+		while (!pq.isEmpty()) {
+			Node curr = pq.poll(); //시간 가장 작은 것
+			if (dist[curr.e] < curr.t) continue;
+			dist[curr.e] = curr.t;
+			for (Node n : graph.get(curr.e)) {
+				if (n.t+dist[curr.e] >= dist[n.e]) continue;
+				pq.add(new Node(n.t+dist[curr.e], n.e));
+			}
+		}
+		return dist[target];
+	}
+
+	static class Node {
+		int t;
+		int e;
+		public Node(int t, int e) {
+			this.t = t;
+			this.e = e;
+		}
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1238
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N명의 학생이 X번 마을에 모여서 파티를 개최
각 학생들이 단방향 도로들을 통해 최단 시간에 오고 간다.
i->X->i로 오는 시간이 가장 오래 소요되는 학생의 시간 구하기
## 🔍 풀이 방법
다익스트라를 사용해서 각 학생들 별로 dijkstra(i, X) + dijkstra(X, i)를 구해서 MAX값을 찾았다.
다익스트라를 할 때, PriorityQueue에 넣는 것들의 가지치기를 하지 않으면 메모리 초과가 뜬다.
플로이드-워셜 알고리즘으로도 풀 수 있다는데 그러면 시간초과가 뜬다.
## ⏳ 회고
X를 향해 갈 때와 X에서 돌아올 때의 값들을 배열에 저장해두면, 걸리는 시간을 줄일 수 있다.
다익스트라 오랜만에 하니 얘도 헷갈린다....