### PR TITLE
[20250320] BOJ / G1 / Lottery for Vitcoins at Moloco (Hard) / 권혁준

### DIFF
--- a/khj20006/202503/20 BOJ G1 Lottery for Vitcoins at Moloco (Hard).md
+++ b/khj20006/202503/20 BOJ G1 Lottery for Vitcoins at Moloco (Hard).md
@@ -1,0 +1,64 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st = new StringTokenizer("");
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static String nextToken() throws Exception {
+		if(!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+	static int nextInt() throws Exception { return Integer.parseInt(nextToken()); }
+	static long nextLong() throws Exception { return Long.parseLong(nextToken()); }
+	static double nextDouble() throws Exception { return Double.parseDouble(nextToken()); }
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static int N;
+	static int[][] A;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = nextInt();
+		A = new int[N][3];
+		for(int i=0;i<N;i++) {
+			A[i][0] = nextInt();
+			A[i][1] = nextInt();
+			A[i][2] = i+1;
+		}
+		
+	}
+	
+	static void solve() throws Exception{
+
+		Arrays.sort(A, (a,b) -> {
+			int resA = (10000-a[1])*a[0] + (a[0]+b[0])*a[1];
+			int resB = (10000-b[1])*b[0] + (a[0]+b[0])*b[1];
+			if(resA > resB) return -1;
+			if(resA < resB) return 1;
+			return a[2]-b[2];
+		});
+		for(int[] i:A) bw.write(i[2] + " ");
+		
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/15513

## 🧭 풀이 시간
36분
![image](https://github.com/user-attachments/assets/80411a24-aa8f-492c-b26c-e5b89b9f1d7e)

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
상이 N개 준비되어 있다.
i번째 상을 얻으려면, 티켓을 한 장 낸 후 p[i]의 확률로 앞면이 나오는 동전을 던져서 앞면이 나와야 하고, 이 때 w[i]만큼의 **코인**을 얻는다. (만약 뒷면이 나온다면, 티켓은 사라진다.)

처음에 티켓 한 장이 있을 때, 상을 고르는 순서를 잘 정해서 얻는 코인의 기댓값을 최대로 해보자.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- 그리디 알고리즘 (Exchange argument)
---
어떤 임의의 두 상 (a, b)에 대해, 어떤 상이 먼저 와야 얻을 수 있는 코인의 기댓값이 높아지는지 생각해보면 된다.
a가 먼저 때의 기댓값과, b가 먼저 왔을 때의 기댓값을 각각 구해서 비교하면 된다. ( = exchange argument)

기댓값의 선형성에 의해, 전체 기댓값을 구할 필요 없이 a와 b가 관여하는 부분만 구해줘도 무관하다.

구한 값을 가지고 sort의 반환 조건을 정해주면 된다.

## ⏳ 회고
식 세우는 게 어려웠고 기댓값 중 a, b가 관여하는 부분만 구해도 된다는 건 증명이 안돼서 그냥 감으로 했다..