### PR TITLE
[20250305] BOJ / G3 / K진 트리 / 신동윤

### DIFF
--- a/03do-new30/202503/05 BOJ G3 이진트리.md
+++ b/03do-new30/202503/05 BOJ G3 이진트리.md
@@ -1,0 +1,33 @@
+```java
+import java.util.*;
+
+public class Main {
+    static int K;
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        long N = sc.nextLong();
+        K = sc.nextInt();
+        int Q = sc.nextInt();
+        for (int i = 0; i < Q; i++) {
+            long x = sc.nextLong() - 1;
+            long y = sc.nextLong() - 1;
+            if (K == 1) {
+                System.out.println(Math.abs(x - y));
+            } else {
+                int dist = 0;
+                while (x != y) {
+                    if (x < y) {
+                        y = (y - 1) / K; // y = y의 부모 노드
+                    } else {
+                        x = (x - 1) / K; // x = x의 부모 노드
+                    }
+                    dist++;
+                }
+                System.out.println(dist);
+            }
+        }
+        sc.close();
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11812
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
"적은 에너지 방법" 으로 채워진 K진 트리에서 두 노드 x와 y 사이의 거리를 구하자

## 🔍 풀이 방법
- x와 y 사이의 거리는 depth 기반으로 구한다.
   - x와 y가 같은 정점에서 만날 때까지 각각 부모 노드를 타고 올라온다고 생각하면 편함
- K = 1일 때(worst)는 x와 y의 차를 리턴하면 된다

## ⏳ 회고
- 0번 노드부터 쓴다고 생각하면 부모 노드 구하는 공식이 조금 더 잘 보이는 느낌 🤔
