### PR TITLE
[20250303] BOJ / G3 / 울타리 치기 / 권혁준

### DIFF
--- a/khj20006/202503/03 BOJ G3 울타리 치기.md
+++ b/khj20006/202503/03 BOJ G3 울타리 치기.md
@@ -1,0 +1,50 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	static long[] D;
+	static int N;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = Integer.parseInt(br.readLine());
+		D = new long[1000001];
+		
+	}
+	
+	static void solve() throws Exception{
+
+		for(int i=1;i<=5;i++) D[i] = i;
+		D[6] = 7;
+		for(int i=7;i<=N;i++) D[i] = D[i-6] + i;
+		bw.write(D[N] + "\n");
+		
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1364

## 🧭 풀이 시간
35분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
![image](https://github.com/user-attachments/assets/f0a458a5-a0cf-4199-97c7-f977b135a525)
- 무한한 육각형 블록 세계에서, N개의 블록으로 울타리를 쳐서 넓이를 최대로 해보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- DP
---
- 둘레가 N인 울타리는 둘레가 N-6인 울타리를 감싼 형태가 된다.
- 따라서, DP[N] = DP[N-6] + N이 성립한다.

## ⏳ 회고
- 육각형이라 규칙 찾기가 힘들었다..