### PR TITLE
[20250327] BOJ / G3 / Fix Wiring / 권혁준

### DIFF
--- a/khj20006/202503/27 BOJ G3 Fix Wiring.md
+++ b/khj20006/202503/27 BOJ G3 Fix Wiring.md
@@ -1,0 +1,68 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st = new StringTokenizer("");
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static String nextToken() throws Exception {
+		while(!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+	static int nextInt() throws Exception { return Integer.parseInt(nextToken()); }
+	static long nextLong() throws Exception { return Long.parseLong(nextToken()); }
+	static double nextDouble() throws Exception { return Double.parseDouble(nextToken()); }
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static int N;
+	static long[] A;
+	
+	public static void main(String[] args) throws Exception {
+			
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = nextInt();
+		A = new long[N*(N-1)/2];
+		for(int i=0;i<A.length;i++) A[i] = nextLong();
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		Arrays.sort(A);
+		long min = 0, max = 0;
+		int cntMin = 0, limitMax = 0, passMax = 0;
+		for(int i=0;i<A.length;i++) {
+			if(cntMin < N-1) {
+				cntMin++;
+				min += A[i];
+			}
+			if(passMax == limitMax) {
+				passMax = 1;
+				limitMax++;
+				max += A[i];
+			}
+			else passMax++;
+		}
+		bw.write(min + " " + max);
+		
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/20026

## 🧭 풀이 시간
10분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
정점이 N개인 완전 그래프와, 길이가 N*(N-1)/2인 배열 A가 주어진다.
완전 그래프의 각 간선의 가중치를 배열 A에서 중복되지 않게 배정했을 때, 만들어지는 최소 스패닝 트리의 비용으로 가능한 최솟값과 최댓값을 각각 구해보자.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- 최소 스패닝 트리
- 그리디 알고리즘
---
최소 스패닝 트리를 직접 구현하지는 않지만, 최소 스패닝 트리를 만드는 과정을 떠올려야 해결할 수 있다.

일단, 최솟값이 되는 경우는 당연히 배열 A에서 가장 작은 N-1개의 수를 고르는 경우이다.

크루스칼 알고리즘으로 접근하면, 우선 A에서 가장 작은 원소는 **반드시** 최소 스패닝 트리에 포함되고, 그 다음으로 작은 원소 또한 **반드시** 포함된다.
그 다음으로 작은 원소는 포함이 안 되도록 할 수 있다. 앞선 두 간선과 싸이클을 이루도록 가중치를 배정하면 이 원소를 건너뛸 수 있다는 의미다.
....
이런 식으로 접근해서 최댓값을 계산해줬다.

## ⏳ 회고
신기하고 재밌다