### PR TITLE
[20250311] BOJ / P5 / 등산 마니아 / 권혁준

### DIFF
--- a/khj20006/202503/11 BOJ P5 등산 마니아.md
+++ b/khj20006/202503/11 BOJ P5 등산 마니아.md
@@ -1,0 +1,79 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static int N;
+	static List<Integer>[] V;
+	static long[] S;
+	static long ans = 0;
+	
+	public static void main(String[] args) throws Exception {
+			
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = Integer.parseInt(br.readLine());
+		V = new List[N+1];
+		S = new long[N+1];
+		for(int i=1;i<=N;i++) V[i] = new ArrayList<>();
+		for(int i=1;i<N;i++) {
+			nextLine();
+			int a = nextInt(), b = nextInt();
+			V[a].add(b);
+			V[b].add(a);
+		}
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		dfs(1,0,0);
+		bw.write(ans + "\n");
+		
+	}
+	
+	static void dfs(int n, int p, long d) {
+		S[n] = 1;
+		
+		for(int i:V[n]) if(i != p) {
+			dfs(i,n,d+1);
+			S[n] += S[i];
+			ans += S[i] * (N-S[i]);
+		}
+		
+		long temp = 0;
+		for(int i:V[n]) if(i != p) {
+			
+			temp += S[i] * (S[n]-S[i]-1); 
+			
+		}
+		temp = temp/2 + S[n]-1;
+		ans += temp * d;
+		
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/20188

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
N개의 오두막과 N-1개의 오솔길이 트리 모양으로 등산로를 이루고 있다.
산 정상에는 1번 오두막이 있고, 한 오두막에서 다른 오두막으로 갈 때는 항상 **산 정상을 거치는 가장 짧은 길**로 간다.
이 때 길의 다양성은 길에 포함된 오솔길의 개수다. (거리를 구하는 게 아님!! 지나온 길의 개수를 구하는거)

가능한 모든 조합(a,b)에 대해, a번 오두막에서 b번 오두막으로 가는 길의 다양성의 총 합을 구해보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- 트리 DP
---
산 정상을 찍지 않고 최단 거리로만 간다고 가정을 하면, 간단한 식으로 해결할 수 있다.
n을 루트로 하는 서브트리의 크기를 sub[n]이라 할 때, 답은 $sub[n] \times (N - sub[n])$이다.

이 값에 **산 정상을 거치는 경우**를 더해서 답을 구할 수 있다.
1~n까지의 경로가 겹치게 되는 경우의 수는, n의 자식들 i에 대해, $sub[n] - 1 + \sum {sub[i] * (sub[n] - sub[i] - 1)}$이다.
여기에 경로의 길이를 곱해주면 된다.

## ⏳ 회고
쉬워보였는데 식 찾기가 생각보다 너무 힘들었다.