### PR TITLE
[20250622] BOJ / G1 / 외판원 순회 / 이강현

### DIFF
--- a/lkhyun/202506/22 BOJ G1 외판원 순회.md
+++ b/lkhyun/202506/22 BOJ G1 외판원 순회.md
@@ -1,0 +1,57 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N;
+    static int[][] cost;
+    static int[][] dp;
+
+    public static void main(String[] args) throws IOException {
+        N = Integer.parseInt(br.readLine());
+        cost = new int[N][N];
+        dp = new int[1 << N][N];
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                cost[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        for (int i = 0; i < (1 << N); i++) {
+            Arrays.fill(dp[i], Integer.MAX_VALUE);
+        }
+
+        dp[1][0] = 0;
+
+        for (int i = 1; i < (1 << N); i++) {
+            for (int j = 0; j < N; j++) {
+                if ((i & (1 << j)) == 0) continue;
+                if (dp[i][j] == Integer.MAX_VALUE) continue;
+
+                for (int k = 0; k < N; k++) {
+                    if ((i & (1 << k)) != 0) continue;
+                    if (cost[j][k] == 0) continue;
+
+                    dp[i | (1 << k)][k] = Math.min(dp[i | (1 << k)][k], dp[i][j] + cost[j][k]);
+                }
+            }
+        }
+
+        int answer = Integer.MAX_VALUE;
+
+        for (int i = 1; i < N; i++) {
+            if (dp[(1 << N) - 1][i] != Integer.MAX_VALUE && cost[i][0] != 0) {
+                answer = Math.min(answer, dp[(1 << N) - 1][i] + cost[i][0]);
+            }
+        }
+
+        bw.write(answer + "");
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2098
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [X] 중
- [ ] 하
## ✏️ 문제 설명
특정한 도시에서 모든 도시를 순회하고 다시 처음 도시로 돌아오는데 걸리는 최소 비용 구하기
## 🔍 풀이 방법
비트마스킹 + dp
dp[거쳐간 도시][현재 도시]로 설정
## ⏳ 회고
순회는 어디서 시작하던 동일한 결과를 얻는 다는 점을 알았고
dp 문제는 for문 중첩을 어떻게 하는지에 따라 달라진다는 것을 알았다.