### PR TITLE
[20250319] BOJ / G4 / 수 나누기 게임 / 김수연

### DIFF
--- a/suyeun84/202503/19 BOJ G4 수 나누기 게임.md
+++ b/suyeun84/202503/19 BOJ G4 수 나누기 게임.md
@@ -1,0 +1,37 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class boj27172 {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+    static int nextInt() {return Integer.parseInt(st.nextToken());}
+    
+	public static void main(String[] args) throws Exception {
+		nextLine();
+		int N = nextInt();
+		nextLine();
+		int[] card = new int[N];
+		int[] selected = new int[1000001];
+		int[] answer = new int[N+1];
+		for (int i = 0; i < N; i++) {
+			card[i] = nextInt();
+			selected[card[i]] = i+1;
+		}
+		
+		for (int i = 0; i < N; i++) {
+			int start = card[i];
+			for (int j = start*2; j < 1000001; j += start) {
+				if (selected[j] > 0) {
+					answer[selected[j]] -= 1;
+					answer[selected[start]] += 1;
+				}
+			}
+		}
+		for (int i = 1; i < N+1; i++) {
+			System.out.print(answer[i]+" ");
+		}
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/27172
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
플레이어의 카드에 적힌 수로 다른 플레이어의 카드에 적힌 수를 나눴을 때, 나머지가 0이면 승리 -> 1점 획득
플레이어의 카드에 적힌 수가 다른 플레이어의 카드에 적힌 수로 나누어 떨어지면 패배 -> 1점 감점
## 🔍 풀이 방법
숫자가 1~1,000,000까지 가능해서 100만 크기의 배열을 만들고 그 값으로 카드의 index를 저장해둠.
그리고, 카드 하나씩 돌아가면서 에라토스테네스의 체로 배수의 숫자들을 방문.
만약 저장되어 있는 index가 0보다 크면 해당 플레이어의 점수--, 카드주인 플레이어의 점수++
## ⏳ 회고
방법을 알면 쉬운데, 숫자 배열의 값으로 인덱스를 저장하는 방법을 생각하지 못했다.