### PR TITLE
[20250404] BOJ / P3 / 정원 정리 / 권혁준

### DIFF
--- a/khj20006/202504/04 BOJ P3 정원 정리.md
+++ b/khj20006/202504/04 BOJ P3 정원 정리.md
@@ -1,0 +1,94 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st = new StringTokenizer("");
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static String nextToken() throws Exception {
+		while(!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+	static int nextInt() throws Exception { return Integer.parseInt(nextToken()); }
+	static long nextLong() throws Exception { return Long.parseLong(nextToken()); }
+	static double nextDouble() throws Exception { return Double.parseDouble(nextToken()); }
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static int N, M;
+	static boolean[][] edge;
+	static int[] sub;
+	static int[][] dp;
+	static final int INF = 1234;
+	
+	public static void main(String[] args) throws Exception {
+			
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = nextInt();
+		M = nextInt();
+		edge = new boolean[N+1][N+1];
+		sub = new int[N+1];
+		for(int i=1;i<N;i++) {
+			int a = nextInt(), b = nextInt();
+			edge[a][b] = edge[b][a] = true;
+		}
+		dp = new int[N+1][];
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		pre(1,0);
+		dfs(1,0);
+		int ans = dp[1][M];
+		for(int i=2;i<=N;i++) if(sub[i] >= M) ans = Math.min(ans, dp[i][M] + 1);
+		bw.write(ans + "\n");
+		
+	}
+	
+	static void pre(int n, int p) {
+		sub[n] = 1;
+		for(int i=1;i<=N;i++) if(edge[n][i] && i != p) {
+			pre(i,n);
+			sub[n] += sub[i];
+		}
+	}
+	
+	static void dfs(int n, int p) {
+		
+		dp[n] = new int[sub[n]+1];
+		Arrays.fill(dp[n], INF);
+		dp[n][1] = 0;
+		dp[n][0] = 1;
+		for(int i=1;i<=N;i++) if(edge[n][i] && i != p) {
+			dfs(i,n);
+			int[] ndp = new int[sub[n]+1];
+			Arrays.fill(ndp, INF);
+			for(int k=0;k<=sub[i];k++) {
+				for(int g=sub[n];g>=k;g--) {
+					ndp[g] = Math.min(ndp[g], dp[i][k] + dp[n][g-k]);
+				}
+			}
+			dp[n] = ndp;
+		}
+		if(n != 1) dp[n][0] = 1;
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1772

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
정점 N개인 트리가 주어진다.
가지치기를 해서 간선을 하나 끊으면, 나눠진 두 부분 중 한 부분만 남길 수 있다.
정점을 정확히 M개 남기는 최소 가지치기 횟수를 구해보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- 배낭 DP
- 트리 DP
---
1번 점을 루트로 잡고, dp식을 다음과 같이 정의했다.
`dp[n][k] = n번 점을 루트로 하는 서브트리에서 k개의 정점만 남길 때 필요한 최소 가지치기 횟수`

이 값은 자식 정점들의 dp값으로부터 배낭 문제 해결법을 통해 채워넣을 수 있다.
DFS로 이 dp값들을 구해줬다.

## ⏳ 회고
배낭을 떠올리니 난이도가 절반이 되었다