### PR TITLE
[20250630] BOJ / G4 / 음식 평론가 / 김수연

### DIFF
--- a/suyeun84/202506/30 BOJ G4 음식 평론가.md
+++ b/suyeun84/202506/30 BOJ G4 음식 평론가.md
@@ -1,0 +1,25 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class boj1188 {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	
+	public static void main(String[] args) throws Exception {
+		nextLine();
+		int N = nextInt();
+		int M = nextInt();
+		
+		int div = M;
+		while(div > 0) {
+			int temp = N;
+			N = div;
+			div = temp % div;
+		}
+		System.out.println(M - N);
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1188
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
소시지 N개를 M명의 평론가에게 같은 양의 소시지를 주기 위해 필요한 최소 칼질 수 구하기
## 🔍 풀이 방법
M과 N의 최대공약수 구하고,
나눠줄 양이 최대공약수니까 평론가 수에서 빼면 정답임
## ⏳ 회고
방법만 생각해내면 쉽다