### PR TITLE
[20250614] BOJ / G3 / 행렬 곱셈 순서 / 이강현

### DIFF
--- a/lkhyun/202506/14 BOJ G3 행렬 곱셈 순서.md
+++ b/lkhyun/202506/14 BOJ G3 행렬 곱셈 순서.md
@@ -1,0 +1,40 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N;
+    static int[] rows;
+    static int[] cols;
+    static int[][] dp;
+
+    public static void main(String[] args) throws IOException {
+        N = Integer.parseInt(br.readLine());
+        rows = new int[N+1];
+        cols = new int[N+1];
+        for (int i = 1; i <= N; i++) {
+            st = new StringTokenizer(br.readLine());
+            rows[i] = Integer.parseInt(st.nextToken());
+            cols[i] = Integer.parseInt(st.nextToken());
+        }
+        dp = new int[N+1][N+1];
+
+        for (int len = 2; len <= N; len++) { //구간
+            for (int i = 1; i <= N - len + 1; i++) { //시작점
+                int j = i + len - 1; //끝점
+                dp[i][j] = Integer.MAX_VALUE;
+
+                for (int k = i; k < j; k++) { //분할지점
+                    int num = dp[i][k] + dp[k+1][j] + rows[i]*cols[k]*cols[j];
+                    dp[i][j] = Math.min(dp[i][j], num);
+                }
+            }
+        }
+        bw.write(dp[1][N] + "\n");
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11049
## 🧭 풀이 시간
90분

## 👀 체감 난이도
- [ ] 상
- [X] 중
- [ ] 하
## ✏️ 문제 설명
행렬 곱셈은 연산 순서에 따라 그 연산 횟수가 달라짐. 이전 행렬의 열의 수와 이후 행렬의 행의 수는 맞추어져 있고 어느 부분을 먼저 연산할지를 결정해야함. 이때 최소 연산 횟수를 구하기.
## 🔍 풀이 방법
dp[i][j] : i부터 j까지의 최소 연산 횟수
구간을 2부터 N까지 늘려가며 시작점 끝점을 정의하고 반복문 내에서 분할지점마다 dp 배열을 업데이트함.
## ⏳ 회고
식에서 연산 순서를 조절하여 최대 혹은 최소값을 구하는 문제의 대표적인 유형인듯 싶다. 프로그래머스에서 괄호 치는 부분을 적절히 조정하는 사칙연산 문제랑 비슷했다.