### PR TITLE
[20250701] BOJ / G4 / 수 나누기 게임 / 이강현

### DIFF
--- a/lkhyun/202507/1 BOJ G4 수 나누기 게임.md
+++ b/lkhyun/202507/1 BOJ G4 수 나누기 게임.md
@@ -1,0 +1,47 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main{
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N;
+    static int[] playerCard;
+    static int[] playerScore;
+    static boolean[] exist;
+    static HashMap<Integer,Integer> idx;
+
+    public static void main(String[] args) throws Exception{
+        N = Integer.parseInt(br.readLine());
+        playerScore = new int[N+1];
+        playerCard = new int[N+1];
+        exist = new boolean[1000001];
+        idx = new HashMap<>();
+        st = new StringTokenizer(br.readLine());
+
+        int max = 0;
+        for (int i = 1; i <= N; i++) {
+            playerCard[i] = Integer.parseInt(st.nextToken());
+            exist[playerCard[i]] = true;
+            idx.put(playerCard[i],i);
+            max = Math.max(max, playerCard[i]);
+        }
+
+        for (int i = 1; i <= N; i++) {
+            for(int j = playerCard[i]; j <= max; j+=playerCard[i]) {
+                if(exist[j]){
+                    playerScore[i]++;
+                    playerScore[idx.get(j)]--;
+                }
+            }
+        }
+        StringBuffer sb = new StringBuffer();
+        for (int i = 1; i <= N; i++) {
+            sb.append(playerScore[i]).append(" ");
+        }
+        bw.write(sb.toString());
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/27172
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
N명의 플레이어가 서로 다른 카드를 뽑고 그 카드로 1:1 대결을 함.
대결은 서로 나누었을 때, 상대를 나머지 없이 나눌 수 있으면 +1을 얻고 나누어진 상대는 -1의 점수를 가짐. 서로 나눌 수 없다면 점수 변화 x
모두 서로 한번씩 대결은 마쳤을 때, 모든 플레이어의 최종 점수를 출력.
## 🔍 풀이 방법
에라토스테네스의 체
## ⏳ 회고
N이 100000이라서 이분탐색을 생각했지만 가능은 하나, 이 방법이 더 효율적.