### PR TITLE
[20250624] BOJ / G5 / 트리와 쿼리 / 이강현

### DIFF
--- a/lkhyun/202506/24 BOJ G5 트리와 쿼리.md
+++ b/lkhyun/202506/24 BOJ G5 트리와 쿼리.md
@@ -1,0 +1,55 @@
+```java
+import java.util.*;
+import java.io.*;
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N,R,Q;
+    static List<Integer>[] adjList;
+    static int[] count;
+    static boolean[] visited;
+
+
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        R = Integer.parseInt(st.nextToken());
+        Q = Integer.parseInt(st.nextToken());
+
+        adjList = new List[N+1];
+        for (int i = 1; i <= N; i++) {
+            adjList[i] = new ArrayList<>();
+        }
+
+        for (int i = 1; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+            adjList[u].add(v);
+            adjList[v].add(u);
+        }
+        count = new int[N+1];
+        visited = new boolean[N+1];
+        find(R);
+
+        for (int i = 0; i < Q; i++) {
+            int start = Integer.parseInt(br.readLine());
+            bw.write(count[start] + "\n");
+        }
+        bw.close();
+    }
+    static int find(int u) {
+        if(visited[u]) return 0;
+        int cnt = 1;
+        visited[u] = true;
+
+        for(int v : adjList[u]) {
+            cnt += find(v);
+        }
+        count[u] = cnt;
+        return cnt;
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/15681
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
트리가 주어지고 특정 노드가 주어질때, 그 노드를 루트로 하는 서브트리 노드의 개수를 출력
## 🔍 풀이 방법
재귀, 그래프 탐색
기존 트리에서 루트부터 재귀적으로 자신이 가지는 자식 노드들의 개수를 합하여 저장해둠.
## ⏳ 회고
ez