### PR TITLE
[20250702] BOJ / G3 / 소수의 연속합 / 이강현

### DIFF
--- a/lkhyun/202507/2 BOJ G3 소수의 연속합.md
+++ b/lkhyun/202507/2 BOJ G3 소수의 연속합.md
@@ -1,0 +1,46 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main{
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N;
+    static List<Integer> primes = new ArrayList<>();
+
+    public static void main(String[] args) throws Exception{
+        N = Integer.parseInt(br.readLine());
+        if(N == 1){
+            bw.write("0");
+            bw.close();
+            return;
+        }
+
+        loop: for (int i = 2; i <= N; i++) {
+            for (int j = 2; j*j <= i; j++) {
+                if(i%j == 0){
+                    continue loop;
+                }
+            }
+            primes.add(i);
+        }
+        int ans = 0;
+        int left = 0;
+        int sum = 0;
+        for (int right = left; right < primes.size(); right++) {
+            sum += primes.get(right);
+
+            while(sum > N && left <= right){
+                sum -= primes.get(left++);
+            }
+
+            if(sum == N){
+                ans++;
+            }
+        }
+        bw.write(ans +"");
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1644
## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
소수의 연속적인 합으로 N을 만들 수 있는지 확인하고 만들 수 있는 경우의 수를 출력
## 🔍 풀이 방법
에라토스테네스의 체, 투 포인터
## ⏳ 회고
투 포인터의 단조성에 대해 확실히 알게 됨.
각각의 포인터가 둘 중 하나만 한쪽 방향으로 가야 모든 경우를 탐색할 수 있다는 것