### PR TITLE
[20250312] BOJ / P5 / 순환 순열 / 신희을

### DIFF
--- a/ShinHeeEul/202503/12 BOJ 순환 순열.md
+++ b/ShinHeeEul/202503/12 BOJ 순환 순열.md
@@ -1,0 +1,64 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	
+	
+	static int[] failure;
+	static int count = 0;
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        
+        
+        String a = br.readLine();
+        a += a.substring(0, a.length() - 1);
+        String b = br.readLine();
+        
+        char[] ac = a.toCharArray();
+        char[] bc = b.toCharArray();
+        
+        failure = new int[ac.length];
+        
+        failureFunction(bc);
+        kmp(ac, bc);
+        System.out.println(count);
+    }
+    
+    public static void failureFunction(char[] s) {
+    	int p = 0;
+    	
+    	for(int idx = 1; idx < s.length; idx++) {
+    		
+    		while(p != 0  && s[idx] != s[p]) {
+    			p = failure[p - 1];
+    		}
+    		
+    		if(s[idx] == s[p]) {
+    			p++;
+    			failure[idx] = p;
+    		}
+    	}
+    	
+    }
+    
+    public static void kmp(char[] s1, char[] s2) {
+    	
+    	int p = 0;
+    	
+    	for(int idx = 0; idx < s1.length; idx++) {
+    		
+    		while(p != 0 && s1[idx] != s2[p]) p = failure[p - 1];
+    		
+    		if(s1[idx] == s2[p]) {
+    			if(p == s2.length - 1) {
+    				count++;
+    				p = failure[p];
+    			} else {
+    				p++;
+    			}
+    		}
+    	}
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/12104

## 🧭 풀이 시간
30 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
두 바이너리 문자열 A와 B가 주어졌을 때, A와 XOR 했을 때, 0이 나오는 B의 순환 순열의 개수를 구하는 프로그램을 작성하시오.

순환 순열이란 순열 P = P0, P1, ..., PN-1이 있을 때, 왼쪽으로 k번 순환 이동시킨 순열이다. 즉, P를 k번 순환 이동 시키면, $P_i$ -> $P_{i + k mod n}$ 이 된다.

첫째 줄에 A와 XOR했을 때, 0이 나오는 B의 순환 순열의 개수를 출력한다.

## 🔍 풀이 방법
A를 두 배로 늘려주고 마지막만 빼준다. 예를 들어 A가 101이라면 10110으로 만들어준다.
그리고 A와 B의 kmp를 구해 겹치는 만큼 세준다.

## ⏳ 회고
kmp 기본 문제다. 이제 슬슬 응용 문제도 연습해야지