### PR TITLE
[20250307] BOJ / G3 / 화학실험 / 권혁준

### DIFF
--- a/khj20006/202503/07 BOJ G3 화학실험.md
+++ b/khj20006/202503/07 BOJ G3 화학실험.md
@@ -1,0 +1,74 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+
+	static int N, M;
+	static int[] A, B;
+	
+	static PriorityQueue<int[]> Q = new PriorityQueue<>((a,b) -> {
+		if(a[0] == b[0]) return a[1]-b[1];
+		return a[0]-b[0];
+	});
+	static int[] cnt;
+	
+	public static void main(String[] args) throws Exception {
+			
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = Integer.parseInt(br.readLine());
+		A = new int[N];
+		B = new int[N];
+		cnt = new int[1001001];
+		for(int i=0;i<N;i++) {
+			nextLine();
+			A[i] = nextInt();
+			B[i] = nextInt();
+			Q.offer(new int[] {A[i]+B[i],A[i]});
+			cnt[A[i]+B[i]]++;
+		}
+		
+		M = Integer.parseInt(br.readLine()) - N;
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		for(int i=0;i<M;i++) {
+			int[] now = Q.poll();
+			cnt[now[0]]--;
+			cnt[now[0]+now[1]]++;
+			Q.offer(new int[] {now[0]+now[1], now[1]});
+		}
+		int x = Q.poll()[0];
+		if(cnt[x] == N) bw.write(x + "\n");
+		else bw.write("0");
+		
+		
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1954

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- N종류의 화학 시약 $T_1, T_2, \cdots, T_N$과 $M$ mg의 용액이 있다. 시약 $T_i$는 두 정수 $A_i, B_i$로 이루어져 있다.
- 용액을 $x$ mg만큼 시약 $T_i$에 넣으면, **가스**가 $A_i \times x + B_i$만큼 발생한다.
- $M$ mg의 용액을 적절히 분배해 각각의 시약에 $1$ mg 이상 넣을 때, 모든 시약에서 같은 양의 **가스**가 나올 수 있는지 구해보자.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- 우선순위 큐
---
- 가장 적은 가스가 발생하는 시약에 용액을 $1$ mg씩 투여하고, $M$ mg를 다 썼을 때 가스의 양이 모든 시약에서 같은지 확인하면 된다.
- 처음에 모든 시약에 $1$ mg만큼 투여한 후, **가스** 양을 우선순위 큐에 담아준다.
- 우선순위 큐의 우선순위 기준은 `가스 양이 적은 순`, 가스 양이 동일하다면 `A[i]가 작은 순`으로 설정한다.

## ⏳ 회고
문제가 잘 안 풀리는 걸 보니 25년도 1차 슬럼프가 찾아온 것 같다