### PR TITLE
[20250319] BOJ / 골드1 / K번째 수 / 신동윤

### DIFF
--- a/03do-new30/202503/19 BOJ G1 K번째 수.md
+++ b/03do-new30/202503/19 BOJ G1 K번째 수.md
@@ -1,0 +1,28 @@
+```java
+import java.util.*;
+public class Main {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        int n = sc.nextInt();
+        int k = sc.nextInt();
+        // 이분탐색
+        long left = 0L;
+        long right = (long) n * n;
+        long answer = 0;
+        while (left <= right) {
+            long mid = (left + right) / 2;
+            long cnt = 0;
+            for (int i = 1; i <= n; i++) {
+                cnt += Math.min(mid / i, n);
+            }
+            if (cnt >= k) {
+                answer = mid;
+                right = mid - 1;
+            } else {
+                left = mid + 1;
+            }
+        }
+        System.out.println(answer);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1300
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- N×N인 배열 A를 만든다.  A[i][j] = i×j 이다. 
- 각 수들을 일차원 배열 B에 넣고 오름차순 정렬했을 때, B[k]의 값을 구한다.
- N <= 10^5
- K <= min(10^9, N^2)
## 🔍 풀이 방법
- N의 최대값이 10^5이고, k의 최대값은 10^9까지 가능 -> 직접 배열을 만들고 정렬하는 것은 불가능
- **정답이 될 수 있는 수를 이분탐색**하면서 찾아가는 방법 채택
- 정답 후보 수 mid가 몇 번째 수인지 확인하려면 mid보다 작거나 같은 수의 개수를 센다.
   - sum(min(mid // i, N)) (1 ≤ i ≤ N)으로 구할 수 있다. (각 행 별로 mid보다 작거나 같은 수를 구하는 방식)
 
## ⏳ 회고
- 범위가 넘 크다 싶으면 이분탐색