### PR TITLE
[20250314] BOJ / G5 / 난로 / 권혁준

### DIFF
--- a/khj20006/202503/14 BOJ G5 난로.md
+++ b/khj20006/202503/14 BOJ G5 난로.md
@@ -1,0 +1,63 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st = new StringTokenizer("");
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() throws Exception {
+		if(!st.hasMoreTokens()) nextLine();
+		return Integer.parseInt(st.nextToken());
+	}
+	static long nextLong() throws Exception {
+		if(!st.hasMoreTokens()) nextLine();
+		return Long.parseLong(st.nextToken());
+	}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static int N, K, ans = 0;
+	static PriorityQueue<Integer> Q;
+	
+	public static void main(String[] args) throws Exception {
+			
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = nextInt();
+		K = nextInt();
+		Q = new PriorityQueue<>();
+		int prev = nextInt(), now = 0;
+		
+		for(int i=1;i<N;i++) {
+			now = nextInt();
+			Q.offer(now-prev-1);
+			prev = now;
+		}
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		ans = N;
+		for(int i=N;i>K;i--) ans += Q.poll();
+		bw.write(ans + "\n");
+		
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/15553

## 🧭 풀이 시간
12분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
구사과의 방에는 난로가 하나 있고, 방에 친구가 왔을 때는 항상 난로를 켠다.
오늘은 N명의 친구들이 구사과의 집에 방문하는 날이다.
i번째 친구는 구사과의 방에 시간 T[i]에 도착하고, 시간 T[i]+1에 나간다.
처음에 난로는 꺼져있고, 난로를 최대 K번 켤 수 있다.
구사과는 난로가 켜져 있는 시간을 최소로 하려고 한다.

## 🔍 풀이 방법
[사용한 알고리즘]
- 그리디 알고리즘
- 정렬
---
처음에 그냥 난로를 N번 다 켜놓고, 켜는 걸 취소했을 때 발생하는 비용이 적은 순서대로 꺼주면 된다.

## ⏳ 회고
로직을 잘못 짜서 한 번 갈아엎었다...