### PR TITLE
[20250311] BOJ / P3 / 채석장 게임 / 권혁준

### DIFF
--- a/khj20006/202503/11 BOJ P3 채석장 게임.md
+++ b/khj20006/202503/11 BOJ P3 채석장 게임.md
@@ -1,0 +1,66 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+
+	static int N;
+	static long[] X, M;
+	
+	static long f(long x) {
+		if(x%4 == 0) return x;
+		if(x%4 == 1) return 1;
+		if(x%4 == 2) return x+1;
+		return 0;
+	}
+	
+	public static void main(String[] args) throws Exception {
+			
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = Integer.parseInt(br.readLine());
+		X = new long[N];
+		M = new long[N];
+		for(int i=0;i<N;i++) {
+			nextLine();
+			X[i] = nextLong();
+			M[i] = nextLong();
+		}
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		long res = 0;
+		for(int i=0;i<N;i++) {
+			long x = X[i], m = M[i];
+			res ^= f(x-1) ^ f(x+m-1);
+		}
+		bw.write(res==0 ? "cubelover" : "koosaga");
+		
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16899

## 🧭 풀이 시간
10분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
구사과와 큐브러버는 N개의 채석장을 가지고 있다.
i번째 채석장에는 덤프 트럭이 M[i]개 주차되어 있고, 각 덤프 트럭에는 X[i], X[i]+1, ..., X[i] + M[i] - 1개의 돌이 담겨 있다.

두 사람이 턴을 번갈아 가며 게임을 진행하고, 구사과가 선공이다.
각 사람은 자신의 턴에 덤프 트럭을 하나 고르고 그 트럭에서 돌을 1개 이상 제거한다.
더 이상 돌을 제거할 수 없는 사람이 게임을 지게 된다.

둘 다 최선을 다할 때, 누가 이기는지 구해보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- 스프라그-그런디 정리
---
문제를 Nim game으로 환원시킬 수 있다.
=> 돌 더미가 총 $\sum(M)$개 만큼 있고, 돌이 각각 X[1], X[1] + 1, ..., X[1] + M[1] - 1, X[2], X[2] + 1, ..., X[2] + M[2] - 1, $\cdots$, X[N], X[N] + 1, ..., X[N] + M[N] - 1개 존재하는 Nim Game과 동일하다.

제거할 수 있는 돌의 개수는 1 이상이므로, 돌의 개수를 x라고 할 때 x의 그런디 수는 g[x] = x이다.
전체 게임의 결과는 모든 돌 더미에 대한 그런디 수의 xor값에 따라 좌우되므로, i번째 채석장에 대한 그런디 수를 빠르게 구할 수 있다면 문제를 해결할 수 있다.

결국 X[i] xor (X[i]+1) xor ... xor (X[i]+M[i]-1) 를 빠르게 구하는 게 목표가 된다.
f(x) = 1부터 x까지 모두 xor한 값이라고 정의하면, f는 매우 간단하게 구할 수 있다.
1. x를 4로 나눈 나머지가 0이면 f(x) = x
2. x를 4로 나눈 나머지가 1이면 f(x) = 1
3. x를 4로 나눈 나머지가 2이면 f(x) = x+1
4. x를 4로 나눈 나머지가 3이면 f(x) = 0

이제 f를 이용해서 모든 채석장의 그런디 수를 xor하고, 그 값이 0인지 아닌지 확인하면 된다.

## ⏳ 회고
...