### PR TITLE
[20250317] BOJ / G5 / 2^3은? / 권혁준

### DIFF
--- a/khj20006/202503/17 BOJ G5 2^3은?.md
+++ b/khj20006/202503/17 BOJ G5 2^3은?.md
@@ -1,0 +1,57 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st = new StringTokenizer("");
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() throws Exception {
+		if(!st.hasMoreTokens()) nextLine();
+		return Integer.parseInt(st.nextToken());
+	}
+	static long nextLong() throws Exception {
+		if(!st.hasMoreTokens()) nextLine();
+		return Long.parseLong(st.nextToken());
+	}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static int T, p, q, r;
+	
+	public static void main(String[] args) throws Exception {
+		
+		T = nextInt();
+		while(T-->0) {
+			
+			ready();
+			solve();
+		}
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		p = nextInt();
+		q = nextInt();
+		r = nextInt();
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		bw.write((Math.min(q, r) + p - 1) + "\n");
+		
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/33614

## 🧭 풀이 시간
15분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
세 양의 정수 p, q, r이 주어진다.
a <= p, b <= q, c <= r을 만족하는 (a,b,c)에 대해, $a \oplus b \oplus c = a^{b^c}$가 되는 경우의 수를 구해보자.
$\oplus$는 xor 연산을 의미한다.

## 🔍 풀이 방법
[사용한 알고리즘]
- ?
---
1. a = 1이면, $1 \oplus b \oplus c = 1$인 쌍의 수를 찾으면 된다. -> $b \oplus c = 0$이라서 $b = c$이다.
결국, 경우의 수는 $\min(q,r)$이다.
2. a > 1이면?
2-1. b = 1이면, $a \oplus 1 \oplus c = a$가 된다. -> $c = 1$이다. 경우의 수는 p-1이 된다.
2-2. b > 1이면? $a \oplus b \oplus c = a^{b^c}$인데, $a \oplus b \oplus c <= 2\max(a,b,c) < a^{b^c}$이다. 경우의 수는 0이다.

종합하면, 답은 $\min(q,r) + p-1$이다.

## ⏳ 회고
진짜 신기한 문제다