### PR TITLE
[20250418] BOJ / G5 / 회의실 배정 / 이강현

### DIFF
--- a/lkhyun/202504/18 BOJ G5 회의실 배정.md
+++ b/lkhyun/202504/18 BOJ G5 회의실 배정.md
@@ -1,0 +1,40 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N;
+
+    public static void main(String[] args) throws Exception {
+        N = Integer.parseInt(br.readLine());
+        PriorityQueue<int[]> pq = new PriorityQueue<>((a, b) -> {
+            if (a[1] == b[1]) {
+                return a[0] - b[0];
+            } else {
+                return a[1] - b[1];
+            }
+        });
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            pq.add(new int[] {Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken())});
+        }
+        int cnt = 0;
+        int curTime = 0;
+        while (!pq.isEmpty()) {
+            int[] cur = pq.poll();
+            if (cur[0] >= curTime) {
+                cnt++;
+                curTime = cur[1];
+            }
+        }
+        bw.write(cnt + "");
+        bw.close();
+    }
+}
+
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1931
## 🧭 풀이 시간
15분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [X] 하
## ✏️ 문제 설명
N개의 회의가 있을 때 겹치지 않고 회의실에 배정할때 최대 개수
## 🔍 풀이 방법
끝나는 시간을 기준으로 정렬
## ⏳ 회고
워낙 유명한 문제라 쉽게 했는데, 한가지 생각할게 있었다.
끝나는 시간으로 정렬을 하되 같다면 시작시간 기준으로도 정렬을 해야하는 것을 놓쳤다.
3
2 2
1 2
2 3
위와 같은 반례를 실행할 때 끝나는 시간으로만 정렬을 하게 되면 2 2가 처리되고 1 2가 조건에 막혀 처리되지 않았다.