### PR TITLE
[20250617] BOJ / P5 / 상남자 곽철용 / 이강현

### DIFF
--- a/lkhyun/202506/17 BOJ P5 상남자 곽철용.md
+++ b/lkhyun/202506/17 BOJ P5 상남자 곽철용.md
@@ -1,0 +1,60 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N,M,K;
+    static HashSet<Integer> chosen;
+    static int cheolyoung;
+    static int answer = 0;
+
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        chosen = new HashSet<>();
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            chosen.add(Integer.parseInt(st.nextToken()));
+            chosen.add(Integer.parseInt(st.nextToken()));
+        }
+        st = new StringTokenizer(br.readLine());
+        int a = Integer.parseInt(st.nextToken());
+        int b = Integer.parseInt(st.nextToken());
+        cheolyoung = Math.abs(a%K - b%K);
+
+        List<Integer> remainders = new ArrayList<>();
+        for (int i = 1; i <= 4*N; i++) {
+            if(!chosen.contains(i) && i != a && i != b) {
+                remainders.add(i % K);
+            }
+        }
+        Collections.sort(remainders);
+
+        int size = remainders.size();
+        int mid = size / 2;
+        int left = 0;
+        int right = mid;
+
+        while (left < mid && right < size) {
+            int diff = remainders.get(right) - remainders.get(left);
+
+            if (diff > cheolyoung) {
+                answer++;
+                left++;
+                right++;
+            } else {
+                right++;
+            }
+        }
+
+        bw.write(Math.min(answer, M - 1) + "\n");
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17947
## 🧭 풀이 시간
120분

## 👀 체감 난이도
- [ ] 상
- [X] 중
- [ ] 하
## ✏️ 문제 설명
4XN의 카드 중에 M명의 참가자가 2개씩 카드를 뽑아 버리고 곽철용이 2개의 카드를 뽑았을 때, 철용이를 이기는 참가자의 최대 수를 구하라. 승패는 2개의 카드를 K로 각각 나눈 나머지의 차이이다.
## 🔍 풀이 방법
그리디, 투 포인터
카드는 항상 짝수개를 유지한다. 또한 카드를 K로 나누고 남은 나머지을 구하여 저장하고 정렬했을 때, 두 포인터가 멀어질 수록 뽑았을 때 가치가 커진다. 참가자들은 두 개를 뽑아야하고 따라서 두 개의 집합으로 나누어 포인터를 각각 두고 카드를 뽑으면 된다.
정렬된 리스트를 반으로 나누었을 때, 작은 나머지 집합과 큰 나머지 집합으로 나누어지게 되는데 작은 나머지 집합에서 두개를 골라 곽철용보다 커지더라도 작은 나머지 집합에서 두개를 뽑은 경우보다 두 집합에서 각각 뽑는 것의 차이가 무조건 같거나 크기 때문에 최적해를 가진다.
## ⏳ 회고
투 포인터를 양 끝도 해보고 처음부터도 해보고 다 해봤는데 반례가 있었음. 카드가 4xN이라고 하고 카드를 자꾸 두개씩 뽑는다는 것이 힌트였고 거리만 멀어지면 값이 커지니까 짝을 지어준다는 아이디어가 필요했던 것 같다.
그리고 철용이도 M명에 포함되니까 정답은 최대 M-1개라는 것도....