### PR TITLE
[20250307] BOJ / P4 / Denouncing Mafia / 권혁준

### DIFF
--- a/khj20006/202503/07 BOJ P4 Denouncing Mafia.md
+++ b/khj20006/202503/07 BOJ P4 Denouncing Mafia.md
@@ -1,0 +1,75 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+
+	static int N, K;
+	static List<Integer>[] V;
+	static int[] C;
+	
+	public static void main(String[] args) throws Exception {
+			
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		nextLine();
+		N = nextInt();
+		K = nextInt();
+		
+		V = new List[N+1];
+		C = new int[N+1];
+		for(int i=1;i<=N;i++) V[i] = new ArrayList<>();
+		
+		nextLine();
+		for(int i=2;i<=N;i++) V[nextInt()].add(i);
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		int ans = 0;
+		for(int x = dfs(1);K > 0 && x >= 1;) {
+			if(C[x] > 0) {
+				C[x]--;
+				ans += x;
+				K--;
+			}
+			else x--;
+		}
+		
+		bw.write(ans + "\n");
+		
+	}
+	
+	static int dfs(int n) {
+		int mx = 0;
+		for(int i:V[n]) mx = Math.max(mx, dfs(i));
+		C[mx++]--;
+		C[mx]++;
+		return mx;
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17532

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
$N$명의 마피아 구성원이 서로 트리 형태의 상사-부하 관계를 가지고, 1번 사람은 마피아의 보스이다. (=> 1번의 상사가 없다 => 트리의 루트이다.)

어떤 마피아 구성원이 심문을 받게 되면, 그는 자신의 범죄를 인정하고 체포당하며, 직속 상관의 범죄 또한 인정한다.
직속 상관이 아직 체포되지 않았다면, 직속 상관이 또다시 자신의 직속 상관의 범죄를 인정하며, 체포당한다.

보스에게 도달할 때까지 위 과정이 계속된다.
최대 $K$명의 구성원에게 초기 심문을 진행할 수 있을 때, 최대 몇 명을 체포할 수 있는지 구해보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- 그리디 알고리즘
- DFS
---
당연하게도, **부하가 없는 구성원**(리프 정점)들만 심문하는 것이 **항상 이득**임을 알 수 있다.

문제에서 원하는 값을 간단히 요약하면, `리프 정점을 최대 K개 골라서 루트까지 이동했을 때 만나게 되는 정점 개수의 최댓값`이다.

어떤 정점 n을 루트로 갖는 서브트리 내에서만 생각해보자.
이 서브트리에서 i개의 정점을 골랐을 때 **추가로** 체포되는 사람 수를 $L[i]$라고 하자.
n의 직속 상관 p에 대한 서브트리에서, $L[i]$가 그대로 따라오고 $L[1]$만 1 증가하는 것을 알 수 있다.
=> DFS 한 번으로 트리 전체의 L을 구할 수 있다.

여기서 $L[1] + ... + L[K]$를 구해주면 된다.

## ⏳ 회고
지문만 다르고 구하는 값은 똑같은 문제를 얼마 전에 풀려고 했다가 못 풀었었는데,
오늘 30분 정도 다시 보니 풀이가 떠올랐다 😄 
https://www.acmicpc.net/problem/28759