### PR TITLE
[20250617] BOJ / G4 / 트리의 지름 / 설진영

### DIFF
--- a/Seol-JY/202506/17 BOJ G4 트리의 지름.md
+++ b/Seol-JY/202506/17 BOJ G4 트리의 지름.md
@@ -1,0 +1,73 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+    private static int N;
+    private static List<Node>[] graph;
+    private static boolean[] visited;
+    private static int maxDistance;
+    private static int farthestNode;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        N = Integer.parseInt(br.readLine());
+        graph = new List[N + 1];
+        
+        for (int i = 1; i <= N; i++) {
+            graph[i] = new ArrayList<>();
+        }
+        
+        for (int i = 0; i < N - 1; i++) {
+            st = new StringTokenizer(br.readLine());
+            
+            int parent = Integer.parseInt(st.nextToken());
+            int child = Integer.parseInt(st.nextToken());
+            int weight = Integer.parseInt(st.nextToken());
+
+            graph[parent].add(new Node(child, weight));
+            graph[child].add(new Node(parent, weight));
+        }
+
+        visited = new boolean[N + 1];
+        maxDistance = 0;
+        farthestNode = 1;
+        dfs(1, 0);
+        
+        visited = new boolean[N + 1];
+        maxDistance = 0;
+        dfs(farthestNode, 0);
+
+        System.out.println(maxDistance);
+    }
+
+    private static void dfs(int node, int distance) {
+        visited[node] = true;
+        
+        if (distance > maxDistance) {
+            maxDistance = distance;
+            farthestNode = node;
+        }
+
+        for (Node next : graph[node]) {
+            if (!visited[next.to]) {
+                dfs(next.to, distance + next.weight);
+            }
+        }
+    }
+
+    static class Node {
+        int to;
+        int weight;
+
+        Node(int to, int weight) {
+            this.to = to;
+            this.weight = weight;
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1967

## 🧭 풀이 시간
35분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하


## ✏️ 문제 설명
가중치가 있는 트리에서 트리 지름 구하기 

## 🔍 풀이 방법
임의의 노드에서 가장 먼 노드는 반드시 지름의 끝점 중 하나 라는 원리를 이용해서 
dfs 두번 돌려서 최장 거리 찾기

## ⏳ 회고
처음에는 리프노드 간 최장 거리가 트리의 지름이라 오해했는데, 이는 가중치가 있는 트리에서는 의미가 없다 
트리 지름을 구하는 알고리즘을 알고있어야 쉽게 풀 수 있는 문제였는듯 


