### PR TITLE
[20250625] BOJ / P5 / 순열복원 / 권혁준

### DIFF
--- a/khj20006/202506/25 BOJ P5 순열복원.md
+++ b/khj20006/202506/25 BOJ P5 순열복원.md
@@ -1,0 +1,118 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+    BufferedReader br;
+    BufferedWriter bw;
+    StringTokenizer st;
+
+    public IOController() {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        st = new StringTokenizer("");
+    }
+
+    String nextLine() throws Exception {
+        String line = br.readLine();
+        st = new StringTokenizer(line);
+        return line;
+    }
+
+    String nextToken() throws Exception {
+        while (!st.hasMoreTokens()) nextLine();
+        return st.nextToken();
+    }
+
+    int nextInt() throws Exception {
+        return Integer.parseInt(nextToken());
+    }
+
+    long nextLong() throws Exception {
+        return Long.parseLong(nextToken());
+    }
+
+    double nextDouble() throws Exception {
+        return Double.parseDouble(nextToken());
+    }
+
+    void close() throws Exception {
+        bw.flush();
+        bw.close();
+    }
+
+    void write(String content) throws Exception {
+        bw.write(content);
+    }
+
+}
+
+public class Main {
+
+    static IOController io;
+
+    //
+
+    static int N;
+    static int[] A, seg;
+
+    public static void main(String[] args) throws Exception {
+
+        io = new IOController();
+
+        init();
+        solve();
+
+        io.close();
+
+    }
+
+    public static void init() throws Exception {
+
+        N = io.nextInt();
+        A = new int[N+1];
+        for(int i=1;i<=N;i++) A[i] = io.nextInt();
+        seg = new int[4*N];
+
+    }
+
+    static void solve() throws Exception {
+
+        init(1,N,1);
+        int[] ans = new int[N+1];
+        for(int i=N;i>=1;i--) {
+            int a = A[i];
+            int idx = find(1,N,a+1,1);
+            ans[idx] = i;
+        }
+        
+        for(int i=1;i<=N;i++) io.write(ans[i] + " ");
+
+    }
+    
+    static void init(int s, int e, int n) {
+        if(s == e) {
+            seg[n] = 1;
+            return;
+        }
+        int m=(s+e)>>1;
+        init(s,m,n*2);
+        init(m+1,e,n*2+1);
+        seg[n] = seg[n*2] + seg[n*2+1];
+    }
+    
+    static int find(int s, int e, int v, int n) {
+        if(s == e) {
+            seg[n]--;
+            return s;
+        }
+        int ret = -1;
+        int m = (s+e)>>1;
+        if(v > seg[n*2+1]) ret = find(s,m,v-seg[n*2+1],n*2);
+        else ret = find(m+1,e,v,n*2+1);
+        seg[n] = seg[n*2] + seg[n*2+1];
+        return ret;
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1777

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
Inversion sequence의 i번째 원소에는 순열에서 i보다 뒤에 나오면서 i보다 작은 수의 개수이다.
Inversion sequence가 주어지면, 원래의 순열을 구해보자.

## 🔍 풀이 방법
- 세그먼트 트리
---
수를 N부터 채워넣어보자.
N을 넣을 때는 Inversion sequence의 N번째 원소 S[N]에 따라서 N이 들어가는 위치가 결정된다.
오른쪽 끝에서부터 S[N]번째에 위치하게 된다.
N-1을 넣을 때는 이미 들어간 N을 제외하고, 오른쪽 끝에서부터 S[N-1]번째에 위치하게 된다.

...
이런 방식으로 구현을 시간 내에 하려면, 자연스럽게 구간 합을 빠르게 구할 방법이 필요해진다. -> 이 때 세그먼트 트리를 쓰면 된다.

## ⏳ 회고
Inversion은 국밥이 맞음