### PR TITLE
[20250617] BOJ / P3 / 물류창고 / 권혁준

### DIFF
--- a/khj20006/202506/17 BOJ P3 물류창고.md
+++ b/khj20006/202506/17 BOJ P3 물류창고.md
@@ -1,0 +1,127 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+    BufferedReader br;
+    BufferedWriter bw;
+    StringTokenizer st;
+
+    public IOController() {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        st = new StringTokenizer("");
+    }
+
+    String nextLine() throws Exception {
+        String line = br.readLine();
+        st = new StringTokenizer(line);
+        return line;
+    }
+
+    String nextToken() throws Exception {
+        while (!st.hasMoreTokens()) nextLine();
+        return st.nextToken();
+    }
+
+    int nextInt() throws Exception {
+        return Integer.parseInt(nextToken());
+    }
+
+    long nextLong() throws Exception {
+        return Long.parseLong(nextToken());
+    }
+
+    double nextDouble() throws Exception {
+        return Double.parseDouble(nextToken());
+    }
+
+    void close() throws Exception {
+        bw.flush();
+        bw.close();
+    }
+
+    void write(String content) throws Exception {
+        bw.write(content);
+    }
+
+}
+
+public class Main {
+
+    static IOController io;
+
+    //
+
+    static int N, K, M;
+    static long[] ans;
+    static List<int[]> Edges;
+    static TreeMap<Integer, Long>[] S;
+    static int[] r;
+
+    static int f(int x) { return x==r[x] ? x : (r[x]=f(r[x])); }
+
+    public static void main(String[] args) throws Exception {
+
+        io = new IOController();
+
+        init();
+        solve();
+
+        io.close();
+
+    }
+
+    public static void init() throws Exception {
+
+        N = io.nextInt();
+        K = io.nextInt();
+        M = io.nextInt();
+
+        r = new int[N+1];
+        S = new TreeMap[N+1];
+        for(int i=1;i<=N;i++) {
+            S[i] = new TreeMap<>();
+            S[i].put(io.nextInt(), 1L);
+            r[i] = i;
+        }
+
+        Edges = new ArrayList<>();
+        for(int i=0;i<M;i++) {
+            int a = io.nextInt(), b = io.nextInt(), c = io.nextInt();
+            Edges.add(new int[]{a,b,c});
+        }
+
+        ans = new long[K+1];
+
+    }
+
+    static void solve() throws Exception {
+
+        Collections.sort(Edges, (a,b) -> b[2]-a[2]);
+        for(int[] e:Edges) {
+            int a = e[0], b = e[1], c = e[2];
+
+            int x = f(a), y = f(b);
+            if(x == y) continue;
+            int small = x, large = y;
+            if(S[x].size() > S[y].size()){
+                small = y;
+                large = x;
+            }
+
+            for(int key : S[small].keySet()) {
+                ans[key] += S[large].getOrDefault(key, 0L) * S[small].get(key) * c;
+                S[large].put(key, S[large].getOrDefault(key, 0L) + S[small].get(key));
+            }
+            S[small] = new TreeMap<>();
+            r[small] = large;
+
+        }
+
+        for(int i=1;i<=K;i++) io.write(ans[i] + "\n");
+
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/28296

## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
정점 N개, 간선 M개인 그래프의 각 정점은 1번 회사부터 K번 회사중 하나에 속해있다.
간선에는 정수 가중치가 붙어있다.
두 정점의 **배송 상한선**은 두 정점을 연결하는 경로상의 간선들 중 가장 작은 가중치를 말한다. 만약 경로가 여럿 존재한다면, 배송 상한선이 가장 큰 경로를 선택한다.

1번 ~ K번의 각 회사에 대해, 해당 회사에 속한 정점들끼리의 배송 상한선의 총합을 구해보자.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- 분리 집합
- 작은 집합에서 큰 집합으로 합치는 테크닉
---
이런 문제는 간선 가중치가 큰 순서대로 크루스칼을 돌리며 내려오는 게 정석이다.
컴포넌트를 합칠 때마다, 각 컴포넌트에 존재했던 회사 정보들을 `작은 집합에서 큰 집합으로 합치는 테크닉`으로 합쳐준다.
두 컴포넌트에 있던 회사의 개수를 곱해준 것이 해당 간선을 배송 상한선으로 가지는 경로의 수를 의미한다.

## ⏳ 회고
이런 문제 너무 재밌음