### PR TITLE
[20250614] BOJ / P3 / 교수님은 기다리지 않는다 / 권혁준

### DIFF
--- a/khj20006/202506/14 BOJ P3 교수님은 기다리지 않는다.md
+++ b/khj20006/202506/14 BOJ P3 교수님은 기다리지 않는다.md
@@ -1,0 +1,116 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+    BufferedReader br;
+    BufferedWriter bw;
+    StringTokenizer st;
+
+    public IOController() {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        st = new StringTokenizer("");
+    }
+
+    String nextLine() throws Exception {
+        String line = br.readLine();
+        st = new StringTokenizer(line);
+        return line;
+    }
+
+    String nextToken() throws Exception {
+        while (!st.hasMoreTokens()) nextLine();
+        return st.nextToken();
+    }
+
+    int nextInt() throws Exception {
+        return Integer.parseInt(nextToken());
+    }
+
+    long nextLong() throws Exception {
+        return Long.parseLong(nextToken());
+    }
+
+    double nextDouble() throws Exception {
+        return Double.parseDouble(nextToken());
+    }
+
+    void close() throws Exception {
+        bw.flush();
+        bw.close();
+    }
+
+    void write(String content) throws Exception {
+        bw.write(content);
+    }
+
+}
+
+public class Main {
+
+    static IOController io;
+
+    //
+
+    static int N, M;
+    static int[] r;
+    static long[] c;
+
+    public static void main(String[] args) throws Exception {
+
+        io = new IOController();
+
+        while(true) {
+            N = io.nextInt();
+            M = io.nextInt();
+            if(N == 0) break;
+            init();
+            solve();
+        }
+
+        io.close();
+
+    }
+
+    static int f(int x) {
+        if(x == r[x]) return x;
+        int p = f(r[x]);
+        c[x] += c[r[x]];
+        return (r[x] = p);
+    }
+
+    public static void init() throws Exception {
+
+        r = new int[N+1];
+        for(int i=1;i<=N;i++) r[i] = i;
+        c = new long[N+1];
+
+    }
+
+    static void solve() throws Exception {
+
+        while(M-->0) {
+
+            char op = io.nextToken().charAt(0);
+            int a = io.nextInt(), b = io.nextInt();
+
+            if(op == '!') {
+                int w = io.nextInt();
+                int x = f(a), y = f(b);
+                if(x == y) continue;
+                c[y] = c[a]-c[b]+w;
+                r[y] = x;
+            }
+            else {
+                int x = f(a), y = f(b);
+                if(x != y) io.write("UNKNOWN\n");
+                else io.write((c[b] - c[a]) + "\n");
+            }
+
+        }
+
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/3830

## 🧭 풀이 시간
55분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
상근이의 실험실에는 N개의 샘플이 있다.
샘플의 무게와 관련된 정보가 "! a b w"꼴로 주어지며, 이는 샘플 b가 샘플 a보다 w그램만큼 무겁다는 의미이다.
어떤 두 샘플의 무게를 비교하는 질문은 "? a b"꼴로 주어지며, 샘플 b가 샘플 a보다 몇 그램 더 무거운지 출력해야 한다.

두 종류의 작업은 합쳐서 총 M번 주어진다.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- 분리 집합
---
무게가 전부 상대적으로만 주어지니까, 어떤 한 샘플을 기준으로 잡아야 한다.
기준 샘플의 무게를 0으로 두면, 배열 하나를 둬서 c[a] = 샘플 a의 무게로 정할 수 있다.

분리 집합을 이용해서 각 컴포넌트의 루트를 기준 샘플로 잡고, 정보가 주어질 때마다 union을 해줄 거다.

정보 "! a b w"가 주어지면, 우선 a와 b가 이미 비교 가능한 상태인지 확인한다.
비교 불가능하면, a와 b의 루트 x, y를 먼저 구한다.

새로 주어진 정보 `b가 a보다 w그램 무거움`과,
기존에 알고 있는 정보 `b는 y보다 c[b]그램 무거움`, `a는 x보다 c[a]그램 무거움`를 조합하면 `y는 x보다 c[a]-c[b]+w그램 무거움`라는 결론이 나온다.

c[y] = c[a]-c[b]+w로 갱신하고 y를 x쪽에 붙인다.(분리 집합 union연산)

이 과정에서 y를 루트로 갖던 다른 점들에게 c[y]를 더해줘야 한다.
하지만 이걸 매번 더해주면 시간 초과가 난다.
따라서, find연산 시에만 더해줘서 꼭 필요한 정보만 미리 갱신하면 시간 내에 통과할 수 있다.

## ⏳ 회고
find연산에서 정보를 갱신할 때 로직이 잘못되어서 틀렸음
근데 뭐가 틀렸는지 찾는 데 오래걸림
코드를 빨리 짜는 것도 중요하지만 정확하게 짜는 게 더 중요함을 잊지 말자