### PR TITLE
[20250605] BOJ / P5 / 비 오는 날 / 권혁준

### DIFF
--- a/khj20006/202506/05 BOJ P5 비 오는 날.md
+++ b/khj20006/202506/05 BOJ P5 비 오는 날.md
@@ -1,0 +1,68 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+
+    // IO field
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st = new StringTokenizer("");
+
+    static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+    static String nextToken() throws Exception {
+        while(!st.hasMoreTokens()) nextLine();
+        return st.nextToken();
+    }
+    static int nextInt() throws Exception { return Integer.parseInt(nextToken()); }
+    static long nextLong() throws Exception { return Long.parseLong(nextToken()); }
+    static double nextDouble() throws Exception { return Double.parseDouble(nextToken()); }
+    static void bwEnd() throws Exception {bw.flush();bw.close();}
+
+    // Additional field
+
+    static int N;
+    static long[] A;
+    static PriorityQueue<long[]> Q;
+
+    public static void main(String[] args) throws Exception {
+
+        ready();
+        solve();
+
+        bwEnd();
+
+    }
+
+    static void ready() throws Exception {
+
+        N = nextInt();
+        A = new long[N+1];
+        for(int i=1;i<=N;i++) A[i] = nextInt();
+        Q = new PriorityQueue<>((a,b) -> Long.compare(a[0]*a[1], b[0]*b[1]));
+
+    }
+
+    static void solve() throws Exception {
+
+        if(N == 1){
+            bw.write("0");
+            return;
+        }
+
+        long ans = 0;
+        for(int i=1;i<=N;i++){
+            ans += A[i];
+            Q.offer(new long[]{A[i], 3});
+        }
+        for(int i=2;i<N;i++){
+            long[] x = Q.poll();
+            ans += x[0]*x[1];
+            Q.offer(new long[]{x[0], x[1]+2});
+        }
+        bw.write(ans + "\n");
+
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/23578

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
정점이 N개인 그래프에 모든 정점들 사이의 이동이 가능하도록 간선을 배치해야 한다.
각 정점에는 가중치 A[i]가 존재하며, 그래프의 불만도는 모든 정점의 (차수)^2 * A[i]의 합과 같다.
그래프의 최소 불만도를 구해보자.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- 우선순위 큐
- 차수열
---
최소 불만도를 가지려면 그래프가 **트리** 형태여야만 하는 것은 자명하다.
트리가 아닌 그래프 형태라면, 간선 제거를 통해 더 적은 불만도를 가지는 트리를 항상 만들어낼 수 있기 때문이다.

또, 정점이 N개인 트리에서의 모든 정점의 차수 합은 항상 2N-2이다. 간선 개수가 N-1이기 떄문이다.

여기서, 트리 형태를 만족해야 하므로 모든 정점의 차수는 반드시 1이상이어야 한다.

즉, 각 정점의 차수를 D[i]라고 하면, 모든 D[i]에 대해 D[i] >= 1이고, $\sum$D[i] = 2N-2라는 것이다.
그리고, 위 조건만 만족한다면 D[i] 값이 어떻게 되든 상관없이 **항상 그에 맞는 트리를 구성할 수 있다.**

따라서, 초기에 차수 1씩 모두 할당한 뒤에 우선순위 큐로 최소가 되는 점을 매번 뽑아주는 작업을 N-2번 하면 된다.

## ⏳ 회고
간선으로 이어진 두 점을 동시에 신경쓰는 풀이로 가려다 보니 너무 헷갈렸다.