### PR TITLE
[20250624] BOJ / P5 / 집합 연산 / 권혁준

### DIFF
--- a/khj20006/202506/24 BOJ P5 집합 연산.md
+++ b/khj20006/202506/24 BOJ P5 집합 연산.md
@@ -1,0 +1,152 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+    BufferedReader br;
+    BufferedWriter bw;
+    StringTokenizer st;
+
+    public IOController() {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        st = new StringTokenizer("");
+    }
+
+    String nextLine() throws Exception {
+        String line = br.readLine();
+        st = new StringTokenizer(line);
+        return line;
+    }
+
+    String nextToken() throws Exception {
+        while (!st.hasMoreTokens()) nextLine();
+        return st.nextToken();
+    }
+
+    int nextInt() throws Exception {
+        return Integer.parseInt(nextToken());
+    }
+
+    long nextLong() throws Exception {
+        return Long.parseLong(nextToken());
+    }
+
+    double nextDouble() throws Exception {
+        return Double.parseDouble(nextToken());
+    }
+
+    void close() throws Exception {
+        bw.flush();
+        bw.close();
+    }
+
+    void write(String content) throws Exception {
+        bw.write(content);
+    }
+
+}
+
+public class Main {
+
+    static IOController io;
+
+    //
+
+    static int N, Q;
+    static TreeSet<Long> S;
+    static long[] B;
+
+    public static void main(String[] args) throws Exception {
+
+        io = new IOController();
+
+        init();
+        solve();
+
+        io.close();
+
+    }
+
+    public static void init() throws Exception {
+
+        N = io.nextInt();
+        S = new TreeSet<>();
+        for(int i=0;i<N;i++) S.add(io.nextLong());
+        Q = io.nextInt();
+        B = new long[Q];
+        for(int i=0;i<Q;i++) B[i] = io.nextInt();
+
+    }
+
+    static void solve() throws Exception {
+
+        long sum = 0;
+        for(long i:S) sum += i;
+
+        S.add(Long.MAX_VALUE);
+
+        Deque<long[]> list = new ArrayDeque<>();
+
+        long left = N;
+
+        // 처음에 제거되는 경우가 있으면 먼저 처리
+        if(S.contains((long)N)) {
+            while(left >= 0 && S.contains(left)) S.remove(left--);
+            list.offerLast(new long[]{N, left});
+        }
+
+        // 추가, 제거 반복
+        while(true) {
+
+            long next = S.ceiling(left);
+            if(next == Long.MAX_VALUE){
+                list.offerLast(new long[]{left, next});
+                break;
+            }
+            S.add(left);
+            list.offerLast(new long[]{left, next});
+            S.remove(next);
+            while(left >= 0 && S.contains(left)) S.remove(left--);
+            list.offerLast(new long[]{next, left});
+
+        }
+
+        for(long q : B) {
+
+            while(q > 0) {
+                long[] cur = list.pollFirst();
+                long l = cur[0], r = cur[1], cnt = Math.abs(l-r);
+
+                if(q < cnt) {
+                    if(l > r) {
+                        list.offerFirst(new long[]{l-q, r});
+                        r = l-q;
+                    }
+                    else {
+                        list.offerFirst(new long[]{l+q, r});
+                        r = l+q;
+                    }
+                    q = 0;
+                }
+                else q -= cnt;
+
+                if(l > r) {
+                    sum -= l*(l+1)/2 - r*(r+1)/2;
+                }
+                else {
+                    sum += (r-1)*r/2 - (l-1)*l/2;
+                }
+
+            }
+
+            io.write(sum + "\n");
+
+        }
+
+
+
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/32965

## 🧭 풀이 시간
80분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N개의 원소로 이루어진 중복을 허용하지 않는 집합 S가 주어진다.
이 집합 S에 아래 연산을 여러 번 할 수 있다.
- 집합 S의 원소 개수를 n이라 할 때, n이 S에 존재한다면 S에서 n을 제거하고 존재하지 않는다면 S에 n을 추가한다.
여기에 연산을 K번 한 결과를 구해보자. (쿼리 형식으로 주어짐)

## 🔍 풀이 방법
- 투 포인터
---
직접 연산을 시뮬레이션해보면, 원소가 범위 형태로 추가/제거 작업이 반복되는 것을 볼 수 있다.
이 범위의 개수는 최대 2N개이다.
범위를 구할 때는 투 포인터로 N을 기준 잡은 뒤, 양쪽으로 뻗어나가면 된다.

## ⏳ 회고
생각한 풀이는 투 포인터인데, 이걸 구현하려니까 머리가 너무 아프고 시간을 거의 한시간 썼는데도 구현을 못했음
그래서 위 방식대로 동작하도록 TreeSet을 사용함