### PR TITLE
[20250327] BOJ / G2 / 친구 네트워크 / 신동윤

### DIFF
--- a/03do-new30/202503/27 BOJ G2 친구 네트워크.md
+++ b/03do-new30/202503/27 BOJ G2 친구 네트워크.md
@@ -1,0 +1,80 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static int F, cnt;
+    static Map<String, Integer> map;
+    static int[] parents, friends;
+
+    public static void main(String[] args) throws IOException {
+        int T = Integer.parseInt(br.readLine());
+        for (int tc = 1; tc <= T; tc++) {
+
+            F = Integer.parseInt(br.readLine());
+            map = new HashMap<>();
+            cnt = 0;
+
+            makeSet();
+            init();
+
+            for (int i = 0 ; i < F; i++) {
+                StringTokenizer st = new StringTokenizer(br.readLine());
+                String name1 = st.nextToken();
+                String name2 = st.nextToken();
+                addName(name1); // 이름 관리
+                addName(name2);
+                union(map.get(name1), map.get(name2));
+                // 두 사람의 친구 네트워크에 몇 명이 있는지 구한다.
+                int root = find(map.get(name1));
+                System.out.println(friends[root]);
+            }
+        }
+        br.close();
+    }
+
+    static void addName(String name) {
+        if (map.containsKey(name)) return;
+        map.put(name, cnt++);
+    }
+    
+    static void init() {
+        // friends[i] = i가 집합의 대표자일 때, 해당 집합에 속하는 친구들의 수
+        friends = new int[F*2];
+        for (int i = 0; i < F*2; i++) {
+            friends[i] = 1; // 초기에는 자기 자신만 친구...
+        }
+    }
+
+    static void makeSet() {
+        parents = new int[F * 2]; // F개 관계 -> 최대 F*2명의 사람 존재 가능
+        for (int i = 0; i < F * 2; i++) {
+            parents[i] = i;
+        }
+    }
+
+    static int find(int a) {
+        if (a == parents[a]) return a;
+        return parents[a] = find(parents[a]);
+    }
+
+    static boolean union(int a, int b) {
+        int aRoot = find(a);
+        int bRoot = find(b);
+        if (aRoot == bRoot) return false;
+        if (aRoot < bRoot) {
+            parents[bRoot] = aRoot;
+            friends[aRoot] += friends[bRoot]; // 친구 수 합치깅
+        } else {
+            parents[aRoot] = bRoot;
+            friends[bRoot] += friends[aRoot]; // 친구 수 합치깅
+        }
+        return true;
+    }
+
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/4195

## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
두 사람의 이름이 주어졌을 때, 두 사람은 친구가 된다.
이때 친구 관계가 주어질 때마다 두 사람과 친구인 사람들의 수를 출력한다.

## 🔍 풀이 방법
- 유니온 파인드로 풀이할 수 있다.
- 문자열인 사람들의 이름을 인덱스로 관리할 수 있도록 매핑해줘야 한다.
- 또한, 유니온 함수 실행 시 두 사람의 친구 수를 합쳐주는 과정도 추가되어야 한다.
## ⏳ 회고
- 유니온 파인드인데 응용들이 있어서 재미있게 풀었다.
- 처음엔 친구 수를 단순히 +1씩 증가시켜서 오답이 나왔음. 유니온할 때는 두 집합의 전체 크기를 합쳐야 한다!
- 문제에서 사람 수가 안 주어지기 때문에, 입력으로 주어지는 F를 기준으로 최대 2 * F까지 할당하는 아이디어가 중요했음