### PR TITLE
[20250311] BOJ / P3 / 빵 정렬 / 권혁준

### DIFF
--- a/khj20006/202503/11 BOJ P3 빵 정렬.md
+++ b/khj20006/202503/11 BOJ P3 빵 정렬.md
@@ -1,0 +1,102 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class SegTree{
+	int[] tree;
+	SegTree(int size){
+		tree = new int[size*4 + 1];
+	}
+	void upt(int s, int e, int i, int n) {
+		if(s == e) {
+			tree[n]++;
+			return;
+		}
+		int m=(s+e)>>1;
+		if(i<=m) upt(s,m,i,n*2);
+		else upt(m+1,e,i,n*2+1);
+		tree[n] = tree[n*2] + tree[n*2+1];
+	}
+	int find(int s, int e, int l, int r, int n) {
+		if(l>r || l>e || r<s) return 0;
+		if(l<=s && e<=r) return tree[n];
+		int m=(s+e)>>1;
+		return find(s,m,l,r,n*2) + find(m+1,e,l,r,n*2+1);
+	}
+}
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static int N;
+	static int[] A, pos;
+	static boolean[] vis;
+	static SegTree seg;
+	
+	public static void main(String[] args) throws Exception {
+			
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = Integer.parseInt(br.readLine());
+		A = new int[N+1];
+		pos = new int[N+1];
+		vis = new boolean[N+1];
+		seg = new SegTree(N);
+		
+		nextLine();
+		for(int i=1;i<=N;i++) {
+			int a = nextInt();
+			A[i] = a;
+			pos[a] = i;
+		}
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		int s = 1, e = 2;
+		nextLine();
+		for(int i=1;i<=N-2;i++) {
+			int b = nextInt();
+			int p = pos[b] - seg.find(1, N, 1, pos[b], 1);
+			vis[b] = true;
+			while(vis[A[s]]) s++;
+			while(vis[A[e]] || s >= e) e++;
+			seg.upt(1, N, pos[b], 1);
+			if(p%2 != 0) continue;
+			int temp = pos[A[s]];
+			pos[A[s]] = pos[A[e]];
+			pos[A[e]] = temp;
+			temp = A[s];
+			A[s] = A[e];
+			A[e] = temp;
+		}
+		
+		int p = nextInt(), q = nextInt();
+		if(p == A[s] && q == A[e]) bw.write("Possible");
+		else bw.write("Impossible");
+		
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/5000

## 🧭 풀이 시간
27분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
수열 A를 수열 B로 만들려고 한다.
사용할 수 있는 연산은, 어떤 연속된 세 원소 a, b, c를 골라, 순서를 c, a, b로 바꾼다.

연산을 이용해서 A를 B로 만들 수 있는지 알아보자.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- 세그먼트 트리
---
A를 B로 만들건데, B의 첫 수부터 맞춰주는 방식으로 접근했다.
B의 첫 수 B[1]에 대해, A에서의 B[1]의 위치가 홀수 번째라면, A에서 B[1]만 골라내서 그대로 맨 앞으로 가져올 수 있다.
(연산을 반복 적용하면 됨.)

그렇게 수가 두 개 남을때까지 위 과정을 반복한다.

이 때, A에서의 B[i]의 위치를 구하기 위해 세그먼트 트리를 사용해서, 이미 처리한 수들을 중복해서 세지 않도록 구현했다.

## ⏳ 회고
어렵다 매우