### PR TITLE
[20250310] BOJ / P3 / 소가 길을 건너간 이유 10 / 권혁준

### DIFF
--- a/khj20006/202503/10 BOJ P3 소가 길을 건너간 이유 10.md
+++ b/khj20006/202503/10 BOJ P3 소가 길을 건너간 이유 10.md
@@ -1,0 +1,106 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class SegTree{
+	long[] tree;
+	SegTree(int size){
+		tree = new long[size*4];
+	}
+	void upt(int s, int e, int i, int v, int n) {
+		if(s == e) {
+			tree[n] = v;
+			return;
+		}
+		int m=(s+e)>>1;
+		if(i <= m) upt(s,m,i,v,n*2);
+		else upt(m+1,e,i,v,n*2+1);
+		tree[n] = tree[n*2] + tree[n*2+1];
+	}
+	long find(int s, int e, int l, int r, int n) {
+		if(l>r || l>e || r<s) return 0;
+		if(l<=s && e<=r) return tree[n];
+		int m=(s+e)>>1;
+		return find(s,m,l,r,n*2) + find(m+1,e,l,r,n*2+1);
+	}
+}
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+
+	static int N;
+	static int[] A, B, P, Q;
+	static SegTree seg;
+	
+	public static void main(String[] args) throws Exception {
+			
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = Integer.parseInt(br.readLine());
+		A = new int[N+1];
+		B = new int[N+1];
+		
+		for(int i=1;i<=N;i++) A[i] = Integer.parseInt(br.readLine());
+		for(int i=1;i<=N;i++) B[i] = Integer.parseInt(br.readLine());
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		long ans = Math.min(result(A,B), result(B,A));
+		
+		bw.write(ans + "\n");
+		
+	}
+	
+	static long result(int[] a, int[] b) {
+		
+		P = new int[N+1];
+		Q = new int[N+1];
+		for(int i=1;i<=N;i++) {
+			int x = a[i];
+			P[x] = i;
+		}
+		
+		seg = new SegTree(N+1);
+		long res = 0;
+		
+		for(int i=1;i<=N;i++) {
+			int x = b[i];
+			Q[i] = P[x];
+			res += seg.find(1, N, P[x], N, 1);
+			seg.upt(1, N, P[x], 1, 1);
+		}
+		
+		long ans = res;
+		for(int i=N;i>=1;i--) {
+			res = (res - (N-Q[i]) + Q[i]-1);
+			ans = Math.min(ans, res);
+		}
+		
+		return ans;
+		
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14458

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
농장에 일자형 길이 있고, 양쪽에 목초지가 N개씩 있다.
i번 목초지에는 i번 소만 방목할 수 있다.
양쪽 목초지 번호의 순서가 주어진다.
각 종별 소가 건너는 길이 서로 겹칠 수 있는데,
한 쪽 목초지에서 맨 뒤에 있는 k개의 목초지를 맨 앞으로 옮겨서 서로 겹치는 쌍의 수를 최소화하자.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- 세그먼트 트리
---
- 주어진 대로 겹치는 쌍의 수를 세그먼트 트리를 이용해서 빠르게 계산한다.
- 계산한 다음에는 목초지를 한 개 옮겼을 때, 두 개 옮겼을 때, ..., 를 모두 계산하는데, 이건 목초지의 위치만 알아도 계산이 가능하다.
- 위 과정을 양쪽 목초지에서 모두 수행해주면 된다.

## ⏳ 회고
- 과정을 한 쪽에서만 수행해서 틀렸다.