### PR TITLE
[20250318] BOJ / P5 / 빌보의 생일 / 권혁준

### DIFF
--- a/khj20006/202503/18 BOJ P5 빌보의 생일.md
+++ b/khj20006/202503/18 BOJ P5 빌보의 생일.md
@@ -1,0 +1,87 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class SegTree{
+	int[] tree;
+	SegTree(int size){
+		tree = new int[size*4+1];
+	}
+	
+	void upt(int s, int e, int i, int n) {
+		if(s==e) {
+			tree[n] = 1;
+			return;
+		}
+		int m=(s+e)>>1;
+		if(i<=m) upt(s,m,i,n*2);
+		else upt(m+1,e,i,n*2+1);
+		tree[n] = tree[n*2] + tree[n*2+1];
+	}
+	
+	int find(int s, int e, int l, int r, int n) {
+		if(l>r || l>e || r<s) return 0;
+		if(l<=s && e<=r) return tree[n];
+		int m=(s+e)>>1;
+		return find(s,m,l,r,n*2) + find(m+1,e,l,r,n*2+1);
+	}
+}
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st = new StringTokenizer("");
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static String nextToken() throws Exception {
+		if(!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+	static int nextInt() throws Exception { return Integer.parseInt(nextToken()); }
+	static long nextLong() throws Exception { return Long.parseLong(nextToken()); }
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static int N;
+	static SegTree seg;
+	static TreeMap<String, Integer> T;
+	
+	public static void main(String[] args) throws Exception {
+		
+		for(N = nextInt();N != 0;N = nextInt()) {
+			
+			ready();
+			solve();
+		}
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		T = new TreeMap<>();
+		seg = new SegTree(N);
+		for(int i=1;i<=N;i++) T.put(nextToken(), i);
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		long ans = 0;
+		for(int i=1;i<=N;i++) {
+			int x = T.get(nextToken());
+			ans += seg.find(1, N, x, N, 1);
+			seg.upt(1,N,x,1);
+		}
+		bw.write(ans + "\n");
+
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/4442

## 🧭 풀이 시간
6분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
프로도와 샘은 다가오는 빌보의 111번째 생일 파티를 계획하려고 한다. 그들은 중간계의 모든 호빗을 생일 파티에 초대했고, 단 한 명의 예외도 없이 모두 참석하기로 했다. 호빗은 한 줄로 되어있는 매우 긴 식탁에 앉을것이다. 그러나, 프로도와 샘은 서로 대화를 하지 않으면서 파티를 계획했기 때문에, 각자 독자적으로 좌석표를 작성했다.

결국 프로도와 샘은 새로운 좌석표를 만들기로 했다. 이때, 새로운 좌석표와 두 좌석표에서 다른 순서로 앉은 쌍의 수를 최소로 하려고 한다. 이 값을 구하는 프로그램을 작성하시오.

## 🔍 풀이 방법
[사용한 알고리즘]
- 세그먼트 트리
---
문제 지문에서 inversion counting을 하라고 알려주고 있다.
문자열로 주어지는 건 TreeMap으로 정수화 해준 뒤에 세그먼트 트리로 inversion 개수를 구해줬다.

## ⏳ 회고
...