### PR TITLE
[20250623] BOJ / P3 / System Call / 권혁준

### DIFF
--- a/khj20006/202506/23 BOJ P3 System Call.md
+++ b/khj20006/202506/23 BOJ P3 System Call.md
@@ -1,0 +1,113 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+    BufferedReader br;
+    BufferedWriter bw;
+    StringTokenizer st;
+
+    public IOController() {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        st = new StringTokenizer("");
+    }
+
+    String nextLine() throws Exception {
+        String line = br.readLine();
+        st = new StringTokenizer(line);
+        return line;
+    }
+
+    String nextToken() throws Exception {
+        while (!st.hasMoreTokens()) nextLine();
+        return st.nextToken();
+    }
+
+    int nextInt() throws Exception {
+        return Integer.parseInt(nextToken());
+    }
+
+    long nextLong() throws Exception {
+        return Long.parseLong(nextToken());
+    }
+
+    double nextDouble() throws Exception {
+        return Double.parseDouble(nextToken());
+    }
+
+    void close() throws Exception {
+        bw.flush();
+        bw.close();
+    }
+
+    void write(String content) throws Exception {
+        bw.write(content);
+    }
+
+}
+
+public class Main {
+
+    static IOController io;
+
+    //
+
+    static int N;
+    static long[] F;
+    static long T;
+
+    public static void main(String[] args) throws Exception {
+
+        io = new IOController();
+
+        init();
+        solve();
+
+        io.close();
+
+    }
+
+    public static void init() throws Exception {
+
+        N = io.nextInt();
+        F = new long[N];
+        for(int i=0;i<N;i++) F[i] = io.nextInt();
+        T = io.nextInt();
+
+    }
+
+    static void solve() throws Exception {
+
+        long div = 0;
+        for(int i=0;i<N;i++) div += F[i];
+
+        long[] check = new long[500001];
+
+        for(int i=0;i<N;i++) {
+            if(F[i] != 1) check[(int)F[i]]++;
+            long prev = F[i];
+            for(int j=2;j<=(F[i]-1)/j + 1;j++) {
+                long now = (F[i]-1)/j + 1;
+                check[j] += prev-now;
+                if(now != j) check[(int)now]++;
+                prev = now;
+            }
+        }
+
+        long min = div * (T+1), ans = 1;
+        for(int i=2;i<=500000;i++) if(check[i] != 0) {
+            div -= check[i];
+            long res = div * (T+i);
+            if(res < min) {
+                min = res;
+                ans = i;
+            }
+        }
+
+        io.write(min + " " + ans);
+
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/15825

## 🧭 풀이 시간
100분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
크기가 각각 F[i]인 N개의 파일들이 있다.
하나의 파일을 읽을 때, 버퍼의 크기 K만큼 읽을 수 있고, 시간은 (T+K)만큼 걸린다.
모든 파일을 읽는 가장 짧은 시간과 그 때의 버퍼 크기를 구해보자.

## 🔍 풀이 방법
그냥 깡 수학 문제임

버퍼의 크기가 K일 때 파일들을 읽는 데 걸리는 시간은 $\sum {{\lceil \dfrac{F[i]}{K} \rceil (T + K)}}$이다.
단순히 모든 K를 확인하면 시간 초과가 나고, 답이 될 수 있는 K만 적절히 골라 탐색해야 한다.
여기서 적절한 K란, 어떤 파일 F[i]에 대해 $\lceil \dfrac{F[i]}{K} \rceil$ 값이 바뀌게 되는 K를 말한다.
그리고 이 K의 개수는 대략 $\sqrt{F[i]}$이다.
또, 적절한 K는 값이 $\sqrt{F[i]}$를 넘어가면 잘 존재하지 않는다.

각 K에 대해, 버퍼의 크기가 K-1에서 K가 되었을 때 모든 파일들의 $\lceil \dfrac{F[i]}{K} \rceil$ 합이 얼마만큼 줄어드는지 기록하는 배열을 만든다.
이제 버퍼의 크기를 1부터 늘려가며 변동이 있을 때만 시간 계산을 해주면 된다.

## ⏳ 회고
처음에는 저 적절한 K가 파일 크기의 약수인 줄 알고 풀었다가 틀렸음

그 다음엔 아예 풀이를 갈아엎고, K값에 따른 전체 시간이 볼록성을 가질 거라 생각했다.
볼록성을 지닌다면 풀이가 `삼분 탐색`으로 좁혀지기 때문에 일단 그냥 구현해보고 제출했는데 틀렸다. 볼록성이 없다는 게 증명이 된 거다.

또 풀이를 갈아엎고 처음에 냈던 풀이를 다듬어 보니까 맞았다.
너무 어려웠음