### PR TITLE
[20250702] BOJ / G4 / 카드 정렬하기 / 설진영

### DIFF
--- a/Seol-JY/202507/02 BOJ G4 카드 정렬하기.md
+++ b/Seol-JY/202507/02 BOJ G4 카드 정렬하기.md
@@ -1,0 +1,30 @@
+```java
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.util.PriorityQueue;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        PriorityQueue<Long> pq = new PriorityQueue<>();
+        for (int i = 0; i < n; i++) {
+            pq.add(Long.parseLong(br.readLine()));
+        }
+
+        long total = 0;
+        while (pq.size() > 1) {
+            long a = pq.poll();
+            long b = pq.poll();
+            long sum = a + b;
+            total += sum;
+            pq.add(sum);
+        }
+
+        System.out.println(total);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1715

## 🧭 풀이 시간
35분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
숫자 카드 묶음이 N개 주어지고,
카드 두 묶음을 합치려면, 각 묶음의 카드 수를 더한 만큼의 비교 작업이 필요
이걸 반복해서 모든 카드 묶음을 하나로 만들되, 비교 횟수의 총합이 최소가 되게 만드는 게 목표
 
## 🔍 풀이 방법
작은 묶음부터 합쳐야 비교 횟수가 작아진다는 것을 인지

모든 카드 묶음을 우선순위 큐에 넣음
큐에서 2개를 꺼내 합치고, 그 값을 누적 비교 횟수에 더하기
큐에 1개만 남을 때까지 반복

## ⏳ 회고
그리디+우선순위 문제