### PR TITLE
[20250507] BOJ / P1 / 닌자배치 / 권혁준

### DIFF
--- a/khj20006/202505/07 BOJ P1 닌자배치.md
+++ b/khj20006/202505/07 BOJ P1 닌자배치.md
@@ -1,0 +1,83 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st = new StringTokenizer("");
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static String nextToken() throws Exception {
+		while(!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+	static int nextInt() throws Exception { return Integer.parseInt(nextToken()); }
+	static long nextLong() throws Exception { return Long.parseLong(nextToken()); }
+	static double nextDouble() throws Exception { return Double.parseDouble(nextToken()); }
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static int N, M;
+	static long[] b, c, l, s;
+	static long ans = 0;
+	static PriorityQueue<Long>[] Q;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+		
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = nextInt();
+		M = nextInt();
+		b = new long[N+1];
+		c = new long[N+1];
+		l = new long[N+1];
+		s = new long[N+1];
+		Q = new PriorityQueue[N+1];
+		for(int i=1;i<=N;i++) {
+			b[i] = nextInt();
+			c[i] = nextInt();
+			l[i] = nextInt();
+			s[i] = c[i];
+			Q[i] = new PriorityQueue<>((a,b) -> Long.compare(b, a));
+			Q[i].add(c[i]);
+			ans = Math.max(ans, l[i]);
+		}
+		
+		
+	}
+	
+	static void solve() throws Exception {
+		
+		for(int i=N;i>1;i--) {
+			int p = (int)b[i];
+			if(Q[i].size() > Q[p].size()) {
+				Q[i].addAll(Q[p]);
+				s[i] += s[p];
+				Q[p] = Q[i];
+				s[p] = s[i];
+			}
+			else {
+				Q[p].addAll(Q[i]);
+				s[p] += s[i];
+			}
+			while(s[p] > M) s[p] -= Q[p].poll();
+			ans = Math.max(ans, l[p] * Q[p].size());
+		}
+		
+		bw.write(ans + "\n");
+		
+	}
+	
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/4002

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
N명의 닌자들은 **마스터 닌자**를 제외하고, 보스를 한 명씩 모신다. (트리 구조로 주어짐)
각 닌자들은 자신이 받는 월급이 정해져있고, 정수로 표현되는 리더십 레벨을 가진다.

닌자들 중 한 명을 매니저로 정해서, 매니저를 조상으로 갖는 모든 닌자들을 각각 자유롭게 고용할 수 있다.
단, 고용한 모든 닌자들에게 월급을 주어야 하며, 총 예산 M을 초과하면 안 된다.
만족도를 (고용한 닌자 수) * (매니저의 리더십 레벨)로 정의할 때, 만족도의 최댓값을 구해보자.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- 우선순위 큐
- Smaller to Larger
---
월급이 더 적은 닌자부터 고용하는 것은 자명하다.
리프 노드에 있는 닌자부터 올라가며 각 닌자가 매니저일 때 고용한 닌자들을 우선순위 큐에 담아준다.
간선을 타고 올라갈 때마다, 두 우선순위 큐를 합칠 때 size가 작은 걸 큰 쪽에 붙이고(Smaller to Larger), 총 예산을 초과한다면 월급이 큰 닌자부터 우선순위 큐에서 제거한다.

각 닌자가 매니저일 때의 고용할 수 있는 최대 닌자 수는 그 시점의 큐의 size이므로 만족도를 계산할 수 있게 된다.

## ⏳ 회고
Java에서 참조형 변수에 대한 = 연산은 주소만 가져와서 시간복잡도가 $O(1)$인 걸 알게 됐다.