### PR TITLE
[20250415] BOJ / G1 / 순열 그래프의 연결성 판별 / 권혁준

### DIFF
--- a/khj20006/202504/15 BOJ G1 순열 그래프의 연결성 판별.md
+++ b/khj20006/202504/15 BOJ G1 순열 그래프의 연결성 판별.md
@@ -1,0 +1,82 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st = new StringTokenizer("");
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static String nextToken() throws Exception {
+		while(!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+	static int nextInt() throws Exception { return Integer.parseInt(nextToken()); }
+	static long nextLong() throws Exception { return Long.parseLong(nextToken()); }
+	static double nextDouble() throws Exception { return Double.parseDouble(nextToken()); }
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static int N;
+	static int[] A, max;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = nextInt();
+		A = new int[N+1];
+		for(int i=1;i<=N;i++) A[i] = nextInt();
+		max = new int[N+1];
+
+	}
+	
+	static void solve() throws Exception{
+		
+		for(int i=1;i<=N;i++) max[i] = Math.max(max[i-1], A[i]);
+		
+		int min = -1;
+		Stack<Integer> ans = new Stack<>();
+		ans.add(N+1);
+		for(int i=N;i>=1;) {
+			int j = i, tempMin = A[i];
+			while(j>=1 && max[j] == max[i]) {
+				tempMin = Math.min(tempMin, A[j]);
+				j--;
+			}
+			if(min == -1) min = tempMin;
+			else {				
+				if(max[i] <= min) ans.add(i+1);
+				min = Math.min(min, tempMin);
+			}
+			i = j;
+		}
+		if(!ans.isEmpty() && ans.peek() != 1) ans.add(1);
+		
+		bw.write((ans.size()-1) + "\n");
+		int now = ans.pop();
+		while(!ans.isEmpty()) {
+			int next = ans.pop();
+			bw.write((next-now) + " ");
+			for(int i=now;i<next;i++) bw.write(i + " ");
+			bw.write("\n");
+			now = next;
+		}
+		
+	}
+	
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/7982

## 🧭 풀이 시간
29분
![image](https://github.com/user-attachments/assets/074c3b8e-b546-4093-8ab0-df7e7f8042bd)

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
1부터 N까지의 수가 하나씩 들어있는 순열 A가 있다.
순열 그래프는 N개의 정점으로 이루어진 무방향 그래프로, 두 정점 쌍 (i,j)사이에 i<j와 A[i]>A[j]를 모두 만족하면 간선이 존재한다.
이 순열 그래프의 모든 컴포넌트 구성을 구해보자.

## 🔍 풀이 방법
[사용한 알고리즘]
- X
---
순열 A에서 최댓값을 기준으로 오른쪽에 있는 모든 원소들과는 연결되어 있음이 확실하다.
이 부분을 A에서 잘라내고 남은 부분에 대해 다시 최댓값을 구하면, 또 오른쪽 원소들과 모두 연결되어 있다.
....
이런 식으로 생각하면 덩어리들이 여러 개 생기는데, 이 덩어리들 각각의 min값을 구해보면 각 덩어리들이 서로 연결될 수 있는지 알 수 있다.

## ⏳ 회고
너무 어렵다