### PR TITLE
[20250319] BOJ / G4 / FreeCell / 권혁준

### DIFF
--- a/khj20006/202503/19 BOJ G4 FreeCell.md
+++ b/khj20006/202503/19 BOJ G4 FreeCell.md
@@ -1,1 +1,53 @@
+```java
 
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st = new StringTokenizer("");
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static String nextToken() throws Exception {
+		if(!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+	static int nextInt() throws Exception { return Integer.parseInt(nextToken()); }
+	static long nextLong() throws Exception { return Long.parseLong(nextToken()); }
+	static double nextDouble() throws Exception { return Double.parseDouble(nextToken()); }
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static int N, M, K;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = nextInt();
+		M = nextInt();
+		K = nextInt();
+		
+	}
+	
+	static void solve() throws Exception{
+
+		boolean ans = (1<<M)*(N+1) >= K;
+		bw.write(ans ? "yes" : "no");
+
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11201

## 🧭 풀이 시간
15분 29초
![image](https://github.com/user-attachments/assets/213bec6d-31cb-49da-bd42-e7ea60a0117b)

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
카드 게임 `프리셀`의 규칙에 맞게 카드를 이동시킬 수 있다.
임의의 연속된 번호가 적힌 카드 K장이 임의의 스택 한 곳의 top에 존재하고 비어있는 셀이 N개, 비어있는 스택이 M개 존재한다.
K장의 카드를 임의의 다른 스택 한 곳으로 옮길 수 있는지 구해보자.

## 🔍 풀이 방법
**[사용한 알고리즘]**

X

---

N장의 카드는 비어있는 셀로 보낼 수 있고, 그 다음 카드는 빈 스택 한 곳에 놓은 뒤 셀에 잇는 카드를 전부 이 곳으로 가져오면 셀 전체를 다시 비어있는 셀로 만들 수 있다.
그리고, 이렇게 채운 스택 두 개를 합치면 크기 두 배가 되며, 스택이 한 곳 줄어든다고 생각하면 된다.

이를 수식으로 정리하면, N과 M이 주어졌을 때 옮길 수 있는 최대 카드 수는 $2^M \times (N+1)$개이다.

## ⏳ 회고
복잡하다