### PR TITLE
[20250615] BOJ / G2 / 보석 도둑 / 이강현

### DIFF
--- a/lkhyun/202506/15 BOJ G2 보석 도둑.md
+++ b/lkhyun/202506/15 BOJ G2 보석 도둑.md
@@ -1,0 +1,47 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N,K;
+    static int[][] jewelryInfo;
+    static TreeMap<Integer,Integer> backpack; //중복되는 가방 구분을 위한 맵
+    static long sum;
+
+
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        jewelryInfo = new int[N][2]; // 0이면 무게, 1이면 가격
+        backpack = new TreeMap<>();
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            jewelryInfo[i][0] = Integer.parseInt(st.nextToken());
+            jewelryInfo[i][1] = Integer.parseInt(st.nextToken());
+        }
+        for (int i = 0; i < K; i++) {
+            int capacity = Integer.parseInt(br.readLine());
+            backpack.put(capacity,backpack.getOrDefault(capacity,0)+1);
+        }
+        Arrays.sort(jewelryInfo,(a,b) -> b[1]-a[1]);
+
+        sum = 0;
+        for (int i = 0; i < N; i++) {
+            Integer cur = backpack.ceilingKey(jewelryInfo[i][0]);
+            if(cur != null){
+                sum += jewelryInfo[i][1];
+                backpack.put(cur,backpack.get(cur)-1);
+                if(backpack.get(cur)==0){
+                    backpack.remove(cur);
+                }
+            }
+        }
+        bw.write(sum+"");
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1202
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [X] 중
- [ ] 하
## ✏️ 문제 설명
무게가 M이고 가격이 V인 보석을 훔칠건데 가방의 용량이 C임. 하나의 가방에는 하나의 보석만 들어갈 수 있음. 보석과 가방 목록이 주어질 때 훔칠 수 있는 보석 가격의 합의 최댓값을 구하기. 
## 🔍 풀이 방법
그리디, 자료구조
처음에는 0-1 knapsack 문제인줄 알다가 가방의 수와 보석의 수가 300000인걸 보고 이거 그리디다라고 생각해서 둘다 정렬해놓고 그냥 넣었음. 
근데 보석의 가치를 내림차순 정렬하는 건 맞는데 가방에 적절하게 넣는게 문제였음. 
현재 보석이 가치는 크나 무게가 작은데 가장 큰 가방에 들어가면 손해니까
그래서 treeset을 써서 가방에서 보석 무게보다는 큰데 그중 가장 작은 것을 뽑고 넣었음.
근데 또 같은 크기의 가방인 경우는 treeset에서 중복이 안돼서 treemap으로 바꾸고 풀었음.
## ⏳ 회고
접근하는거랑 푸는 방법은 좋았는데 적절한 가방 선택하는거를 어캐할지 몰라서 method를 찾음. treeset은 ceiling, treemap은 ceilingKey라는 것이 있는데 이게 입력 인자보다 크거나 같지만 제일 작은거 하나 뽑아주는 거임. 시간 복잡도는 2logN