### PR TITLE
[20250321] BOJ / G4 / Jigsaw of Shadows / 권혁준

### DIFF
--- a/khj20006/202503/21 BOJ G4 Jigsaw of Shadows.md
+++ b/khj20006/202503/21 BOJ G4 Jigsaw of Shadows.md
@@ -1,0 +1,31 @@
+```cpp
+
+#include <bits/stdc++.h>
+using namespace std;
+
+using ld = long double;
+
+int main(){
+  cin.tie(0)->sync_with_stdio(0);
+  
+  int theta, N;
+  cin>>theta>>N;
+  vector<pair<int,int>> A(N);
+  for(auto &[x,h]:A) cin>>x>>h;
+  sort(A.begin(), A.end());
+  
+  ld t = tan(M_PI * theta / 180.);
+  ld ans = 0, last = -1;
+  for(int i=0;i<N;i++){
+    int x = A[i].first, h = A[i].second;
+    ld pos = (ld)h / t;
+    if(last > pos+x) continue;
+    if(last > x) ans += pos+x-last;
+    else ans += pos;
+    last = pos+x;
+  }
+  cout<<ans;
+  
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/33144

## 🧭 풀이 시간
18분
![image](https://github.com/user-attachments/assets/10d0cc8f-f88e-454a-8c50-057f1bea6ac6)

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
사람 N명이 평지에 서있고, 빛이 지면과 이루는 각도가 $theta$이다.
사람들 그림자 길이의 총 합을 구해보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- 스위핑
---
사람들을 위치 기준으로 정렬시켜놓고 왼쪽 사람부터 스위핑하며 그림자의 길이를 구한다.
삼각함수로 간단하게 구할 수 있었고, 겹치는 부분에 대한 처리를 조심하며 구현했다.

## ⏳ 회고
자바로 푸니까 시간 초과가 떴다.
코드 그대로 C++로 옮기니까 맞았다.