### PR TITLE
[20250509] BOJ / D5 / Confuzzle / 권혁준

### DIFF
--- a/khj20006/202505/09 BOJ D5 Confuzzle.md
+++ b/khj20006/202505/09 BOJ D5 Confuzzle.md
@@ -1,0 +1,50 @@
+```cpp
+#include <iostream>
+#include <vector>
+#include <map>
+#include <utility>
+#include <algorithm>
+using namespace std;
+
+int N, INF = 1e9 + 7, ans = INF, C[100001]{};
+vector<vector<int>> V(100001);
+map<int, pair<int, int>> M[100001]{};
+
+void dfs(int n, int p) {
+	for (int i : V[n]) if (i != p) {
+		dfs(i, n);
+		C[i]++;
+		if (M[i].size() > M[n].size()) swap(M[i], M[n]), swap(C[i], C[n]);
+		for (auto[c, d] : M[i]) {
+			auto[fir, sec] = d;
+			if (M[n].find(c) == M[n].end()) M[n][c] = { fir + C[i] - C[n], sec + C[i] - C[n] };
+			else {
+				if (fir + C[i] < M[n][c].first + C[n]) M[n][c].second = M[n][c].first, M[n][c].first = fir + C[i] - C[n];
+				else if (fir < M[n][c].second) M[n][c].second = fir + C[i] - C[n];
+				if (sec < M[n][c].second) M[n][c].second = sec + C[i] - C[n];
+			}
+			ans = min(ans, M[n][c].first + M[n][c].second + 2*C[n]);
+		}
+		M[i] = map<int, pair<int, int>>();
+	}
+}
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin >> N;
+	for (int i = 1, a; i <= N; i++) {
+		cin >> a;
+		M[i][a] = { 0,INF };
+	}
+	for (int i = 1, a, b; i < N; i++) {
+		cin >> a >> b;
+		V[a].push_back(b);
+		V[b].push_back(a);
+	}
+
+	dfs(1, 0);
+	cout << ans;
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/20297

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
$N$개의 정점으로 구성된 가중치 없는 트리가 주어진다. 트리 상의 두 정점 사이의 거리는 두 정점 사이의 간선의 개수로 정의한다.

각 정점에는 수가 적혀 있으며, 적어도 두 정점은 같은 값임이 보장된다. 이때, 서로 같은 값이 쓰여 있는 두 정점 쌍 중 가장 거리가 가까울 때의 거리를 구해보자.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- Map
- Smaller to Larger
---
리프 노드에서부터 올라오며 (정점 고윳값, 거리)를 Map으로 관리한다.
두 정점 사이의 거리를 구해야 하기 때문에, 거리를 저장할 때는 가장 짧은 거리 두 개만 저장한다.
Map을 합칠 때는 Smaller to Larger로 합쳐준다.

## ⏳ 회고
센트로이드를 공부하고 연습 문제로 풀려했는데,
정작 센트로이드 없이 푸는 게 더 직관적인 것 같다.