### PR TITLE
[20250314] BOJ / P5 / 트리와 경로 개수 쿼리 / 권혁준

### DIFF
--- a/khj20006/202503/14 BOJ P5 트리와 경로 개수 쿼리.md
+++ b/khj20006/202503/14 BOJ P5 트리와 경로 개수 쿼리.md
@@ -1,0 +1,93 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st = new StringTokenizer("");
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() throws Exception {
+		if(!st.hasMoreTokens()) nextLine();
+		return Integer.parseInt(st.nextToken());
+	}
+	static long nextLong() throws Exception {
+		if(!st.hasMoreTokens()) nextLine();
+		return Long.parseLong(st.nextToken());
+	}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static int N;
+	static int[] A;
+	static long[] R, B, ans;
+	static List<Integer>[] V;
+	static long blue = 0, red = 0;
+	
+	public static void main(String[] args) throws Exception {
+			
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = nextInt();
+		A = new int[N+1];
+		for(int i=1;i<=N;i++) {
+			A[i] = nextInt();
+			red += A[i] == 1 ? 1 : 0;
+			blue += A[i] == 0 ? 1 : 0;
+		}
+		V = new List[N+1];
+		for(int i=1;i<=N;i++) V[i] = new ArrayList<>();
+		
+		for(int i=1;i<N;i++) {
+			int a = nextInt(), b = nextInt();
+			V[a].add(b);
+			V[b].add(a);
+		}
+		
+		R = new long[N+1];
+		B = new long[N+1];
+		ans = new long[N+1];
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		dfs(1, 0);
+		for(int Q=nextInt();Q-->0;) {
+			int x = nextInt();
+			bw.write(ans[x] + "\n");
+		}
+		
+	}
+	
+	static void dfs(int n, int p) {
+		
+		for(int i:V[n]) if(i != p) {
+			dfs(i, n);
+			R[n] += R[i] + (A[i] == 1 ? 1 : 0);
+			B[n] += B[i] + (A[i] == 0 ? 1 : 0);
+		}
+		ans[n] += R[n] * (blue - (B[n] + (A[n] == 0 ? 1 : 0)));
+		ans[n] += B[n] * (red - (R[n] + (A[n] == 1 ? 1 : 0)));
+		for(int i:V[n]) if(i != p) {
+			ans[n] += (R[i] + (A[i] == 1 ? 1 : 0)) * (B[n] - (B[i] + (A[i] == 0 ? 1 : 0)));
+		}
+		
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/25638

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
정점이 N개인 트리가 주어지고, 각 정점은 빨강 혹은 파랑으로 색칠되어 있다.
쿼리를 Q개 처리해보자.
각 쿼리는 정수 $u$ 하나로 이루어지며, 다음을 구해야 한다.
- 임의의 빨간색 정점과 파란색 정점을 연결하는 단순 경로 중에서 $u$번 정점을 경유하는 경로의 개수를 출력한다. 단, $u$가 경로의 시작, 끝점이면 안 된다.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- Rerooting
---
우선, 트리의 루트를 1로 잡고, $T_n$을 n을 루트로 하는 서브트리라고 가정한다.
$R_n$과 $B_n$을 각각 $T_n$에 존재하는 빨강, 파랑 정점의 수로 정의한다.

쿼리 $u$에 대한 답이 될 수 있는 경로 중, 시작점과 끝점을 고르는 경우를 살펴보면 크게 세 가지 경우로 나눌 수 있다.
1. $T_n$에서 **n을 제외한** 빨간 점, $T_n$에 속하지 않은 파란 점
2. $T_n$에서 **n을 제외한** 파란 점, $T_n$에 속하지 않은 빨간 점
3. n의 자식들을 차례대로 $x_1, x_2, \cdots, x_k$라고 할 때, $T_x$에 속한 빨간 점, $T_x$에 속하지 않고 $T_n$에 속한 **n을 제외한** 파란 점

DFS 한 번으로 위 세 가지 값들을 모두 구해서 더한 값을 각각 $answer_n$에 저장한다.

## ⏳ 회고
...