### PR TITLE
[20250618] BOJ / G2 / 가장 긴 증가하는 부분 수열 2 / 이강현

### DIFF
--- a/lkhyun/202506/18 BOJ G2 가장 긴 증가하는 부분 수열.md
+++ b/lkhyun/202506/18 BOJ G2 가장 긴 증가하는 부분 수열.md
@@ -1,0 +1,40 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N;
+    static List<Integer> LIS;
+
+    public static void main(String[] args) throws IOException {
+        N = Integer.parseInt(br.readLine());
+        LIS = new ArrayList<>();
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            int cur = Integer.parseInt(st.nextToken());
+            if(LIS.isEmpty() || LIS.get(LIS.size()-1) < cur){
+                LIS.add(cur);
+            }else{
+                LIS.set(binarySearch(cur),cur);
+            }
+        }
+        bw.write(LIS.size() + "\n");
+        bw.close();
+    }
+    public static int binarySearch(int target) {
+        int left = 0; int right = LIS.size() - 1;
+        while(left < right){
+            int mid = (left + right) / 2;
+            if(LIS.get(mid) < target){
+                left = mid + 1;
+            }else{
+                right = mid;
+            }
+        }
+        return left;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/12015
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [X] 하
## ✏️ 문제 설명
가장 긴 증가하는 부분 수열의 길이를 출력
## 🔍 풀이 방법
이분 탐색
입력 받을 때마다 수열에서 입력값보다 크거나 같은 위치를 입력값으로 수정. 입력값보다 모두 작다면 뒤에 추가. 만들어진 새로운 수열의 길이가 LIS의 길이.
## ⏳ 회고
싸피에서 배운거라 금방한듯