### PR TITLE
[20250312] BOJ / P4 / 이항 계수 5 / 권혁준

### DIFF
--- a/khj20006/202503/12 BOJ P4 이항 계수 5.md
+++ b/khj20006/202503/12 BOJ P4 이항 계수 5.md
@@ -1,0 +1,72 @@
+```java
+
+import java.util.*;
+import java.io.*;
+import java.math.BigInteger;
+
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static boolean[] sieve;
+	static long N, K, M;
+	static long[] cnt;
+	
+	public static void main(String[] args) throws Exception {
+			
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		nextLine();
+		N = nextLong();
+		K = nextLong();
+		M = nextLong();
+		
+		sieve = new boolean[(int)N+1];
+		cnt = new long[(int)N+1];
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		for(int i=2;i*i<=N;i++) if(!sieve[i]) for(int j=i*i;j<=N;j+=i) sieve[j] = true;
+		
+		for(int i=2;i<=N;i++) if(!sieve[i]) for(long k=i;k<=N;k*=i) cnt[i] += N/k;
+		for(int i=2;i<=N;i++) if(!sieve[i]) for(long k=i;k<=K;k*=i) cnt[i] -= K/k;
+		for(int i=2;i<=N;i++) if(!sieve[i]) for(long k=i;k<=N-K;k*=i) cnt[i] -= (N-K)/k;
+		
+		long ans = 1;
+		for(int i=2;i<=N;i++) ans = (ans * power(i, cnt[i])) % M;
+		bw.write(ans + "\n");
+		
+	}
+	
+	static long power(long x, long y) {
+		if(y == 0) return 1;
+		if(y == 1) return x%M;
+		long h = power(x,y>>1) % M;
+		h = (h*h)%M;
+		if(y%2==0) return h;
+		return h*x%M;
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11439

## 🧭 풀이 시간
10분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
이항 계수 $comb(n, k)$를 $m$으로 나눈 나머지를 구해보자.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- 에라토스테네스의 체
- 분할 정복을 이용한 거듭제곱
---
$comb(n, k)$를 소인수분해 해보자.
$comb(n, k) = \dfrac{n!}{k! (n-k)!}$ 이다.
만약, 어떤 수 $x$에 대해, $x!$을 소인수분해한 결과를 구할 수 있다면? 저것도 구할 수 있다.

### $x!$ 소인수분해 하기
정확히는, 소인수분해라기 보다는, 정수 배열 cnt를 정의해서 `cnt[i] = 소인수 i가 x!에서 곱해진 횟수`를 구할 것이다.
이 때, 소수 i에 대해 $cnt[i] = \dfrac{x}{i} + \dfrac{x}{i\times i} + \dfrac{x}{i \times i \times i} + \cdots $이다. (분수 계산에서 나머지는 버린다.)

---
이제, n!을 소인수분해한 결과를 cnt에 더해주고, k!과 (n-k)!을 소인수분해한 결과를 각각 cnt에서 빼주면 최종 소인수분해 결과가 나오게 된다.
이 배열을 순회하며 **분할 정복을 이용한 거듭제곱**으로 빠르게 결과값을 구해주면 된다.

## ⏳ 회고
어제 풀었던 문제랑 같은 테크닉을 쓴다. (조합의 소인수분해 결과 구하기)
https://www.acmicpc.net/problem/1095