### PR TITLE
[20250423] BOJ / G1 / 통나무 자르기 / 이강현

### DIFF
--- a/lkhyun/202504/23 BOJ G1 통나무 자르기.md
+++ b/lkhyun/202504/23 BOJ G1 통나무 자르기.md
@@ -1,0 +1,102 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static int L, K, C;
+    static boolean[] visited;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+
+        L = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        C = Integer.parseInt(st.nextToken());
+
+        Set<Integer> removeDup = new TreeSet<>();
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < K; i++) {
+            removeDup.add(Integer.parseInt(st.nextToken()));
+        }
+
+        int[] arr = new int[removeDup.size()];
+        int i = 0;
+        for (int a : removeDup) {
+            arr[i++] = a;
+        }
+
+        int count = Math.min(removeDup.size(), C);
+        // result[0] = 최대 길이, result[1] = 첫번째 위치, result[2] = 분할 수
+        int[] result = search(0, L, arr, count);
+
+        if (result[2] == count) {
+            bw.write(result[0] + " " + result[1]);
+        } else {
+            for (int j = 0; j < arr.length; j++) {
+                if (!visited[j]) {
+                    if (arr[j] < result[1]) {
+                        bw.write(result[0] + " " + arr[j]);
+                    } else {
+                        bw.write(result[0] + " " + result[1]);
+                    }
+                    break;
+                }
+            }
+        }
+        bw.close();
+    }
+
+    public static int[] search(int start, int end, int[] arr, int count) {
+        int l = start;
+        int r = end;
+        int cnt = 0;
+        int max = 0;
+        int prev = end;
+        while (l <= r) {
+            int mid = (l + r) / 2; //mid를 넘어서면 분할함.
+            prev = end;
+            cnt = 0;
+            max = 0;
+            visited = new boolean[arr.length];
+            for (int i = arr.length - 1; i >= 0; i--) {
+                if ((prev - arr[i]) >= mid) {
+                    if(i+1 <= arr.length - 1 && !visited[i+1]){ // 현 시점이 기준치를 넘어버린 상황이기에 그 이전을 자름.
+                        visited[i+1] = true;
+                        max = Math.max(max,prev-arr[i+1]);
+                        prev = arr[i+1];
+                        max = Math.max(max,prev-arr[i]);
+                    }else { // 현시점이 첫 분할 지점이거나 혹은 이전 지점이 이미 분할된 곳이어서 더이상 나눌 수 없을 때
+                        visited[i] = true;
+                        max = Math.max(max, prev - arr[i]);
+                        prev = arr[i];
+                    }
+                    cnt++;
+                }
+            }
+            if ((prev - start) >= mid) { // 마지막 구간 처리
+                if (arr[0] != prev) {
+                    max = Math.max(max, prev - arr[0]);
+                    visited[0] = true;
+                    prev = arr[0];
+                    cnt++;
+                }
+                max = Math.max(max, prev);
+            }
+            if(l == r) break;
+            if (cnt > count) {
+                l = mid + 1;
+            } else {
+                r = mid;
+            }
+        }
+        return new int[] {max, prev, cnt};
+    }
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1114
## 🧭 풀이 시간
3일

## 👀 체감 난이도
- [X] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
통나무의 길이, 자를 수 있는 위치와 자를 수 있는 횟수가 주어진다. 분할된 통나무의 최대 길이가 가장 작게 분할했을 때, 최대 길이와 가장 먼저 분할한 위치를 구하자.
## 🔍 풀이 방법
이분 탐색
## ⏳ 회고
공유기 설치 문제와 비슷한 느낌의 이분 탐색, 다만 공유기 설치는 공유기 각각의 위치를 최대한 넓게 하기만 하면 되었기에 먼저 맨 앞에 설치해놓고 그냥 mid값 조정하면서 횟수만 맞추면 됐음. 근데 이건 분할하는 지점이 중간에 주어져서 통나무 양 끝도 고려해야 함. 
분할 횟수가 5면 조각이 6개 나올 수 있으니 여기서부터 머리 아픔. 그리고 단순히 mid 넘기면 여기서 분할하자. 이것도 아님. 
분할 지점 순회하면서 mid를 넘으면 넘은 시점에서 분할할 지 바로 이전 부분에서 분할할지 결정해야 함. 
안 그러면 1 6 7 8 9 일때, mid가 2고 분할 가능 횟수가 3이라고 가정하면 1에서는 안 자르고 6에서 자르고 8에서 자르게 될텐데 분할 횟수가 적어서 mid를 1로 줄이고 이분탐색을 다시 돌면 또 분할 횟수가 3을 넘어버려서 결국 mid를 2로 결정하게 됨. 
이때 최댓값을 1에서 못 잘라서 6으로 반환하게 되는데 사실 1에서 자르고 6에서도 자르는게 최적임. 하고 싶은 말은 mid가 분할 기준인거지 딱 떨어지는 최적값이 아닌거임. 그냥 여기서 개빡침.
그래서 매 순간 현 시점에서 자를지 바로 이전 시점에서 자를지 생각해야하고 이전 시점에서 자르게 되면 분할되는 토막이 두개 생겨서 두개로 최댓값을 또 뽑아야함.
근데 여기서 또 끝이 아님. 자른 경우의 맨 첫번째 분할지점을 또 반환하래 그래서 뒤에서부터 잘랐음. 
근데 또 분할했을 때 분할 개수가 모자르면 더 앞부분을 쪼개서 반환해야함. 
1 2 5 10 에서 3번 쪼갤 수 있는데 5랑 10을 쪼개서 1번 횟수가 남았다고 하면 앞에서부터 또 안 쪼갠 부분 무의미하게 쪼개야하는거임.
너무 열받는데 내가 멍청해서 그럼 그냥