### PR TITLE
[20250314] BOJ / P5 / 크리스마스 트리 꾸미기 / 권혁준

### DIFF
--- a/khj20006/202503/14 BOJ P5 크리스마스 트리 꾸미기.md
+++ b/khj20006/202503/14 BOJ P5 크리스마스 트리 꾸미기.md
@@ -1,0 +1,74 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st = new StringTokenizer("");
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() throws Exception {
+		if(!st.hasMoreTokens()) nextLine();
+		return Integer.parseInt(st.nextToken());
+	}
+	static long nextLong() throws Exception {
+		if(!st.hasMoreTokens()) nextLine();
+		return Long.parseLong(st.nextToken());
+	}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static int N, L;
+	static long[][] dp, sum;
+	static final long mod = 100030001L;
+	
+	public static void main(String[] args) throws Exception {
+			
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = nextInt();
+		L = nextInt();
+		dp = new long[N+1][N+1];
+		sum = new long[N+1][N+1];
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		if(L > N) {
+			bw.write("0");
+			return;
+		}
+		dp[0][0] = 1;
+		for(int i=0;i<=L;i++) sum[0][i] = 1;
+		for(int h=1;h<=L;h++) for(int n=1;n<=N;n++) {
+			
+			for(int k=0;k<n;k++) {
+				dp[n][h] += sum[k][h-1] * dp[n-1-k][h-1];
+				dp[n][h] += dp[k][h-1] * sum[n-1-k][h-1];
+				dp[n][h] -= dp[k][h-1] * dp[n-1-k][h-1];
+				dp[n][h] = (dp[n][h] + mod) % mod;
+			}
+			
+			sum[n][h] = (sum[n][h-1] + dp[n][h]) % mod;
+		}
+		bw.write(dp[N][L] + "\n");
+		
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16468

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N개의 정점으로 높이가 정확히 L인 **이진 트리**를 만들 수 있는 경우의 수를 구해보자.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- DP
- 누적 합
---
$dp[n][h]$를 정점 $n$개로 높이 $h$의 트리를 만드는 경우의 수라고 정의한다.

정점 하나를 루트로 잡고, 나머지 n-1개의 정점으로 왼쪽, 오른쪽 서브트리를 구성할 수 있다.

그러면, $dp[n][h] = dp[k][i] \times dp[n-1-k][h-1] + dp[k][h-1] \times dp[n-1-k][i] - dp[k][h-1] \times dp[n-1-k][h-1]$와 같이 쓸 수 있다. $(0 \le k < n ; 0 \le i < h)$

이를 그대로 구현하면 $O(N^2L^2)$으로 시간 초과일테고, 누적 합으로 $O(N^2L)$로 줄여 해결한다.

## ⏳ 회고
누적 합 구현이 생각보다 잘 안 돼서 힘들었다.