### PR TITLE
[20250227] BOJ / D4 / 트리와 K번째 수 / 권혁준

### DIFF
--- a/khj20006/202502/27 BOJ D4 트리와 K번째 수.md
+++ b/khj20006/202502/27 BOJ D4 트리와 K번째 수.md
@@ -1,0 +1,107 @@
+```cpp
+
+#include <iostream>
+#include <vector>
+#include <algorithm>
+#include <cmath>
+using namespace std;
+#define AA(p,q,s)	p.begin(), p.end(), q.begin(), q.end(), s.begin()
+int A[100001]{}, par[100001]{}, sz[100001]{}, dep[100001]{}, cn[100001]{}, ci[100001]{};
+vector<vector<int>> V(100001), C(100001);
+vector<vector<int>> seg[100001]{};
+
+int dfs(int n, int p) {
+	par[n] = p, sz[n] = 1;
+	for (int i : V[n]) if (i != p) sz[n] += dfs(i, n);
+	return sz[n];
+}
+
+void hld(int n, int p, int s, int d) {
+	dep[n] = d, cn[n] = s, ci[n] = C[s].size();
+	C[s].push_back(n);
+	int h = -1;
+	for (int i : V[n]) if (i != p && (h == -1 || sz[i] > sz[h])) h = i;
+	if (h != -1) hld(h, n, s, d);
+	for (int i : V[n]) if (i != p && i != h) hld(i, n, i, d + 1);
+}
+
+void init(int id, int s, int e, int n) {
+	if (s == e) {
+		seg[id][n] = { A[C[id][s]] };
+		return;
+	}
+	int m = (s + e) >> 1;
+	init(id, s, m, n * 2);
+	init(id, m + 1, e, n * 2 + 1);
+	seg[id][n].resize(seg[id][n * 2].size() + seg[id][n * 2 + 1].size());
+	merge(AA(seg[id][n * 2], seg[id][n * 2 + 1], seg[id][n]));
+}
+
+int find(int id, int s, int e, int l, int r, int k, int n) {
+	if (l > r || l > e || r < s) return 0;
+	if (l <= s && e <= r) return lower_bound(seg[id][n].begin(), seg[id][n].end(), k) - seg[id][n].begin();
+	int m = (s + e) >> 1;
+	return find(id, s, m, l, r, k, n * 2) + find(id, m + 1, e, l, r, k, n * 2 + 1);
+}
+
+int cnt(int a, int b, int k) {
+	int res = 0;
+	while (cn[a] != cn[b]) {
+		if (dep[a] > dep[b]) {
+			res += find(cn[a], 0, C[cn[a]].size() - 1, 0, ci[a], k, 1);
+			a = par[cn[a]];
+		}
+		else {
+			res += find(cn[b], 0, C[cn[b]].size() - 1, 0, ci[b], k, 1);
+			b = par[cn[b]];
+		}
+	}
+	if (ci[a] > ci[b]) swap(a, b);
+	res += find(cn[a], 0, C[cn[a]].size() - 1, ci[a], ci[b], k, 1);
+	return res;
+}
+
+int M[100000]{};
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	int N, Q;
+	cin >> N >> Q;
+	vector<pair<int, int>> Value;
+	for (int i = 1; i <= N; i++) {
+		cin >> A[i];
+		Value.emplace_back(A[i], i);
+	}
+	sort(Value.begin(), Value.end());
+	for (int i = 0; i < N; i++) M[i] = Value[i].first, A[Value[i].second] = i;
+
+
+	for (int i = 1, a, b; i < N; i++) {
+		cin >> a >> b;
+		V[a].push_back(b);
+		V[b].push_back(a);
+	}
+
+	dfs(1, 0);
+	hld(1, 0, 1, 0);
+
+	for (int i = 1; i <= N; i++) if (!C[i].empty()) {
+		seg[i].resize((1 << ((int)log2(C[i].size()) + 2)) + 1);
+		init(i, 0, C[i].size() - 1, 1);
+	}
+
+	for (int x, y, k; Q--;) {
+		cin >> x >> y >> k;
+		long long s = 0, e = 100000, m = (s + e + 1) >> 1;
+		while (s < e) {
+			if (cnt(x, y, m) < k) s = m;
+			else e = m - 1;
+			m = (s + e + 1) >> 1;
+		}
+		cout << M[m] << '\n';
+	}
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11932

## 🧭 풀이 시간
62분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
- 정점이 N개인 트리의 각 정점에 가중치가 달려있다. 질문을 Q개 처리해보자.
- 각 질문은 (x, y, k)로 표현되며, `정점 x에서 정점 y로 가는 경로 상에 존재하는 정점들의 가중치 중 K번째로 작은 가중치`를 구해야 한다.

## 🔍 풀이 방법
[사용한 알고리즘]
- heavy-light 분할
- 머지 소트 트리
- 이분 탐색
---
- 만약 트리가 아니라 수열에서 어떤 부분의 k번째 가중치를 찾는 문제였다면, 이 문제는 머지 소트 트리 + 매개 변수 탐색으로 해결할 수 있다.
- heavy-light 분할로 트리를 일자로 편 다음, heavy와 light 체인 각각에 대한 머지 소트 트리를 전부 만들어준다.
- 질문이 들어오면, 경로 상에 존재하는 체인들에서 매개 변수 탐색으로 k번째 가중치가 되는 값을 찾아주면 된다.
- 시간 제한이 엄청 빡빡해서, 가중치를 압축해야 겨우 통과한다.

## ⏳ 회고
- 드디어 클래스 8을 달성했다 ㅎ ㅎ