### PR TITLE
[20250621] BOJ / G1 / 계단 수 / 이강현

### DIFF
--- a/lkhyun/202506/21 BOJ G1 계단 수.md
+++ b/lkhyun/202506/21 BOJ G1 계단 수.md
@@ -1,0 +1,45 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N;
+    static int[][][] dp;
+    static int MOD = 1000000000;
+
+    public static void main(String[] args) throws IOException {
+        N = Integer.parseInt(br.readLine());
+        //dp[자릿수][끝자리수][포함관계]
+        dp = new int[N+1][10][1024];
+        for (int i = 1; i <= 9; i++) {
+            dp[1][i][1<<i] = 1;
+        }
+
+        for (int i = 2; i <= N; i++) {
+            for (int j = 0; j <= 9; j++) {
+                for (int k = 0; k < (1<<10); k++) {
+                    if(j>0 && dp[i-1][j-1][k] > 0){
+                        dp[i][j][k | 1<<j] += dp[i-1][j-1][k];
+                        dp[i][j][k | 1<<j] %= MOD;
+                    }
+                    if(j<9 && dp[i-1][j+1][k] > 0){
+                        dp[i][j][k | 1<<j] += dp[i-1][j+1][k];
+                        dp[i][j][k | 1<<j] %= MOD;
+                    }
+                }
+            }
+        }
+        int sum = 0;
+        for (int i = 0; i <= 9; i++) {
+            sum += dp[N][i][1023];
+            sum %= MOD;
+        }
+        bw.write(sum + "\n");
+        bw.close();
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1562
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [X] 중
- [ ] 하
## ✏️ 문제 설명
N자리 수가 계단 수를 만족하고 0~9까지의 모든 숫자를 포함하는 경우의 수를 출력.
여기서 계단 수란, 수의 각 자리 숫자가 인접한 자리 숫자와의 차이가 1인 경우를 말한다.
## 🔍 풀이 방법
dp + 비트마스킹
N 자리수의 경우의 수는 N-1 자리 수에서 맨 끝자리가 0~9인경우를 모두 더하면 된다.
여기에 비트마스킹을 적용하여 0~9를 모두 포함하는 경우만 모두 더해 출력한다.
## ⏳ 회고
비트마스킹은 맨날 헷갈려