### PR TITLE
[20250313] BOJ / P5 / 운전 면허 시험 / 권혁준

### DIFF
--- a/khj20006/202503/13 BOJ P5 운전 면허 시험.md
+++ b/khj20006/202503/13 BOJ P5 운전 면허 시험.md
@@ -1,0 +1,101 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st = new StringTokenizer("");
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() throws Exception {
+		if(!st.hasMoreTokens()) nextLine();
+		return Integer.parseInt(st.nextToken());
+	}
+	static long nextLong() throws Exception {
+		if(!st.hasMoreTokens()) nextLine();
+		return Long.parseLong(st.nextToken());
+	}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static final int INF = 1000111777;
+	
+	static int N, M, L, G;
+	static int[][] right, down;
+	static int[][][][] D;
+	
+	
+	public static void main(String[] args) throws Exception {
+		
+		for(int T=nextInt();T-->0;) {
+			
+			ready();
+			solve();
+		}
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = nextInt();
+		M = nextInt();
+		L = nextInt();
+		G = nextInt();
+		right = new int[N][M];
+		down = new int[N][M];
+		D = new int[N][M][Math.min(N-1, M-1)*2+2][2];
+		
+		for(int i=0;i<N;i++) for(int j=0;j<M-1;j++) right[i][j] = nextInt();
+		for(int i=0;i<N-1;i++) for(int j=0;j<M;j++) down[i][j] = nextInt();
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		dp();
+		int ans = INF;
+		for(int i=0;i<Math.min(N-1, M-1)*2+2;i++) {
+			if(Math.min(D[N-1][M-1][i][0], D[N-1][M-1][i][1]) <= G) {
+				bw.write((L*(N+M-2)+i)+"\n");
+				return;
+			}
+		}
+		bw.write("-1\n");
+		
+	}
+	
+	static void dp() {
+		
+		for(int i=0;i<N;i++) for(int j=0;j<M;j++) for(int k=0;k<Math.min(N-1,M-1)*2+2;k++) Arrays.fill(D[i][j][k], INF);
+		
+		D[0][1][0][0] = right[0][0];
+		D[1][0][0][1] = down[0][0];
+		for(int i=0;i<N;i++) for(int j=0;j<M;j++) for(int k=0;k<Math.min(N-1, M-1)*2+2;k++) {
+			if(i+j <= 1) continue;
+			if(j>0) {
+				D[i][j][k][0] = right[i][j-1];
+				int res = D[i][j-1][k][0];
+				if(k > 0) res = Math.min(res, D[i][j-1][k-1][1]);
+				D[i][j][k][0] += res;
+			}
+			if(i>0) {
+				D[i][j][k][1] = down[i-1][j];
+				int res = D[i-1][j][k][1];
+				if(k > 0) res = Math.min(res, D[i-1][j][k-1][0]);
+				D[i][j][k][1] += res;
+			}
+		}
+		
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/10251

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
M행 N열 격자 그리드 모양의 운전 면허 시험장에 세 가지 시험 규칙이 존재한다.
1. 응시자는 가장 왼쪽 위 지점에서 시작해서 →, ↓ 방향으로만 차를 몰아 가장 오른쪽 아래 지점에 도착해야 한다.
2. 차를 모는 시간은 격자 한 칸당 L이고, 방향을 바꾸는 데 걸리는 시간은 1이다.
3. 시험 시작 전에 연료를 G만큼 주입한다. 응시자는 G 이하의 연료를 사용하여 가장 빠른 시간 내에 도착 지점으로 도착해야 한다.
최단 시간을 구해보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- DP
---
오른쪽, 아래로만 이동할 수 있기 때문에, 걸리는 시간은 무조건 `(L * (N+M-2)) + (방향 전환 횟수)`이다.

dp[x][y][n]를 (x,y)까지 방향 전환 n회로 도달하는 경우 중 연료 소모량의 최솟값으로 정의해서, dp[N][M][n] <= G인 n의 최솟값을 찾아주면 문제를 해결할 수 있다.

## ⏳ 회고
다익스트라로 풀었다가 시간 초과 맞고, 굳이 다익스트라가 필요없다는 걸 깨달았다.