### PR TITLE
[20250705] BOJ / P5 / 대기업 승범이네 / 권혁준

### DIFF
--- a/khj20006/202507/05 BOJ P5 대기업 승범이네.md
+++ b/khj20006/202507/05 BOJ P5 대기업 승범이네.md
@@ -1,0 +1,104 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+    BufferedReader br;
+    BufferedWriter bw;
+    StringTokenizer st;
+
+    public IOController() {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        st = new StringTokenizer("");
+    }
+
+    String nextLine() throws Exception {
+        String line = br.readLine();
+        st = new StringTokenizer(line);
+        return line;
+    }
+
+    String nextToken() throws Exception {
+        while (!st.hasMoreTokens()) nextLine();
+        return st.nextToken();
+    }
+
+    int nextInt() throws Exception {
+        return Integer.parseInt(nextToken());
+    }
+
+    long nextLong() throws Exception {
+        return Long.parseLong(nextToken());
+    }
+
+    double nextDouble() throws Exception {
+        return Double.parseDouble(nextToken());
+    }
+
+    void close() throws Exception {
+        bw.flush();
+        bw.close();
+    }
+
+    void write(String content) throws Exception {
+        bw.write(content);
+    }
+
+}
+
+public class Main {
+
+    static IOController io;
+
+    //
+
+    static int N;
+    static int[] A;
+    static int[][] dp;
+    static List<Integer>[] V;
+
+    public static void main(String[] args) throws Exception {
+
+        io = new IOController();
+
+        init();
+        solve();
+
+        io.close();
+
+    }
+
+    public static void init() throws Exception {
+
+        N = io.nextInt();
+        A = new int[N+1];
+        V = new List[N+1];
+        for(int i=1;i<=N;i++) V[i] = new ArrayList<>();
+        for(int i=2;i<=N;i++) V[io.nextInt()].add(i);
+        for(int i=1;i<=N;i++) A[i] = io.nextInt();
+        dp = new int[N+1][2];
+
+    }
+
+    static void solve() throws Exception {
+
+        dfs(1);
+        io.write(Math.max(dp[1][0], dp[1][1]) + "\n");
+
+    }
+
+    static void dfs(int n) {
+        for(int i:V[n]) {
+            dfs(i);
+            dp[n][0] += Math.max(dp[i][0], dp[i][1]);
+        }
+        int max = Integer.MIN_VALUE;
+        for(int i:V[n]) {
+            max = Math.max(max, -Math.max(dp[i][0], dp[i][1]) + dp[i][0] + A[i] * A[n]);
+        }
+        dp[n][1] = dp[n][0] + max;
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17831

## 🧭 풀이 시간
15분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
정점이 N개인 트리가 있다. 정점에 가중치가 있다.
부모-자식 관계로 멘토링을 형성할 수 있는데, 이 때 시너지의 값은 (부모 가중치) * (자식 가중치)이다.
한 정점은 하나의 멘토링에만 포함될 수 있을 때, 전체 시너지의 합을 최대화 해보자.

## 🔍 풀이 방법
- 트리 DP
---
두 종류의 DP를 준비한다.
dp1[n] = n번 정점을 루트로 하는 서브트리 내에서, n번 정점이 어떤 멘토링에도 포함되지 않는 경우의 최대 시너지 합 
dp2[n] = n번 정점을 루트로 하는 서브트리 내에서, n번 정점이 누군가의 멘토인 경우의 최대 시너지 합

n의 자식들을 i라고 하면,
$dp1[n] = \sum{ \max(dp1[i], dp2[i])}$
$dp2[n] = dp1[n] + \max(dp[i][0] + A[i] * A[n] - \max(dp[i][0], dp[i][1]))$
이 성립한다.

## ⏳ 회고
난이도 기여 의견을 보니 2*n 타일 채우기 문제랑 비슷하다는데, 잘 모르겠다..