### PR TITLE
[20250504] BOJ / G4 / 특정한 최단 경로 / 이강현

### DIFF
--- a/lkhyun/202505/04 BOJ G4 특정한 최단 경로.md
+++ b/lkhyun/202505/04 BOJ G4 특정한 최단 경로.md
@@ -1,0 +1,83 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static class Node {
+        int to,cost;
+        Node(int to, int cost) {
+            this.to = to;
+            this.cost = cost;
+        }
+    }
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N,E;
+    static List<Node>[] adjList;
+    static int v1,v2;
+    static int MAX = Integer.MAX_VALUE;
+    static int min = -1;
+
+    public static void main(String[] args) throws Exception {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        E = Integer.parseInt(st.nextToken());
+        adjList = new ArrayList[N+1];
+        for (int i = 1; i <= N; i++) {
+            adjList[i] = new ArrayList<>();
+        }
+        for (int i = 0; i < E; i++) {
+            st = new StringTokenizer(br.readLine());
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+            int cost = Integer.parseInt(st.nextToken());
+            adjList[from].add(new Node(to, cost));
+            adjList[to].add(new Node(from, cost));
+        }
+        st = new StringTokenizer(br.readLine());
+        v1 = Integer.parseInt(st.nextToken());
+        v2 = Integer.parseInt(st.nextToken());
+        int[][] dist = new int[3][N+1];
+        dijkstra(1,dist[0]);
+        dijkstra(v1,dist[1]);
+        dijkstra(v2,dist[2]);
+
+        boolean flag1 = true;
+        boolean flag2 = true;
+        if(dist[0][v1] == MAX || dist[1][v2] == MAX || dist[2][N] == MAX) flag1 = false;
+        if(dist[0][v2] == MAX || dist[2][v1] == MAX || dist[1][N] == MAX) flag2 = false;
+        if(flag1 && flag2){
+            min = Math.min(dist[0][v1] + dist[1][v2] + dist[2][N],dist[0][v2] + dist[2][v1] + dist[1][N]);
+        }else if(flag1){
+            min = dist[0][v1] + dist[1][v2] + dist[2][N];
+        }else if(flag2){
+            min = dist[0][v2] + dist[2][v1] + dist[1][N];
+        }
+        bw.write(min + "");
+        bw.close();
+    }
+    public static void dijkstra(int start , int[] dist) {
+        PriorityQueue<Node> pq = new PriorityQueue<>((a,b) -> a.cost - b.cost);
+        pq.add(new Node(start,0));
+        Arrays.fill(dist,MAX);
+        dist[start] = 0;
+
+        while (!pq.isEmpty()) {
+            Node cur = pq.poll();
+
+            if(cur.cost > dist[cur.to]) {
+                continue;
+            }
+            for(Node n : adjList[cur.to]){
+                int newDist = dist[cur.to] + n.cost;
+                if(newDist < dist[n.to]) {
+                    dist[n.to] = newDist;
+                    pq.add(new Node(n.to,newDist));
+                }
+            }
+        }
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1504
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [X] 중
- [ ] 하
## ✏️ 문제 설명
종착지까지 특정한 경유지 두 곳을 꼭 거쳐서 가야하는 문제, 이때 방향성은 없음
## 🔍 풀이 방법
다익스트라
## ⏳ 회고
다익스트라의 최적화 과정을 깊게 이해하는게 중요했던 것 같다. 결론적으로는 1에서 N까지 가야하고 v1,v2를 꼭 지나야한다고 할때 1,v1,v2,N 과 1, v2,v1,N 둘 중 하나만 비교해서 최적을 결정할 수 있다는 건데, 사실 1에서 v1,v2 각각으로 가는 비용이 1이고 v1에서 v2 사이를 99, v1,v2에서 N까지를 1이라고 잡으면 1,v1,N,v2,N 이런식으로 가는게 가장 최적일 것임.
근데 다익스트라 알고리즘이 실행되면서 결국 최적 비용 배열은 인접경로 99가 아니라 v1->1->v2와 같은 경로로 최적화 되어 2가 될 것이므로 N을 먼저 가는 경우는 결국 v1,v2를 먼저 가는 방법에 이미 반영이 된다는 거였음.
이는 아래와 같은 삼각부등식 때문에 적용된다는 것을 배울 수 있었다.
![image](https://github.com/user-attachments/assets/27164a13-0a93-4469-bf11-bbc53795c647)
