### PR TITLE
[20250510] BOJ / G4 / 행렬 제곱

### DIFF
--- a/lkhyun/202505/10 BOJ G4 행렬 제곱.md
+++ b/lkhyun/202505/10 BOJ G4 행렬 제곱.md
@@ -1,0 +1,63 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int N;
+    static long B;
+    static int[][] matrix;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st;
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        B = Long.parseLong(st.nextToken());
+        matrix = new int[N][N];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                matrix[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+        int[][] result;
+        result = pow(matrix, B);
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                bw.write(result[i][j] + " ");
+            }
+            bw.write("\n");
+        }
+        bw.close();
+    }
+    static public int[][] mul(int[][] a, int[][] b) {
+        int[][] c = new int[N][N];
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                for (int k = 0; k < N; k++) {
+                    c[i][j] = (c[i][j] + (a[i][k] * b[k][j]) % 1000) % 1000;
+                }
+            }
+        }
+        return c;
+    }
+    static public int[][] pow(int[][] a, long n) {
+        if(n == 1){
+            int[][] result = new int[N][N];
+            for (int i = 0; i < N; i++) {
+                for (int j = 0; j < N; j++) {
+                    result[i][j] = a[i][j] % 1000;
+                }
+            }
+            return result;
+        }
+        if(n%2 == 0){
+            return pow(mul(a,a),n/2);
+        }else{
+            return mul(pow(mul(a,a),n/2),a);
+        }
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/10830
## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [X] 하
## ✏️ 문제 설명
행렬 제곱을 구하기
## 🔍 풀이 방법
제곱하는 크기가 매우 크기 때문에 분할하여 구해야함. a^100 = (a*a)^50을 이용
## ⏳ 회고
a의 1제곱을 반환할 때, 입력 그대로 반환했는데 이러면 이후 내부 연산에서 꼬일 수 있어 복사해야했고 또, 첫 입력이 1000이 들어오면 모듈러 연산이 적용되지 않아 0이 나와야하지만 1000이 나오는 예외가 생긴다. 항상 모듈러연산이 모든 연산의 과정에 적용되고 있는지 확인하자.