### PR TITLE
[20250305] BOJ / P5 / Cards Flipping / 권혁준

### DIFF
--- a/khj20006/202503/05 BOJ P5 Cards Flipping.md
+++ b/khj20006/202503/05 BOJ P5 Cards Flipping.md
@@ -1,0 +1,96 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+
+	static List<Integer>[] V;
+	static int N;
+	static int[] A, B;
+	static boolean[] vis;
+	static int ans = 0, cnt = 0;
+	static boolean multiedge;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+
+		N = Integer.parseInt(br.readLine());
+		A = new int[N];
+		B = new int[N];
+		
+		nextLine();
+		for(int i=0;i<N;i++) A[i] = nextInt();
+		
+		nextLine();
+		for(int i=0;i<N;i++) B[i] = nextInt();
+
+		vis = new boolean[1000001];
+		V = new List[1000001];
+		
+		for(int i=0;i<=1000000;i++) V[i] = new ArrayList<>();
+		
+		for(int i=0;i<N;i++) {
+			V[A[i]].add(B[i]);
+			V[B[i]].add(A[i]);	
+		}
+		
+		for(int i=0;i<=1000000;i++) if(!V[i].isEmpty()) Collections.sort(V[i]);
+		
+	}
+	
+	static void solve() throws Exception{
+
+		for(int i=0;i<=1000000;i++) {
+			if(vis[i]) continue;
+			multiedge = false;
+			cnt = 0;
+			vis[i] = true;
+			if(dfs(i, -1) && !multiedge) ans += cnt-1;
+			else ans += cnt;
+		}
+		bw.write(ans + "\n");
+		
+	}
+	
+	// 트리면 true, 아니면 false
+	static boolean dfs(int n, int p) {
+		cnt++;
+		boolean res = true;
+		int prev = -1;
+		for(int i=0;i<V[n].size();i++) if(!V[n].get(i).equals(p)) {
+			int x = V[n].get(i);
+			if(i < V[n].size()-1 && V[n].get(i+1).equals(x)) multiedge = true;
+			if(vis[x]) res = false;
+			else{
+				vis[x] = true;
+				res &= dfs(x,n);
+			}
+		}
+		return res;
+	}
+	
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/32830

## 🧭 풀이 시간
100분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
- 카드 N개의 앞, 뒷면에 각각 색이 칠해져있다.
- 색은 0 ~ 1000000 사이의 정수로 나타낸다.
- 카드를 적당히 뒤집어서, 보이는 색의 종류를 최대화해보자.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- DFS
---
- 각 카드의 앞, 뒷면에 칠해진 색을 a, b라고 하면, a와 b를 잇는 간선을 그래프에 추가시킨다.
- 어떤 점 a와 간선으로 연결된 점들은, a가 선택된 시점에서 **반드시 쓰여야 하는** 점들을 의미한다.
- 완성된 그래프의 각 컴포넌트별로, 이 컴포넌트가 트리인지 아닌지 확인한다.
- 트리가 아니면, 해당 그래프에 존재하는 색을 **항상** 모두 보이게 할 수 있다.
- 만약 트리라면, 트리에 존재하는 색 중 **하나만 제외하고** 모두 보이게 할 수 있다.

## ⏳ 회고
- 처음엔 DP로 접근했다가 실패하고, 두 번째엔 그래프 상에서 최장 경로를 구하는 거라고 생각했다가 반례가 나와서 갈아엎었다.
- 이후에도 중복 간선의 여부를 생각하지 않아서 고생했다.