### PR TITLE
[20250308] BOJ / G2 / MEX / 권혁준

### DIFF
--- a/khj20006/202503/08 BOJ G2 MEX.md
+++ b/khj20006/202503/08 BOJ G2 MEX.md
@@ -1,0 +1,82 @@
+## JAVA
+```java
+
+import java.util.*;
+import java.io.*;
+
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+
+	static int N;
+    static boolean[] A = new boolean[2200001];
+    static boolean[] B = new boolean[2200001];
+    
+	public static void main(String[] args) throws Exception {
+			
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = Integer.parseInt(br.readLine());
+        for(nextLine();N-->0;A[nextInt()]=true);
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		for(int i=0;i<=2200000;i++) {
+            if(!A[i] && !B[i]){
+                bw.write(i + "\n");
+                return;
+            }
+            if(i<2 || !A[i]) continue;
+            for(long j=i*2;j<=Math.min(2200000L,(long)i*i);j+=i) B[(int)j] = true;
+        }
+		
+	}
+	
+}
+
+```
+
+## C++
+```cpp
+
+#include <iostream>
+#include <bitset>
+using namespace std;
+using ll = long long;
+
+int main() {
+    cin.tie(0)->sync_with_stdio(0);
+
+    int N;
+    cin>>N;
+    bitset<2200001> A, B;
+    for(int a;N--;A[a]=1) cin>>a;
+    for(int i=0;i<2200001;i++) {
+        if(!A[i] && !B[i]) return cout<<i,0;
+        if(i < 2 || !A[i]) continue;
+        for(ll j=i*2;j<=min(2200000LL, (ll)i*i);j+=i) B[j] = 1;
+    }
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/23820

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
길이 $N$인 수열 $A_1, A_2, \cdots, A_N$이 주어지면, $mex( \[ A_i \times A_j\ | 1 \le i \le j \le N \] )$를 구해보자.
$mex(S)$는 `집합 S에 포함되지 않은 가장 작은 0 이상의 정수`이다.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- 수학
---
우선, 수열의 원소가 $2\,000\,000$이하라서 **이보다 큰 가장 작은 소수**는 절대로 만들 수 없다.
그리고, 수열에 0이나 1이 없는 경우는 mex값이 각각 0, 1이므로 제외하고 생각한다.

### 풀이 

수열의 원소 중 작은 수부터 볼 것이다.

1️⃣ 어떤 수 $a$가 수열에 존재하고, $a$보다 작은 수들 내에서 $mex$값이 $a$ 이상이라면, $a$부터 $a^2$까지 수 중 $a$의 배수는 **항상 만들 수 있다고 봐도 상관없다.**

따라서, 등장한 원소들 각각에 대해, 직접 $A_i$부터 $A_i^2$까지의 $A_i$ 배수를 만들 수 있다고 체크해주면 된다. ( => 구현은 boolean 배열로 했다.)

이후, 체크한 배열을 돌며 만들 수 없는 가장 작은 수를 찾아내면 된다.


### 1️⃣ 의 증명

만약 $a$부터 $a^2$까지 수 중 만들 수 없는 $a$의 배수가 있다고 가정하고, 그 수를 $a \times b$라고 하자.
$b < a$이기 때문에, $b$가 없어서 생기는 곱의 부재는 이미 $a \times b$까지 오기 전에 걸러지기 때문이다.

### 예시

수열 $A = {0, 1, 2, 3, 5, 6}$이라고 가정하자.
원소 $6$에 대해, 그 전까지의 수들만을 이용해 $mex$를 $6$이상으로 만들 수 있다.
$6$부터 $36$까지의 $6$의 배수들을 모두 만들 수 있다고 가정했지만, 실제로는 $6 \times 4 = 24$를 만들 수 없다.
하지만, $mex$값으로 $24$가 가능한지 확인하기 전에, 이미 $4$의 부재로 $mex$는 $16$을 만들 수 없게 된다.

### 시간복잡도

이 문제에서 중복 값을 가지는 원소가 있다면, 굳이 여러 번 수행할 필요 없이 중복을 제거해도 상관없다.

각 원소 $A_i$에 대해, 체크 작업의 연산량은 $\dfrac{2\,000\,000}{A_i}$이다.
따라서 시간 복잡도는 원소의 최댓값을 $X$라 할 때, $O(\frac{X}{2} + \frac{X}{3} + \cdots + \frac{X}{X})$이다.
$\Rightarrow$   $O(X\log{X})$이다.  (조화수열의 합 $\frac{1}{1} + \frac{1}{2} + \cdots + \frac{1}{X} = O(\log{X})$이기 때문)

## ⏳ 회고
진짜 수학 너무 어렵다