### PR TITLE
[20250404] BOJ / G5 / 빌런 호석 / 김수연

### DIFF
--- a/suyeun84/202504/04 BOJ G5 빌런 호석.md
+++ b/suyeun84/202504/04 BOJ G5 빌런 호석.md
@@ -1,0 +1,48 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class boj22251 {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+    static int nextInt() {return Integer.parseInt(st.nextToken());}
+    
+    static int[][] digit = {
+            {0, 4, 3, 3, 4, 3, 2, 3, 1, 2},
+            {4, 0, 5, 3, 2, 5, 6, 1, 5, 4},
+            {3, 5, 0, 2, 5, 4, 3, 4, 2, 3},
+            {3, 3, 2, 0, 3, 2, 3, 2, 2, 1},
+            {4, 2, 5, 3, 0, 3, 4, 3, 3, 2},
+            {3, 5, 4, 2, 3, 0, 1, 4, 2, 1},
+            {2, 6, 3, 3, 4, 1, 0, 5, 1, 2},
+            {3, 1, 4, 2, 3, 4, 5, 0, 4, 3},
+            {1, 5, 2, 2, 3, 2, 1, 4, 0, 1},
+            {2, 4, 3, 1, 2, 1, 2, 3, 1, 0}
+    };
+    static int N, K, P, X, answer;
+	public static void main(String[] args) throws Exception {
+		nextLine();
+		N = nextInt(); // N층까지 이용 가능
+		K = nextInt(); // 숫자 길이
+		P = nextInt(); // 1~P개 반전
+		X = nextInt(); // 실제 층
+		
+		solve(0, 1, 0, 0);
+			
+		System.out.println(answer-1);
+	}
+	
+	static void solve(int idx, int ten, int now, int cnt) {
+		if (now > N || cnt > P) return;
+		if (idx == K) {
+			if (now != 0) answer++;
+			return;
+		}
+		for(int i = 0; i < 10; i++) {
+			solve(idx+1, ten*10, i*ten+now, cnt+digit[X/ten%10][i]);
+		}
+	}
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/22251
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
호석이가 디스플레이의 LED 중에서 최소 1개, 최대 P개를 반전시키려고 한다.
반전 이후 층은 1 이상 N 이하가 되어야하며,
현재 엘리베이터는 X층에 멈춰있다.
## 🔍 풀이 방법
digit 배열에 각 숫자로 바꾸려고 할 때 반전시켜야 하는 LED의 갯수 저장해두고,
dfs로 재귀를 돌면서 조건을 만족할 때, answer를 증가시킨다.
## ⏳ 회고
간단하게 생각하면 되는데, 괜히 복잡하게 생각해서 시간을 많이 잡아먹었다.