### PR TITLE
[20250618] BOJ / P5 / 상남자 곽철용 / 권혁준

### DIFF
--- a/khj20006/202506/18 BOJ P5 상남자 곽철용.md
+++ b/khj20006/202506/18 BOJ P5 상남자 곽철용.md
@@ -1,0 +1,111 @@
+```java
+import java.math.BigInteger;
+import java.util.*;
+import java.io.*;
+
+class IOController {
+    BufferedReader br;
+    BufferedWriter bw;
+    StringTokenizer st;
+
+    public IOController() {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        st = new StringTokenizer("");
+    }
+
+    String nextLine() throws Exception {
+        String line = br.readLine();
+        st = new StringTokenizer(line);
+        return line;
+    }
+
+    String nextToken() throws Exception {
+        while (!st.hasMoreTokens()) nextLine();
+        return st.nextToken();
+    }
+
+    int nextInt() throws Exception {
+        return Integer.parseInt(nextToken());
+    }
+
+    long nextLong() throws Exception {
+        return Long.parseLong(nextToken());
+    }
+
+    double nextDouble() throws Exception {
+        return Double.parseDouble(nextToken());
+    }
+
+    void close() throws Exception {
+        bw.flush();
+        bw.close();
+    }
+
+    void write(String content) throws Exception {
+        bw.write(content);
+    }
+
+}
+
+public class Main {
+
+    static IOController io;
+
+    //
+
+    static int N, M, K, base;
+    static List<Integer> A;
+
+    public static void main(String[] args) throws Exception {
+
+        io = new IOController();
+
+        init();
+        solve();
+
+        io.close();
+
+    }
+
+    public static void init() throws Exception {
+
+        N = io.nextInt();
+        M = io.nextInt();
+        K = io.nextInt();
+
+        boolean[] ex = new boolean[4*N+1];
+        for(int i=0;i<M;i++) {
+            ex[io.nextInt()] = true;
+            ex[io.nextInt()] = true;
+        }
+
+        int a = io.nextInt(), b = io.nextInt();
+        ex[a] = true;
+        ex[b] = true;
+        base = Math.abs((a%K) - (b%K));
+
+        A = new ArrayList<>();
+        for(int i=1;i<=4*N;i++) if(!ex[i]) A.add(i%K);
+
+    }
+
+    static void solve() throws Exception {
+
+        Collections.sort(A);
+        int e = A.size() - 1, s = A.size()/2, ans = 0;
+        while(s >= 0) {
+            int a = A.get(e), b = A.get(s);
+            if(a-b > base) {
+                e--;
+                ans++;
+            }
+            s--;
+        }
+        io.write(Math.min(ans, M-1) + "\n");
+
+
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17947

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
4N개의 카드로 M명의 참가자가 게임을 한다.
각 참가자는 2개의 카드를 버리고, 총 2N개의 남은 카드들로 게임을 진행한다.
각 참가자는 2개의 카드를 뽑고, 두 장의 카드에 적힌 숫자를 K로 나눈 나머지의 차이를 점수로 얻는다.
철용이가 뽑은 두 장의 카드가 주어지면, 철용이를 이기는 사람들이 최대 몇 명인지 구해보자.

## 🔍 풀이 방법
**[사용한 알고리즘]**
- 그리디
- 투 포인터
---
철용이의 점수를 미리 구해놓고, 사용되지 않은 카드 리스트를 만든다.
이 리스트에서 두 카드를 골랐을 때 서로 멀리 있을수록 얻는 점수가 커진다.
이 리스트를 반갈해서 양쪽에서 한 장씩 고르는 것이 항상 이득이 된다.
반 갈랐을 때 같은 쪽에서 두 개를 골라도 철용이의 점수를 넘을 수는 있지만, 항상 위의 경우로 옮겨줄 수 있기 때문이다.

## ⏳ 회고
아이디어가 참신함