### PR TITLE
[20250629] BOJ / P3 / 시그마 시그마 시그마 시그마 / 권혁준

### DIFF
--- a/khj20006/202506/29 BOJ P3 시그마 시그마 시그마 시그마.md
+++ b/khj20006/202506/29 BOJ P3 시그마 시그마 시그마 시그마.md
@@ -1,0 +1,132 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+    BufferedReader br;
+    BufferedWriter bw;
+    StringTokenizer st;
+
+    public IOController() {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        st = new StringTokenizer("");
+    }
+
+    String nextLine() throws Exception {
+        String line = br.readLine();
+        st = new StringTokenizer(line);
+        return line;
+    }
+
+    String nextToken() throws Exception {
+        while (!st.hasMoreTokens()) nextLine();
+        return st.nextToken();
+    }
+
+    int nextInt() throws Exception {
+        return Integer.parseInt(nextToken());
+    }
+
+    long nextLong() throws Exception {
+        return Long.parseLong(nextToken());
+    }
+
+    double nextDouble() throws Exception {
+        return Double.parseDouble(nextToken());
+    }
+
+    void close() throws Exception {
+        bw.flush();
+        bw.close();
+    }
+
+    void write(String content) throws Exception {
+        bw.write(content);
+    }
+
+}
+
+class Segtree {
+    int size;
+    long[] seg;
+    Segtree(int size) {
+        this.size = size;
+        seg = new long[this.size*4];
+    }
+
+    void update(int s, int e, int i, int v, int n) {
+        if(s == e) {
+            seg[n] = v;
+            return;
+        }
+        int m = (s+e)>>1;
+        if(i <= m) update(s,m,i,v,n*2);
+        else update(m+1,e,i,v,n*2+1);
+        seg[n] = seg[n*2] + seg[n*2+1];
+    }
+
+    long find(int s, int e, int l, int r, int n) {
+        if(l>r || l>e || r<s) return 0;
+        if(l<=s && e<=r) return seg[n];
+        int m = (s+e)>>1;
+        return find(s,m,l,r,n*2) + find(m+1,e,l,r,n*2+1);
+    }
+
+}
+
+public class Main {
+
+    static IOController io;
+
+    //
+
+    static final long MOD = 998244353;
+
+    static int N;
+    static int[][] infos;
+    static Segtree left, right;
+
+    public static void main(String[] args) throws Exception {
+
+        io = new IOController();
+
+        init();
+        solve();
+
+        io.close();
+
+    }
+
+    public static void init() throws Exception {
+
+        N = io.nextInt();
+        infos = new int[N][];
+        for(int i=1;i<=N;i++){
+            int a = io.nextInt();
+            infos[i-1] = new int[]{a,i};
+        }
+        left = new Segtree(N);
+        right = new Segtree(N);
+
+    }
+
+    static void solve() throws Exception {
+
+        Arrays.sort(infos, (a,b) -> a[0]==b[0] ? b[1]-a[1] : a[0]-b[0]);
+
+        long ans = 0;
+        for(int[] info : infos) {
+            int val = info[0], idx = info[1];
+            long res1 = left.find(1,N,1,idx-1,1) % MOD * (N-idx+1) % MOD;
+            long res2 = right.find(1,N,idx+1,N,1) % MOD * idx % MOD;
+            ans = (ans + (res1 + res2) * val) % MOD;
+            left.update(1,N,idx,idx,1);
+            right.update(1,N,idx,N-idx+1,1);
+        }
+        io.write(ans + "\n");
+
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/27471

## 🧭 풀이 시간
35분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
길이 N인 수열 A에 대해, 다음 값을 998,244,353으로 나눈 나머지를 구해보자.
![image](https://github.com/user-attachments/assets/6f544ad3-9ae8-48a0-b397-105aa65c21ae)

## 🔍 풀이 방법
조합론적으로 접근해보면, 정답을 구할 때 각각의 원소가 몇 번 더해질까를 생각해볼 수 있다.
수열의 i번째 수 A[i]가 몇 번 더해지는지 구해보자.

당연히, A[i]보다 작거나 같은 수를 선택해야 A[i]가 정답에 더해질 수 있다.

A[i]의 왼쪽에 있으면서 더 작은 수들 A[j]에 대해, max(A[i], A[j])를 구하게 되는 경우의 수가 j * (N-i+1) 번 존재한다.
A[i]의 오른쪽에 있으면서 더 작은 수들 A[k]에 대해, max(A[i], A[k])를 구하게 되는 경우의 수가 i * (N-k+1) 번 존재한다.

따라서, A[i]가 더해지는 횟수는 (j * (N-i+1)의 합) + (i * (N-k+1)의 합) 이고,
A[i]가 정답에 영향을 미치는 정도는 A[i] * ((j * (N-i+1)의 합) + (i * (N-k+1)의 합)) 이다.

저 합을 빠르게 구하기 위해서, 세그먼트 트리를 두 개 사용했다.
각각 왼쪽 끝에서 떨어진 정도와, 오른쪽 끝에서 떨어진 정도를 구간 합 세그먼트 트리로 두었다.

## ⏳ 회고
최근 풀었던 문제들 중에 가장 재밌었음