### PR TITLE
[20250410] BOJ / P2 / 최대 문자열 붙여넣기 / 권혁준

### DIFF
--- a/khj20006/202504/10 BOJ P2 최대 문자열 붙여넣기.md
+++ b/khj20006/202504/10 BOJ P2 최대 문자열 붙여넣기.md
@@ -1,0 +1,84 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st = new StringTokenizer("");
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static String nextToken() throws Exception {
+		while(!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+	static int nextInt() throws Exception { return Integer.parseInt(nextToken()); }
+	static long nextLong() throws Exception { return Long.parseLong(nextToken()); }
+	static double nextDouble() throws Exception { return Double.parseDouble(nextToken()); }
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static int M;
+	static char[] T;
+	static char[][] P;
+	static int[][] X;
+	static int[] dp;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		T = nextToken().toCharArray();
+		dp = new int[T.length];
+		M = nextInt();
+		P = new char[M][];
+		X = new int[M][];
+		for(int i=0;i<M;i++) {
+			P[i] = nextToken().toCharArray();
+			X[i] = new int[P[i].length];
+		}
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		for(int i=0;i<M;i++) {
+			for(int j=1;j<P[i].length;j++) {
+				X[i][j] = X[i][j-1];
+				while(X[i][j]>0 && P[i][X[i][j]] != P[i][j]) X[i][j] = X[i][X[i][j]-1];
+				if(P[i][X[i][j]] == P[i][j]) X[i][j]++;
+			}
+		}
+		
+		int[] idx = new int[M];
+		for(int i=0;i<T.length;i++) {
+			for(int j=0;j<M;j++) {
+				while(idx[j]>0 && P[j][idx[j]] != T[i]) idx[j] = X[j][idx[j]-1];
+				if(P[j][idx[j]] == T[i]) idx[j]++;
+				if(idx[j] == P[j].length) {
+					int res = (i >= P[j].length ? dp[i-P[j].length] : 0) + P[j].length;
+					dp[i] = Math.max(dp[i], res);
+					idx[j] = X[j][idx[j]-1];
+				}
+			}
+			if(i>0) dp[i] = Math.max(dp[i], dp[i-1]);
+		}
+		
+		bw.write(dp[T.length-1] + "\n");
+		
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2401

## 🧭 풀이 시간
17분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
어떤 긴 문자열이 주어지고 여러 개의 짧은 문자열들이 주어질 때 이때 짧은 문자열을 긴 문자열에 붙여 넣을때 가장 길게 붙여 넣는 경우를 찾아라.
단 이때 짧은 문자열들끼리는 교차 할 수 없다. (‘aabbc'  에  'aab' 와 'bbc' 둘 다 붙여 넣는 것은 불가능하다.) 또, 짧은 문자열은 여러 번 사용할 수 있다.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- KMP
- DP
---
짧은 문자열 각각에 대해 부분 일치 테이블을 구했다.
`dp[i] = 긴 문자열의 i번째 글자까지 확인했을 때 문제의 정답`으로 정의하고,
긴 문자열에서 한 문자씩 보면서 모든 작은 문자열과의 매칭 여부를 확인한다.
매칭된 것이 있다면, dp값을 갱신해준다.

## ⏳ 회고
코드트리에 있던 문제와 똑같다 (https://www.codetree.ai/ko/trails/complete/curated-cards/challenge-padding-a-string/description)