### PR TITLE
[20250313] BOJ / G3 / 줄 세우기 / 신동윤

### DIFF
--- a/03do-new30/202503/13 BOJ G3 줄 세우기.md
+++ b/03do-new30/202503/13 BOJ G3 줄 세우기.md
@@ -1,0 +1,67 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static int N, M;
+    static List<Integer>[] graph;
+    static int[] indegree;
+    public static void main(String[] args) throws IOException {
+        input();
+        getIndegree();
+        List<Integer> order = topologySort();
+        for (int num : order) {
+            System.out.print(num + " ");
+        }
+        System.out.println();
+    }
+
+    static ArrayList<Integer> topologySort() {
+        ArrayList<Integer> orderList = new ArrayList<>(); // 정점의 방문 순서
+        Queue<Integer> q = new ArrayDeque<>();
+        for (int i = 1; i < N+1; i++) {
+            if (indegree[i] == 0) {
+                q.offer(i);
+            }
+        }
+
+        while (!q.isEmpty()) {
+            int node = q.poll();
+            orderList.add(node);
+            for (int next : graph[node]) {
+                if (--indegree[next] == 0) q.offer(next);
+            }
+        }
+        return orderList;
+    }
+
+    static void getIndegree() {
+        indegree = new int[N+1];
+        for (int from = 1; from < N+1; from++) {
+            for (int to : graph[from] ){
+                // 진입 차수 기록
+                indegree[to]++;
+            }
+        }
+    }
+
+    static void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        graph = new List[N+1];
+        for (int i = 1; i < N+1; i++) {
+            graph[i] = new ArrayList<>();
+        }
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            graph[a].add(b);
+        }
+        br.close();
+
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2252

## 🧭 풀이 시간
15분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
- 일부 학생들의 키 비교 결과가 주어졌을 때, 
- 전체 학생들의 키 순서를 출력한다.

## 🔍 풀이 방법
- 주어지는 키 비교 결과를 유향 그래프로 보고 풀이한다.
- 위상 정렬을 이용해야 하므로 그래프를 저장한 뒤 진입 차수를 구해준다.

## ⏳ 회고
- 위상 정렬을 배워서 어렵지 않았다.