### PR TITLE
[20250310] BOJ / P4 / 감옥 건설 / 권혁준

### DIFF
--- a/khj20006/202503/10 BOJ P4 감옥 건설.md
+++ b/khj20006/202503/10 BOJ P4 감옥 건설.md
@@ -1,0 +1,116 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Point{
+	int x,y,id;
+	Point(int x, int y, int id){
+		this.x = x;
+		this.y = y;
+		this.id = id;
+	}
+	
+	// this -> a -> b CCW
+	// 1 : CCW, 0 : line, 1 : CW
+	int ccw(Point a, Point b) {
+		long res = (long)a.x * b.y + (long)b.x * this.y + (long)this.x * a.y - ((long)b.x * a.y + (long)this.x * b.y + (long)a.x * this.y);
+		if(res == 0) return 0;
+		return res > 0 ? 1 : -1;
+	}
+	boolean isInPolygon(List<Point> A) {
+		if(A.size() < 3) return false;
+		boolean res = true;
+		for(int i=0;i<A.size();i++) {
+			Point cur = A.get(i), next = A.get((i+1)%A.size());
+			res &= this.ccw(cur, next) == 1;
+		}
+		return res;
+	}
+}
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+
+	static int N;
+	static Point prison;
+	static Point[] walls;
+	static boolean[] used;
+	
+	public static void main(String[] args) throws Exception {
+			
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		nextLine();
+		N = nextInt();
+		prison = new Point(nextInt(), nextInt(), -1);
+		walls = new Point[N];
+		used = new boolean[N];
+		for(int i=0;i<N;i++) {
+			nextLine();
+			walls[i] = new Point(nextInt(), nextInt(), -1);
+		}
+		Arrays.sort(walls, (a,b) -> {
+			if(a.x == b.x) return a.y-b.y;
+			return a.x-b.x;
+		});
+		for(int i=0;i<N;i++) walls[i].id = i;
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		int ans = 0;
+		while(canConstructConvexHull()) ans++;
+		bw.write(ans + "\n");
+		
+	}
+	
+	static boolean canConstructConvexHull() throws Exception {
+		
+		List<Point> lower = new ArrayList<>();
+		List<Point> upper = new ArrayList<>();
+		for(int i=0;i<N;i++) if(!used[i]) {
+			while(lower.size() > 1 && walls[i].ccw(lower.get(lower.size()-2), lower.get(lower.size()-1)) <= 0) lower.remove(lower.size()-1);
+			while(upper.size() > 1 && walls[i].ccw(upper.get(upper.size()-2), upper.get(upper.size()-1)) >= 0) upper.remove(upper.size()-1);
+			lower.add(walls[i]);
+			upper.add(walls[i]);
+		}
+		
+		List<Point> convexHull = new ArrayList<>();
+		for(int i=0;i<lower.size();i++) {
+			used[lower.get(i).id] = true;
+			convexHull.add(lower.get(i));
+			
+		}
+		for(int i=upper.size()-2;i>0;i--) {
+			used[upper.get(i).id] = true;
+			convexHull.add(upper.get(i));
+		}
+		
+		
+		return prison.isInPolygon(convexHull);
+		
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2254

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
2차원 좌표평면 세상에 점 (Px, Py)에 감옥이 있고 담 기둥이 N개 있다.
이 기둥들을 이어서 다각형 모양의 담을 만들 수 있다.
담은 여러 개 만들 수 있지만, 각각의 담은 감옥을 완전히 감싸야 하고, 담 안에 또 다른 담이 있다면 이를 완전히 포함해야 한다.

겹치지 않게 만들 수 있는 최대 담의 겹 수를 구해보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- 볼록 껍질
- 볼록 다각형 내부의 점 판정
---
의식의 흐름대로, **볼록 껍질**을 밖에서부터 만들 수 있을 만큼 만든 게 답이라 생각했다.
과정은 다음과 같다.
1. 남아있는 담 기둥들로 **볼록 껍질**을 만든다.
2. 감옥이 **볼록 껍질** 내에 포함되는지 확인한다.
3. 포함된다면, 사용한 담 기둥들을 제거하고 1로 돌아간다.

이렇게 해서 만들었던 **볼록 껍질의 개수**가 답이 된다.

## ⏳ 회고
감옥이 볼록 껍질 내에 포함되는지 확인할 때 CCW를 사용했는데, 방향 판정을 반대로 해놓고 뭐가 틀렸나 한참을 고민했다.