### PR TITLE
[20250319] BOJ / G5 / 비트 문자열 재배열하기 / 권혁준

### DIFF
--- a/khj20006/202503/19 BOJ G5 비트 문자열 재배열하기.md
+++ b/khj20006/202503/19 BOJ G5 비트 문자열 재배열하기.md
@@ -1,0 +1,87 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st = new StringTokenizer("");
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static String nextToken() throws Exception {
+		if(!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+	static int nextInt() throws Exception { return Integer.parseInt(nextToken()); }
+	static long nextLong() throws Exception { return Long.parseLong(nextToken()); }
+	static double nextDouble() throws Exception { return Double.parseDouble(nextToken()); }
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static int N, M;
+	static int start = 0, end1 = 0, end2 = 0;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = nextInt();
+		M = nextInt();
+		for(int i=N-1;i>=0;i--) if(nextInt() == 1) start |= (1<<i);
+		int[] temp = new int[M];
+		for(int i=0;i<M;i++) temp[i] = nextInt();
+		int x = 0, y = 0;
+		for(int i=M-1;i>=0;i--) {
+			if(i%2 == 0) {
+				x += temp[i];
+				for(int j=0;j<temp[i];j++) end1 |= (1<<y++);
+			}
+			else {
+				y += temp[i];
+				for(int j=0;j<temp[i];j++) end2 |= (1<<x++);
+			}
+		}
+		
+	}
+	
+	static void solve() throws Exception{
+
+		boolean[] vis = new boolean[32768];
+		vis[start] = true;
+		Queue<int[]> Q = new LinkedList<>();
+		Q.offer(new int[] {start,0});
+		while(!Q.isEmpty()) {
+			int[] now = Q.poll();
+			int n = now[0], t = now[1];
+			if(n == end1 || n == end2) {
+				bw.write(t+"\n");
+				return;
+			}
+			for(int i=0;i<N-1;i++) {
+				int x = (1<<i) * ((n&(1<<i)) == 0 ? 0 : 1);
+				int y = (1<<(i+1)) * ((n&(1<<(i+1))) == 0 ? 0 : 1);
+				int next = n^x^y;
+				next |= (x<<1) | (y>>1);
+				if(!vis[next]) {
+					vis[next] = true;
+					Q.offer(new int[] {next,t+1});
+				}
+			}
+		}
+
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/10330

## 🧭 풀이 시간
15분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
비트 문자열은 0, 1로만 이루어진 문자열이다. 여러분은 비트 문자열을 하나 받아서 특정한 문자열로 바꾸어야 한다. 이때, 여러분이 유일하게 할 수 있는 연산은 인접한 두 비트를 바꾸는 것이다.

초기 문자열의 상태는 그냥 비트의 순열로 주어진다. 하지만 바꾸고자 하는 문자열은 '연속 코드'의 형태로 주어진다. 연속 코드란, 문자열에 나타나는 연속된 0 또는 1의 개수를 차례대로 늘어놓은 순열이다. 예를 들어, "011100"의 연속 코드는 "1 3 2"가 된다. 이때, 연속 코드가 같은 문자열은 0으로 시작하는 것 하나, 그리고 1로 시작하는 것 하나로 항상 두 개씩 있다.

초기 문자열에서 나중 문자열로 문자열을 바꾸는데 필요한 최소한의 연산의 수를 계산하여라.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- BFS
---
수들이 비트로 쪼개져있으니까 알아보기 어렵고 불편하다.
-> 정수 하나로 바꿔줄 수 있다.
정수로 바꿔준 다음은, 단순하면서도 복잡한 1차원 BFS가 된다.

## ⏳ 회고
너무 어려운데 왜 골드5인지 모르겠다