### PR TITLE
[20250314] BOJ / P5 / Random Generator / 권혁준

### DIFF
--- a/khj20006/202503/14 BOJ P5 Random Generator.md
+++ b/khj20006/202503/14 BOJ P5 Random Generator.md
@@ -1,0 +1,84 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class SegTree{
+	int[] tree;
+	SegTree(int size){
+		tree = new int[size*4+1];
+	}
+	
+	void upt(int s, int e, int i, int v, int n) {
+		if(s == e) {
+			tree[n] = v;
+			return;
+		}
+		int m=(s+e)>>1;
+		if(i <= m) upt(s, m, i, v, n*2);
+		else upt(m+1, e, i, v, n*2+1);
+		tree[n] = tree[n*2] + tree[n*2+1];
+	}
+	
+	int find(int s, int e, int v, int n) {
+		if(s == e) return s;
+		int m=(s+e)>>1;
+		if(v <= tree[n*2]) return find(s, m, v, n*2);
+		return find(m+1, e, v-tree[n*2], n*2+1);
+	}
+}
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st = new StringTokenizer("");
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() throws Exception {
+		if(!st.hasMoreTokens()) nextLine();
+		return Integer.parseInt(st.nextToken());
+	}
+	static long nextLong() throws Exception {
+		if(!st.hasMoreTokens()) nextLine();
+		return Long.parseLong(st.nextToken());
+	}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static int N;
+	static SegTree seg;
+	
+	public static void main(String[] args) throws Exception {
+			
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = nextInt();
+		seg = new SegTree(N);
+		for(int i=1;i<=N;i++) seg.upt(1, N, i, nextInt(), 1);
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		for(int i=1;i<=N;i++) {
+			int p = nextInt();
+			int x = seg.find(1, N, p, 1);
+			bw.write(x + " ");
+			seg.upt(1, N, x, 0, 1);
+		}
+		
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/19646

## 🧭 풀이 시간
12분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
1부터 N까지의 양의 정수 i를 각각 w[i]개씩 일렬로 배치한다.
j번째 step에서, p[j]번째의 수를 순열에 추가한다.
각 step이 끝나면, 방금 추가한 수를 순열에서 모두 없앤다.

모든 step이 끝난 후의 순열을 구해보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- 세그먼트 트리
---
문제에서 주어진 그대로 세그먼트 트리로 구현하면 된다.

1. 세그먼트 트리의 i번째 말단 정점에 w[i]를 저장하고, 구간 합을 저장하도록 구성한다.
2. 각 step마다, 1부터 k까지의 구간 합이 p[j]인 곳의 인덱스 k를 구해 출력한다.

## ⏳ 회고
디버깅 용으로 각 step마다 매번 버퍼를 flush해줬는데 시간 초과가 났다.
flush가 많이 무겁나보다