### PR TITLE
[20250402] BOJ / G1 /  외판원 순회 / 설진영

### DIFF
--- a/Seol-JY/202504/02 BOJ G1 외판원 순회.md
+++ b/Seol-JY/202504/02 BOJ G1 외판원 순회.md
@@ -1,0 +1,53 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+    static int N;
+    static int[][] map, dp;
+    static final int MAX_VALUE = 16_000_001;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        
+        N = Integer.parseInt(br.readLine());
+        map = new int[N][N];
+        dp = new int[N][(1<<N) - 1];
+        for(int i = 0; i < N; i++) Arrays.fill(dp[i], -1);
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                map[i][j] = nextInt(st);
+            }
+        }
+
+        System.out.println(dfs(0, 1));
+    }
+
+    static int dfs(int now, int visited) {
+        if (visited == (1 << N) - 1) {
+            if (map[now][0] == 0) return MAX_VALUE;
+            return map[now][0];
+        }
+
+        if(dp[now][visited] != -1) return dp[now][visited];
+        dp[now][visited] = MAX_VALUE;
+
+        for (int i = 0; i < N; i++) {
+            if((visited & (1 << i)) == 0 && map[now][i] != 0) {
+                dp[now][visited] = Math.min(dfs(i, visited | (1 << i)) + map[now][i], dp[now][visited]);
+            }
+        }
+
+        return dp[now][visited];
+    }
+
+    private static int nextInt(StringTokenizer st) {
+        return Integer.parseInt(st.nextToken());
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2098

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
전형적인 TSP 문제, 근데 시간제한이 빡센..

## 🔍 풀이 방법
TSP는 결국 사이클이 형성되었을때의 최단거리 이므로, 시작 지점이 중요하지 않음.
DP 배열을 현재까지의 방문을 표현하는 비트와 마지막으로 방문한 지점 값으로 두고, 메모이제이션 수행
재귀 호출로 필요한 값 차례대로 구하고 종료

## ⏳ 회고
너무 어렵다... 뭔가 아이디어는 떠올랐는데 구현을 도저히 못하겠어서 참고함.