### PR TITLE
[20250620] BOJ / P5 / 가장 긴 증가하는 부분 수열 5 / 이강현

### DIFF
--- a/lkhyun/202506/20 BOJ P5 가장 긴 증가하는 부분 수열.md
+++ b/lkhyun/202506/20 BOJ P5 가장 긴 증가하는 부분 수열.md
@@ -1,0 +1,75 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N;
+    static int[] arr;
+    static List<Integer> LIS;
+    static int[] lisLen;
+    static int[] realIdx;
+
+    public static void main(String[] args) throws IOException {
+        N = Integer.parseInt(br.readLine());
+        arr = new int[N+1];
+        LIS = new ArrayList<>();
+        lisLen = new int[N+1];
+        realIdx = new int[N+1];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= N; i++) {
+            int cur = Integer.parseInt(st.nextToken());
+            arr[i] = cur;
+
+            if(LIS.isEmpty() || LIS.get(LIS.size()-1) < cur){
+                LIS.add(cur);
+                lisLen[i] = LIS.size();//맨 뒤에 붙이는 경우는 LIS길이만큼 만들 수 있는거
+                realIdx[LIS.size()-1] = i;
+            } else {
+                int pos = binarySearch(cur);
+                LIS.set(pos, cur);
+                lisLen[i] = pos + 1; //LIS는 0-base니까 1더해줌. 이진 탐색으로 찾은 위치까지 LIS를 만들 수 있다는 의미.
+                realIdx[pos] = i;
+            }
+        }
+
+        bw.write(LIS.size() + "\n");
+
+        List<Integer> result = new ArrayList<>();
+        int targetLength = LIS.size();
+
+        for (int i = N; i >= 1; i--) {
+            if (lisLen[i] == targetLength) {
+                result.add(arr[i]);
+                targetLength--;
+            }
+        }
+
+        Collections.reverse(result);
+
+        for (int i : result) {
+            bw.write(i + " ");
+        }
+        bw.write("\n");
+
+        bw.close();
+    }
+
+    public static int binarySearch(int target) {
+        int left = 0; int right = LIS.size() - 1;
+
+        while(left < right){
+            int mid = (left + right) / 2;
+            if(LIS.get(mid) < target){
+                left = mid + 1;
+            } else {
+                right = mid;
+            }
+        }
+        return left;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14003
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [X] 중
- [ ] 하
## ✏️ 문제 설명
가장 긴 증가하는 부분 수열(LIS)의 길이와 LIS 자체를 출력.
N은 최대 100만
## 🔍 풀이 방법
이분 탐색
LIS 배열을 이분 탐색을 통하여 만들기(nlogn)
LIS의 특정 인덱스와 매핑되는 실제 arr의 인덱스를 저장.
arr의 특정 원소를 마지막으로 하여 만들 수 있는 LIS의 길이를 저장.
LIS 배열의 길이가 결국 LIS의 길이라는 점을 이용하여 값을 1씩 줄여가며 값을 출력.
## ⏳ 회고
헷갈려....