### PR TITLE
[20250504] BOJ / G4 / 거짓말 / 이강현

### DIFF
--- a/lkhyun/202505/04 BOJ G4 거짓말.md
+++ b/lkhyun/202505/04 BOJ G4 거짓말.md
@@ -1,0 +1,66 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N,M;
+    static boolean[] knowingPeople;
+
+    public static void main(String[] args) throws Exception {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        st = new StringTokenizer(br.readLine());
+        int temp = Integer.parseInt(st.nextToken());
+        knowingPeople = new boolean[N+1];
+        for (int i = 0; i < temp; i++) {
+            knowingPeople[Integer.parseInt(st.nextToken())] = true;
+        }
+
+        List<List<Integer>> party = new ArrayList<>();
+        for (int i = 0; i < M; i++) {
+            List<Integer> l = new ArrayList<>();
+            st = new StringTokenizer(br.readLine());
+            int num = Integer.parseInt(st.nextToken());
+            for (int j = 0; j < num; j++) {
+                int people = Integer.parseInt(st.nextToken());
+                l.add(people);
+            }
+            party.add(l);
+        }
+
+
+        int prev;
+        int curr = party.size();
+        do{
+            prev = curr;
+            curr = 0;
+            
+            for (int i = 0; i < party.size(); i++) {
+                boolean found = false;
+                for (int j = 0; j < party.get(i).size(); j++) {
+                    if(knowingPeople[party.get(i).get(j)]){
+                        found = true;
+                        break;
+                    }
+                }
+                if(found){
+                    for (int j = 0; j < party.get(i).size(); j++) {
+                        knowingPeople[party.get(i).get(j)] = true;
+                    }
+                    party.remove(i--);
+                }else{
+                    curr++;
+                }
+            }
+        }while(!party.isEmpty() && prev != curr);
+
+        bw.write(curr + "");
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1043
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [X] 하
## ✏️ 문제 설명
파티의 개수와 파티에 참석하는 사람들의 리스트가 주어짐. 이때 지민이가 모든 파티 중 사람들에게 들키지 않고 거짓말을 할 수 있는 최대 파티 수를 구하는 문제. 이미 진실을 알고 있는 사람들이 주어지고 진실과 거짓말을 둘다 듣는 경우도 들통나는 경우임. 
## 🔍 풀이 방법
진실을 알고 있는 사람들을 boolean 배열로 저장해두고 매 파티를 순회하면서 진실을 아는 사람이 참석한 경우 그 파티의 모든 사람들이 진실을 알고 있다고 체크함. 그리고 그 파티를 리스트에서 제거하고 이를 반복하다가 진실을 알고 있었던 사람 혹은 새롭게 알게된 사람들이 전혀 참석하지 않은 파티만이 남게 되었을 때 이 수를 출력함.
## ⏳ 회고
단순한 구현이었다고 생각함. 정렬을 통해 진실을 아는 사람들을 먼저 처리해야한다고 생각했으나 아니었음. 5개의 파티가 있을 때 1,2번 파티만 진실을 아는 사람이 있다고 가정하고 1,2번에 참석한 사람이 5번에 있고 5번에 참석한 사람이 3번에 있다면, 5번 파티가 3번 파티보다 더 먼저 처리되어야 하므로 정렬을 매 순간 반복해야하지만 그냥 정렬을 하지 않고 반복해서 순회하는 게 더 효율적이었던 것 같음.