### PR TITLE
[20250306] BOJ / P4 / My뷰 꾸미기 / 권혁준

### DIFF
--- a/khj20006/202503/06 BOJ P4 My뷰 꾸미기.md
+++ b/khj20006/202503/06 BOJ P4 My뷰 꾸미기.md
@@ -1,0 +1,72 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+
+	static int N;
+	static long ans = 1;
+	static long[] fac = new long[600001];
+	static final long mod = (long)1e9 + 7;
+	
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = Integer.parseInt(br.readLine());
+		fac[0] = 1;
+		for(int i=1;i<=600000;i++) fac[i] = (fac[i-1] * i) % mod;
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		while(N-- > 0) {
+			nextLine();
+			int a = nextInt(), b = nextInt();
+			ans = (ans * (comb(a+b,a) + mod - 1)) % mod;
+		}
+		bw.write(ans + "\n");
+		
+	}
+	
+	static long comb(int x, int y) {
+		
+		return fac[x] * power(fac[x-y], mod-2) % mod * power(fac[y], mod-2) % mod;
+		
+	}
+	
+	// x^p % mod
+	static long power(long x, long p) {
+		if(p == 0) return 1;
+		if(p == 1) return x % mod;
+		long half = power(x,p>>1) % mod;
+		half = half * half % mod;
+		if(p%2==0) return half;
+		return half * x % mod;
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/25569

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
당신은 $N$개의 관심 분야를 정하고, 관심 분야마다 $2$명의 에디터를 골라 그들의 콘텐츠를 받아보기로 했다.

$i\ (1 \le i \le N)$번째 관심 분야의 에디터 $2$명은 각각 현재까지 $A_i$개, $B_i$개의 글을 작성하였다. 
당신은 각 관심 분야마다, 에디터 $2$명의 글이 **같은 개수만큼 등장하도록** _My뷰_를 꾸밀 것이다.
또한, 에디터마다 최소 $1$개 이상씩의 글이 등장하도록 할 것이다.

_My뷰_를 구성할 수 있는 경우의 수를 $10^9 + 7$로 나눈 나머지를 구해보자.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- 조합론
- 분할 정복을 이용한 거듭제곱
- 페르마의 소정리
---
### 식 도출하기
- $i$번째 관심 분야에서 글을 고르는 경우의 수를 $f(i)$라고 정의했다.
- $i$번째 관심 분야 $(A_i, B_i)$에 대해서 $v = \min(A_i, B_i)$라고 하면, $f(i)$는 ((글을 $1$개 고르는 경우) + (글을 $2$개 고르는 경우) + ... + (글을 $v$개 고르는 경우)) $\mod (10^9 + 7)$이다.
- 글을 $k$개 고르는 경우의 수 => 각 사람이 쓴 글에서 $k$개씩 골라오게 되면
$\_{A_i}C_{k} \times \_{B_i}C_{k} \mod (10^9 + 7)$이다.
- 식을 정리하면, $f(i) = \sum \limits_{k=1}^{\min(A_i, B_i)} {\_{A_i}C_{k} \times \_{B_i}C_{k}} \mod (10^9 + 7)$이다.

### 빠르게 계산하기
- A의 글과 B의 글을 한 곳에 모아놓고 생각하면, $A_i + B_i$개의 글 중에서 $\min(A_i, B_i)$개만 고르는 경우로 치환이 가능하다.
- 다시 쓰면, $f(i) = $\_{A_i + B_i}C_{\min(A_i,B_i)} - 1$이다. (글을 고르지 않는 경우는 불가능하니 1을 빼준다)
- 이 $f(i)$를 $10^9 + 7$로 나눈 **나머지**는 **페르마의 소정리**와 **분할 정복을 이용한 거듭제곱**으로 $O(\log{A_i})$만에 구할 수 있다.

### 정답 구하기
- 위의 $f(i)$를 모두 곱한 값에 $10^9 + 7$로 나눈 나머지를 취하면 된다.

## ⏳ 회고
- $f(i)$ 구하는 기다란 식까지는 잘 도출했는데, 두 명의 글을 합쳐놓고 뽑는다는 생각을 못했다.
- 무료 gpt도 많이 똑똑한 것 같다