### PR TITLE
[20250321] BOJ / G4 / Bi-coloring / 권혁준

### DIFF
--- a/khj20006/202503/21 BOJ G4 Bi-coloring.md
+++ b/khj20006/202503/21 BOJ G4 Bi-coloring.md
@@ -1,0 +1,83 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st = new StringTokenizer("");
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static String nextToken() throws Exception {
+		while(!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+	static int nextInt() throws Exception { return Integer.parseInt(nextToken()); }
+	static long nextLong() throws Exception { return Long.parseLong(nextToken()); }
+	static double nextDouble() throws Exception { return Double.parseDouble(nextToken()); }
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static int N, M;
+	static boolean[][] E;
+	static int[] C;
+	
+	public static void main(String[] args) throws Exception {
+		for(int T=nextInt();T-->0;) {
+			
+			ready();
+			solve();
+		}
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = nextInt();
+		M = nextInt();
+		E = new boolean[N][N];
+		C = new int[N];
+		for(int i=0;i<M;i++) {
+			int a = nextInt(), b = nextInt();
+			E[a][b] = true;
+			E[b][a] = true;
+		}
+		
+	}
+	
+	static void solve() throws Exception{
+
+		int ans = 1;
+		for(int i=0;i<N;i++) if(C[i] == 0) {
+			C[i] = 1;
+			if(dfs(i,1)) ans<<=1;
+			else {
+				bw.write("-1\n");
+				return;
+			}
+		}
+		bw.write(ans + "\n");
+		
+	}
+	
+	static boolean dfs(int n, int c) {
+		boolean res = true;
+		for(int i=0;i<N;i++) if(E[n][i]) {
+			if(C[i] == 0) {
+				C[i] = c^2;
+				res &= dfs(i,c^2);
+			}
+			else if(C[i] == c) res = false;
+		}
+		return res;
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/9719

## 🧭 풀이 시간
7분
![image](https://github.com/user-attachments/assets/390d6756-7cb4-4241-ae7d-33ee04e50e30)

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
주어진 그래프에서 두 개의 색만을 이용해 정점을 색칠할 수 있는 경우의 수를 구해보자.
단, 인접한 두 정점은 같은 색으로 칠할 수 없다.

## 🔍 풀이 방법
[사용한 알고리즘]
- DFS
---
DFS로 직접 색을 칠하며 모순이 생기는지 판별하고, 생기지 않았다면 그 컴포넌트에 대한 색칠 가능한 경우의 수는 2가 된다.
컴포넌트별로 모두 DFS를 돌려 정답을 구했다.

## ⏳ 회고
재밌다