### PR TITLE
[20250303] BOJ / P5 / 발전소 / 권혁준

### DIFF
--- a/khj20006/202503/03 BOJ P5 발전소.md
+++ b/khj20006/202503/03 BOJ P5 발전소.md
@@ -1,0 +1,82 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	static int[][] D, C;
+	static int N, P, ans;
+	static final int INF = (int)1e9;
+	static int start = 0;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = Integer.parseInt(br.readLine());
+		D = new int[N][1<<N];
+		for(int i=0;i<N;i++) Arrays.fill(D[i], INF);
+		C = new int[N][N];
+		for(int i=0;i<N;i++) {
+		    nextLine();
+		    for(int j=0;j<N;j++) C[i][j] = nextInt();
+		}
+		
+		char[] info = br.readLine().toCharArray();
+        int temp = 0;
+		for(int i=0;i<N;i++) {
+            start |= (info[i] == 'Y' ? (1<<i) : 0);
+            temp += (info[i] == 'Y' ? 1 : 0);
+        }
+		
+		P = Integer.parseInt(br.readLine());
+		for(int i=0;i<N;i++) if((1<<i) != 0) D[i][start] = 0;
+		ans = temp >= P ? 0 : INF;
+		
+	}
+	
+	static void solve() throws Exception{
+
+		for(int i=0;i<N;i++) dp(i,(1<<N)-1);
+		bw.write((ans==INF ? -1 : ans) + "\n");
+		
+	}
+	
+	static int dp(int n, int k) throws Exception {
+	    if(D[n][k] != INF || (start & (1<<n)) != 0) return D[n][k];
+	    int p = k^(1<<n);
+	    int prev = INF, cost = INF, cnt = 0;
+	    for(int i=0;i<N;i++){
+	        if((p & (1<<i)) == 0) continue;
+	        cnt++;
+	        prev = Math.min(prev, dp(i, p));
+	        cost = Math.min(cost, C[i][n]);
+	    }
+	    D[n][k] = Math.min(D[n][k], prev+cost);
+	    if(cnt >= P-1) ans = Math.min(ans, D[n][k]);
+	    return D[n][k];
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1102

## 🧭 풀이 시간
35분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
- N개의 발전소가 있고, 각 발전소 중 몇 개는 고장났다.
- 고장나지 않은 발전소를 이용해서 고장난 발전소를 고칠 수 있다.
- 발전소를 고치는 비용이 N*N 형태로 주어진다.
- 최소 P개의 발전소가 고장나있지 않도록 고치는 최소 수리 비용을 구해보자.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- Bit DP 
---
- 고장난 발전소와 고장나지 않은 발전소의 조합으로 가능한 경우들을 **비트마스킹**으로 **정수 하나**만을 사용해서 나타낼 수 있다.
ex)
![image](https://github.com/user-attachments/assets/fa2d896d-97a4-4371-9525-5233a4a55d59)
=> `1101101`로 나타낼 수 있다.
- 이 비트마스킹을 이용해서 2차원 DP배열을 떠올렸다.
- $DP[n][k] =$ 비트마스킹 k인 상태에서, 마지막으로 고친 발전소의 번호가 n이었을 때의 최소 수리 비용
- 마지막으로 고친 발전소가 n이니까, 그 이전 상태로 가능한 경우는 $DP[i][k \oplus 2^n]$이다. (단, $2^i | k = k$ 이어야 함)
- top-down으로 돌려서, 각 상태 별로 고장나지 않은 발전소가 P개 이상인 경우에만 정답을 갱신해줬다.

## ⏳ 회고
- 처음에 다 고장나있는 경우에서 P = 0일 때를 처리하지 못해 틀림.