### PR TITLE
[20250514] BOJ / G4 / 사전 순 최대 공통 부분 수열 / 이강현

### DIFF
--- a/lkhyun/202505/14 BOJ G4 사전 순 최대 공통 부분 수열.md
+++ b/lkhyun/202505/14 BOJ G4 사전 순 최대 공통 부분 수열.md
@@ -1,0 +1,63 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N,M;
+    static int[] A,B;
+
+
+    public static void main(String[] args) throws IOException {
+        N = Integer.parseInt(br.readLine());
+        A = new int[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            A[i] = Integer.parseInt(st.nextToken());
+        }
+
+        M = Integer.parseInt(br.readLine());
+        B = new int[M];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < M; i++) {
+            B[i] = Integer.parseInt(st.nextToken());
+        }
+
+        List<Integer> common = new ArrayList<>();
+        int[] temp = searchMax(-1,-1);
+        while(temp[0] != -1) {
+            common.add(A[temp[0]]);
+            temp = searchMax(temp[0], temp[1]);
+        }
+        if(common.size() == 0){
+            bw.write("0");
+        }else{
+            bw.write(common.size()+"\n");
+            for(int i:common){
+                bw.write(i+" ");
+            }
+        }
+        bw.close();
+    }
+    public static int[] searchMax(int endA, int endB){
+        int maxAIndex = -1 ,maxBIndex = -1;
+        for (int i = N-1; i > endA; i--) {
+            for (int j = M-1; j > endB; j--) {
+                if (A[i] == B[j]){ //공통으로 가지는 경우
+                    if(maxAIndex == -1 || A[maxAIndex] <= A[i]){
+                        maxAIndex = i;
+                        maxBIndex = j;
+                    }else{
+                        break;
+                    }
+                }
+            }
+        }
+        return new int[]{maxAIndex,maxBIndex};
+    }
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/30805
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [X] 중
- [ ] 하
## ✏️ 문제 설명
두 수열에서 순서를 고려하는 공통 수열에 대해서 사전 순으로 가장 나중에 나오는 공통 수열을 출력하는 문제
## 🔍 풀이 방법
그리디 알고리즘
## ⏳ 회고
두 수열을 모두 순회하여 공통된 원소들중 가장 큰 원소의 인덱스를 찾아냄. 어차피 사전 순 가장 뒤인 수열 하나만 출력하는 거니까 가장 큰 공통 원소가 맨 앞에 오는게 무조건 제일 큰 경우임. 그리고 가장 큰 게 여러개 있을 수도 있으니 그 중 가장 앞에 있는 인덱스를 뽑기 위해 수열 뒤에서부터 순회하기로 함.
그리고 한번 순회하여 인덱스를 구했다면 리스트에 추가하고 또 맨 뒤에서부터 찾은 인덱스 바로 뒤까지만 순회함. 이를 반복하여 더 이상 공통 원소를 찾아내지 못하면 리스트를 출력함.
그냥 생각나는대로 풀었는데 맞아서 기분이 좋다 ㅎ