### PR TITLE
[20250505] BOJ / G4 / 트리의 지름 / 이강현

### DIFF
--- a/lkhyun/202505/05 BOJ G4 트리의 지름.md
+++ b/lkhyun/202505/05 BOJ G4 트리의 지름.md
@@ -1,0 +1,64 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static class Node {
+        int to,cost;
+        Node(int to, int cost) {
+            this.to = to;
+            this.cost = cost;
+        }
+    }
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N;
+    static List<Node>[] adjList;
+
+    public static void main(String[] args) throws Exception {
+        N = Integer.parseInt(br.readLine());
+        if(N == 1){
+            bw.write("0");
+            bw.close();
+            return;
+        }
+        adjList = new ArrayList[N+1];
+        for (int i = 1; i <= N; i++) {
+            adjList[i] = new ArrayList<>();
+        }
+        for (int i = 1; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            int p = Integer.parseInt(st.nextToken());
+            int c = Integer.parseInt(st.nextToken());
+            int w = Integer.parseInt(st.nextToken());
+            adjList[p].add(new Node(c, w));
+            adjList[c].add(new Node(p, w));
+        }
+        int[] dist = new int[N+1];
+        int A = BFS(1,dist);
+        int B = BFS(A,dist);
+        bw.write(dist[B]+"");
+        bw.close();
+    }
+    public static int BFS(int start,int[] dist){
+        Arrays.fill(dist, Integer.MAX_VALUE);
+        Queue<Integer> q = new ArrayDeque<>();
+        q.add(start);
+        dist[start] = 0;
+
+        int destination = start;
+        while(!q.isEmpty()){
+            int cur = q.poll();
+            for(Node node : adjList[cur]){
+                if(dist[node.to] == Integer.MAX_VALUE){
+                    dist[node.to] = dist[cur] + node.cost;
+                    q.add(node.to);
+                    if(dist[node.to] > dist[destination]) destination = node.to;
+                }
+            }
+        }
+        return destination;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1967
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [X] 중
- [ ] 하
## ✏️ 문제 설명
트리에 대한 정보가 주어짐. 트리에서 두 개의 특정 노드를 잡고 늘렸을 때 그 직선 거리의 최댓값 구하기
## 🔍 풀이 방법
BFS
## ⏳ 회고
원래는 N이 10000이고 그 중 2개를 뽑는 것이 가능하니까 리프 노드들을 모두 모아서 combination 하는 방식으로 진행했는데 올바르게 나오기는 하는데 메모리 초과가 발생했음. 결국 특정 노드에서 BFS를 진행하고 가장 먼 노드에서 다시 BFS를 진행하여 얻는 노드가 가장 멀리 있는 노드 쌍이라는 것을 알게 되었음. 메모리 초과 나는 거 오랜만인듯..