### PR TITLE
[20250312] BOJ / P2 / 홍준이와 울타리 / 권혁준

### DIFF
--- a/khj20006/202503/12 BOJ P2 홍준이와 울타리.md
+++ b/khj20006/202503/12 BOJ P2 홍준이와 울타리.md
@@ -1,0 +1,101 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static int N, X;
+	static int[] A, B, C;
+	
+	public static void main(String[] args) throws Exception {
+			
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		nextLine();
+		N = nextInt();
+		X = nextInt()-1;
+		
+		A = new int[N+1];
+		
+		nextLine();
+		for(int i=1;i<=N;i++) A[i] = nextInt();
+
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		fillB();
+		fillC();
+		
+		
+		long ans1 = 0;
+		for(int i=1;i<=N;i++) ans1 += A[i] - C[i];
+		
+		long ans2 = 0;
+		for(int i=1;i<=N;) {
+			int a = C[i], cnt = 0;
+			while(i<=N && C[i] == a) {
+				i++;
+				cnt++;
+			}
+			ans2 += (cnt - 1) / (X+1) + 1;
+		}
+		
+		bw.write(ans1 + "\n" + ans2);
+		
+	}
+	
+	static void fillB() {
+		
+		Deque<int[]> D = new ArrayDeque<>();
+		
+		B = new int[N+1];
+		for(int i=N;i>=1;i--) {
+			while(!D.isEmpty() && D.peekLast()[0] >= A[i]) D.pollLast();
+			D.offerLast(new int[] {A[i], i});
+			while(!D.isEmpty() && D.peekFirst()[1] - i > X) D.pollFirst();
+			if(B[i] <= N-X) B[i] = D.peekFirst()[0];
+		}
+		for(int i=N-X+1;i<=N;i++) B[i] = B[i-1];
+		
+	}
+	
+	static void fillC() {
+		
+		Deque<int[]> D = new ArrayDeque<>();
+		
+		C = new int[N+1];
+		for(int i=1;i<=N;i++) {
+			while(!D.isEmpty() && D.peekLast()[0] <= B[i]) D.pollLast();
+			D.offerLast(new int[] {B[i], i});
+			while(!D.isEmpty() && i - D.peekFirst()[1] > X) D.pollFirst();
+			C[i] = D.peekFirst()[0];
+		}
+		
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2905

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
각각 너비가 1 cm, 높이가 A[i] cm인 널빤지가 N개 주어지고, 이 널빤지들을 주어진 순서대로 이어 붙인 울타리를 색칠하려 한다.
롤러의 폭은 X cm이고, 롤러를 이용해 색칠할 때, 롤러의 모든 부분이 널빤지를 벗어나지 않게 해야 한다.
즉, 연속된 X개의 널빤지를 골라 중 가장 높이가 낮은 널빤지를 모두 색칠될 때까지 롤러를 굴리는 것을 1회 색칠했다고 표현한다.

이런 방식으로는, 항상 널빤지의 모든 부분을 색칠할 수는 없다.
롤러를 이용해서 색칠할 수 없는 널빤지의 최소 넓이와, 그 때의 최소 롤러질 횟수를 구해보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- 덱
---
먼저, 롤러의 왼쪽 끝부분이 i번째 널빤지에 위치하도록 롤러질을 했을 때의 최소 널빤지 높이를 B[i]라고 정의한다.
식으로 나타내면, $B[i] = \min(A[i], A[i+1], \cdots, A[i+X-1])$ 이다.
주의할 점은, 롤러가 널빤지 경계를 벗어나면 안되기 때문에 B[N-X+2]부터 B[N]까지는 모두 B[N-X+1]이라는 것이다.

그 다음, 롤러질을 통해 i번째 칸에 칠할 수 있는 최대 넓이를 C[i]라고 정의한다.
i번째 칸에 영향을 미치는 롤러질은 B[i-X+1]부터 B[i]까지이기 때문에,
C[i]는 $B[i-X+1], B[i-X+2], ..., B[i]$ 중에서의 최댓값이 된다.
식으로 나타내면, $C[i] = \max(B[i-X+1], B[i-X+2], \cdots, B[i])$ 이다.

B와 C는 모두 **덱**을 monotone하게 관리하는 기법을 이용해서 O(N)에 구할 수 있다.
( => 참고 문제 : https://www.acmicpc.net/problem/11003 )

## ⏳ 회고
처음엔 세그먼트 트리로 짜다가, 식 형태가 덱으로도 충분히 구할 수 있어보여서 중간에 갈아엎고 다시 짰다.