### PR TITLE
[20250312] BOJ / G3 / 소수의 연속합 / 김수연

### DIFF
--- a/suyeun84/202503/12 BOJ G3 소수의 연속합.md
+++ b/suyeun84/202503/12 BOJ G3 소수의 연속합.md
@@ -1,0 +1,55 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class boj1644 {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    
+	static int N;
+	static boolean[] isPrime;
+	static boolean flag = false;
+	public static void main(String[] args) throws Exception {
+		N = Integer.parseInt(br.readLine());
+		int start = 2, end = 3, res = 5, answer = 0;
+		isPrime = new boolean[N+1];
+		primeCheck();
+		if (N == 5) answer = 1;
+		if (isPrime[N]) answer++;
+		while (start < end) {
+			if (res < N) {
+				end = nextIdx(end);
+				res += end;
+			} else if (res >= N) {
+				res -= start;
+				start = nextIdx(start);
+			}
+			if (res == N && start != end) {
+				answer++;
+			}
+			if (flag) break;
+		}
+		System.out.println(answer);
+
+	}
+	static void primeCheck() {
+		Arrays.fill(isPrime, true);
+		isPrime[0] = false;
+		isPrime[1] = false;
+		for (int i = 2; i <= Math.sqrt(N+1); i++) {
+			if(isPrime[i]) {
+				for (int j = i*i; j <= N; j+=i) {
+					isPrime[j] = false;
+				}
+			}
+		}
+	}
+	
+	static int nextIdx(int idx) {
+		for (int i = idx+1; i <= N; i++) {
+			if (isPrime[i]) return i;
+		}
+		flag = true;
+		return idx;
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1644
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
연속된 소수의 합으로 N을 나타낼 수 있는 경우의 수 구하기
## 🔍 풀이 방법
1~N까지 isPrime배열을 생성해서 에라토스테네스의 체를 이용해서 소수여부를 미리 저장해둔다.
이후, 투포인터를 이용해서 더해줄 소수의 범위를 조절해줬다.
## ⏳ 회고
예외처리를 조금 더 신경써야겠다.