### PR TITLE
[20250628] BOJ / S1 / 스티커 / 설진영

### DIFF
--- a/Seol-JY/202506/28 BOJ S1 스티커.md
+++ b/Seol-JY/202506/28 BOJ S1 스티커.md
@@ -1,0 +1,42 @@
+```java
+import java.io.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        int T = Integer.parseInt(br.readLine());
+
+        while (T-- > 0) {
+            int n = Integer.parseInt(br.readLine());
+
+            int[][] sticker = new int[2][n + 1];
+            for (int i = 0; i < 2; i++) {
+                String[] line = br.readLine().split(" ");
+                for (int j = 1; j <= n; j++) {
+                    sticker[i][j] = Integer.parseInt(line[j - 1]);
+                }
+            }
+
+            int[][] dp = new int[2][n + 1];
+
+            dp[0][1] = sticker[0][1];
+            dp[1][1] = sticker[1][1];
+
+            for (int i = 2; i <= n; i++) {
+                dp[0][i] = Math.max(dp[1][i - 1], dp[1][i - 2]) + sticker[0][i];
+                dp[1][i] = Math.max(dp[0][i - 1], dp[0][i - 2]) + sticker[1][i];
+            }
+
+            int result = Math.max(dp[0][n], dp[1][n]);
+            bw.write(result + "\n");
+        }
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/9465

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
2행 N열로 구성된 스티커 배열이 주어진다.
인접한 스티커(상하좌우)는 동시에 뗄 수 없다.
각 스티커에는 점수가 있으며, 뗀 스티커의 점수를 합산한다.
최대 점수의 합을 구하라.

## 🔍 풀이 방법
dp[0][i] = max(dp[1][i - 1], dp[1][i - 2]) + sticker[0][i]
dp[1][i] = max(dp[0][i - 1], dp[0][i - 2]) + sticker[1][i]
점화식 사용

## ⏳ 회고
전형적인 DP 문제, 점화식만 잘 세우면 된다.