### PR TITLE
[20250621] BOJ / G4 / 호텔 / 김수연

### DIFF
--- a/suyeun84/202506/21 BOJ G4 호텔.md
+++ b/suyeun84/202506/21 BOJ G4 호텔.md
@@ -1,0 +1,33 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class boj1106 {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	
+	public static void main(String[] args) throws Exception {
+		nextLine();
+		int C = nextInt();
+		int N = nextInt();
+		int[] dp = new int[C+100];
+		int answer = Integer.MAX_VALUE;
+		Arrays.fill(dp, Integer.MAX_VALUE);
+		dp[0] = 0;
+		for (int i = 0; i < N; i++) {
+			nextLine();
+			int cost = nextInt();
+			int num = nextInt();
+			for (int j = num; j < C+100; j++) {
+				if (dp[j - num] != Integer.MAX_VALUE) {
+					dp[j] = Math.min(dp[j], dp[j-num] + cost);
+				}
+			}
+		}
+		for (int i = C; i < C+100; i++) answer = Math.min(answer, dp[i]);
+		System.out.println(answer);
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1106
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
최소 C명의 고객으로 늘어나기 위해 사용해야 하는 돈의 최솟값 구하기
## 🔍 풀이 방법
dp사용
한 도시에서 최대 100명의 고객까지만 늘어날 수 있어서 dp[C] ~ dp[C+99]까지 중에서 최솟값 찾으면 됨
## ⏳ 회고
dp 배열이 C+100크기인거를 알려면 문제를 꼼꼼히 읽어야겠다.