### PR TITLE
[20250612] BOJ / G3 / 세 용액 / 김수연

### DIFF
--- a/suyeun84/202506/12 BOJ G3 세 용액.md
+++ b/suyeun84/202506/12 BOJ G3 세 용액.md
@@ -1,0 +1,45 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class boj2473 {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	
+	public static void main(String[] args) throws Exception {
+		nextLine();
+		int N = Integer.parseInt(st.nextToken());
+		long[] num = new long[N];
+		long answer = Long.MAX_VALUE;
+		long[] res = new long[3]; 
+		nextLine();
+		for(int i = 0; i < N; i++) {
+			num[i] = Long.parseLong(st.nextToken());
+		}
+		Arrays.sort(num);
+		
+		for (int i = 0; i < N; i++) {
+			int start = i+1;
+			int end = N-1;
+			while (start < end) {
+				long temp = num[i] + num[start] + num[end];
+				if (Math.abs(temp) < answer) {
+					res[0] = num[i];
+					res[1] = num[start];
+					res[2] = num[end];
+					answer = Math.abs(temp);
+				}
+				if (temp > 0) end--;
+				else if (temp < 0) start++;
+				else {
+					System.out.println(res[0]+" "+res[1]+" "+res[2]);
+					return;
+				}
+			}
+		}
+		System.out.println(res[0]+" "+res[1]+" "+res[2]);
+	}
+}                     
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2473
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
주어진 용액들 중 3개의 용액을 선택해서 0에 가장 가까운 혼합 용액 만드려고 할 때, 세 용액 찾기
## 🔍 풀이 방법
주어진 용액들 오름차순으로 정렬한 뒤,
하나의 용액을 무조건 사용한다고 가정하고, 해당 용액보다 값이 큰 용액들 중에서 나머지 두개의 용액을 찾기 위해서 투포인터 사용
값이 -1,000,000,000 이상 1,000,000,000 이하여서 덧셈을 할 때를 대비해서 Long 사용하기
## ⏳ 회고
나름 전형적인 투포인터인거 같다