### PR TITLE
[20250704] BOJ / G5 / 용액 / 설진영

### DIFF
--- a/Seol-JY/202507/4 BOJ G5 용액.md
+++ b/Seol-JY/202507/4 BOJ G5 용액.md
@@ -1,0 +1,40 @@
+```java
+import java.io.*;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int n = Integer.parseInt(br.readLine());
+		
+		long[] arr = new long[n];
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		for(int i = 0; i < n; i++) {
+			arr[i] = Long.parseLong(st.nextToken());
+		}
+		
+		int left = 0;
+		int right = n - 1;
+		int ml = 0, mr = 0;
+		long min = Long.MAX_VALUE;
+		
+        while(left < right) {
+			long sum = arr[left]+arr[right];
+			if(min > Math.abs(sum)) {
+				min = Math.abs(sum);
+				ml = left; mr = right;
+			}
+			
+            if(sum >= 0) {
+				right --;	
+			} else {
+				left ++;
+			}
+		}
+        
+		System.out.println(arr[ml] + " " + arr[mr]);
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2467

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
N개의 용액이 주어지며, 각 용액은 산성(양수) 또는 알칼리성(음수)
두 용액을 섞어 특성값의 합이 0에 가장 가까운 조합을 찾기
입력은 오름차순으로 정렬되어 주어짐
같은 용액을 두 번 사용할 수는 없음

## 🔍 풀이 방법
왼쪽 포인터는 맨 처음 (가장 작은 값), 오른쪽 포인터는 맨 끝 (가장 큰 값)에서 시작
두 값을 더해서 0에 가까운지 확인
절댓값 기준 가장 작은 합이 나올 때마다 결과 갱신

## ⏳ 회고
정수 범위 큰거 확인,  -> 이분탐색이나 투포인터
입력이 정렬되어 있다는 점을 보고 투 포인터로 접근할 수 있었음