### PR TITLE
[20250305] BOJ / P5 / 박성원 / 권혁준

### DIFF
--- a/khj20006/202503/05 BOJ P5 박성원.md
+++ b/khj20006/202503/05 BOJ P5 박성원.md
@@ -1,0 +1,97 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+
+	static long[][] dp;
+	static int N, K;
+	static int[] len, A;
+	static char[][] temp;
+	static long[] pre;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+
+		N = Integer.parseInt(br.readLine());
+		temp = new char[N][];
+		for(int i=0;i<N;i++) temp[i] = br.readLine().toCharArray();
+		K = Integer.parseInt(br.readLine());
+		dp = new long[K][1<<N];
+		len = new int[N];
+		A = new int[N];
+		pre = new long[16];
+		pre[1] = 10;
+		for(int i=2;i<16;i++) pre[i] = pre[i-1] * 10;
+		
+		for(int i=0;i<N;i++) {
+			len[i] = temp[i].length;
+			int res = 0;
+			for(char c : temp[i]) {
+				res = (res * 10 + (c-'0')) % K;
+			}
+			A[i] = res;
+			dp[res][1<<i] = 1;
+		}
+		
+	}
+	
+	static void solve() throws Exception{
+
+		for(int i=1;i<(1<<N);i++) {
+			for(int k=0;k<K;k++) {
+				for(int x=0;x<N;x++) if((i & (1<<x)) == 0) {
+					long tmp = k;
+					int cnt = len[x];
+					while(cnt > 0) {
+						int diff = Math.min(15, cnt);
+						tmp = (tmp * pre[diff]) % K;
+						cnt-=diff;
+					}
+					int res = ((int)tmp + A[x]) % K;
+					dp[res][i|(1<<x)] += dp[k][i];
+				}
+			}
+		}
+		
+		long ans = dp[0][(1<<N)-1], total = 1;
+		for(long i=2;i<=N;i++) total *= i;
+		
+		if(ans == 0) total = 1;
+		else {
+			long[] P = {2,3,5,7,11,13};
+			for(long i:P) {
+				while(ans%i==0 && total%i==0) {
+					ans/=i;
+					total/=i;
+				}
+			}
+		}
+		bw.write(ans+"/"+total);
+		
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1086

## 🧭 풀이 시간
42분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
- 서로 다른 N개의 정수로 이루어진 집합이 있다.
- 각 수는 최대 50자리이다.
- 이 집합에서 가능한 모든 순열 중 하나를 무작위로 골라서, 순열의 원소를 **모두 이어붙여 만든 수**가 K로 나누어떨어질 확률을 구해보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- Bit DP
---
- 어떤 수 A를 K로 나눈 나머지는 아래 과정을 반복해서 구할 수 있다.
1. result = 0
2. A의 각 자리에 있는 수 i마다, result = (result * 10 + i) % K
=> 나머지의 성질에 의해 가능하다. 
$(a + b) \mod K = ((a \mod K) + (b \mod K)) \mod K$
$(a \times b) \mod K = ((a \mod K) \times (b \mod K)) \mod K$

- 나머지 관리 방법을 알았으면, dp를 정의한다.
`dp[m][k] = 집합에서 고른 원소들 목록이 k일 때의 가능한 수 중, K로 나눈 나머지가 m인 경우의 수`
- 위 식을 bottom-up으로 채워 해결했다.

## ⏳ 회고
- dp 전이할 때 각 수를 매번 직접 더해주니까 시간 초과가 난다.
- $pre[k] = 10^k$로 정의해놓고 커팅해서 해결할 수 있었다.