### PR TITLE
[20250310] BOJ / P4 / 교차 집합 크기 합 / 권혁준

### DIFF
--- a/khj20006/202503/10 BOJ P4 교차 집합 크기 합.md
+++ b/khj20006/202503/10 BOJ P4 교차 집합 크기 합.md
@@ -1,0 +1,90 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+
+	static long[] C = new long[1000001];
+	static long[] ans;
+	static List<Integer> A = new ArrayList<>();
+	static int N;
+	static long[] F = new long[1000001];
+	
+	static final long mod = 998244353;
+	
+	public static void main(String[] args) throws Exception {
+			
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		
+		N = Integer.parseInt(br.readLine());
+		for(int p=0;p<N;p++) {
+			nextLine();
+			for(int i=nextInt();i-->0;) A.add(nextInt());
+		}
+		Collections.sort(A);
+		for(int i=0;i<A.size();) {
+			int cnt = 0, a = A.get(i);
+			while(i<A.size() && A.get(i).equals(a)) {
+				cnt++;
+				i++;
+			}
+			C[cnt]++;
+		}
+		
+		ans = new long[N+1];
+
+		F[0] = 1;
+		for(int i=1;i<=N;i++) F[i] = (F[i-1] * i) % mod;
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		for(int i=1;i<=N;i++) if(C[i] > 0) {
+			for(int k=1;k<=i;k++) {
+				ans[k] = (ans[k] + C[i] * comb(i, k)) % mod;
+			}			
+		}
+		
+		for(int i=1;i<=N;i++) bw.write(ans[i] + "\n");
+		
+	}
+	
+	static long comb(int n, int k) {
+		return F[n] * power(F[k],mod-2) % mod * power(F[n-k],mod-2) % mod;
+	}
+	
+	static long power(long n, long m) {
+		if(m == 0) return 1;
+		if(m == 1) return n;
+		long p = power(n,m>>1) % mod;
+		p = (p*p) % mod;
+		if(m%2 == 0) return p;
+		return p*n%mod;
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/30806

## 🧭 풀이 시간
80분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
N개의 집합 $S_1, S_2, \cdots, S_N$이 주어진다.
이 집합들 중 $k$개를 골라, 고른 집합들의 교집합을 생각해보자. $a_k$는 집합을 고르는 가능한 모든 선택 방법에 대해 교집합의 크기를 더한 값이다.

모든 $k = 1, 2, \cdots, N$에 대해, $a_k$를 $998\,244\,353 (=119 \times 2^{23} +1)$로 나눈 나머지를 구해보자.
$(998\,244\,353)$은 소수이다.

## 🔍 풀이 방법
[사용한 알고리즘]
- 조합론
---
각 원소 $i$가 등장한 횟수를 $cnt[i]$라고 하면, 각 $k$에 대해 $a_k$에 $C(cnt[i], k)$만큼 더해지는 것을 알 수 있다.

모든 원소에 대해 저 값을 구해서 $a_k$를 관리하면 된다.

구하는 데 걸리는 시간 복잡도는 원소의 등장 횟수에 비례하는데, 결국 $O(\sum(|S|))$정도이기 때문이다.

## ⏳ 회고
식은 10분만에 도출했는데 시간복잡도가 당연히 $O(N^2)$일 거라 생각하고 고민만 하다가 끝났다.
풀이를 보고 생각해보니, 각 **원소가 등장한 횟수**에 포커스를 맞췄으면 금방 해결했을 것 같은데 아쉽다.
더 집중해야 할 듯