### PR TITLE
[20250707] BOJ / G2 / 1의 개수 세기 / 이강현

### DIFF
--- a/lkhyun/202507/7 BOJ G2 1의 개수 세기.md
+++ b/lkhyun/202507/7 BOJ G2 1의 개수 세기.md
@@ -1,0 +1,42 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main{
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    public static void main(String[] args) throws Exception{
+        st = new StringTokenizer(br.readLine());
+        long A = Long.parseLong(st.nextToken());
+        long B = Long.parseLong(st.nextToken());
+        long total = countOnes(B) - countOnes(A-1);
+        bw.write(String.valueOf(total));
+        bw.close();
+    }
+    public static long countOnes(long N) {
+        long result = 0;
+
+        // 첫번째 비트: 0,1,0,1,0,1,0,1 -> 주기 2
+        // 두번째 비트: 0,0,1,1,0,0,1,1 -> 주기 4
+        // 세번째 비트: 0,0,0,0,1,1,1,1 -> 주기 8
+        // ...
+        for (int i = 0; i < 60; i++) {
+            long bitPosition = 1L << i; // 한 주기에 있는 1의 개수
+
+            long cycle = 2L * bitPosition; // 주기 구하기, 규칙을 보면 주기의 앞쪽 반절은 0, 뒤쪽 반절은 1임.
+
+            long cycles = (N + 1) / cycle; //0부터 N까지 cycle 개수, 0부터니까 N+1로 구하기
+
+            result += cycles * bitPosition; // 주기 x 한 주기에 있는 1의 개수 = 총 1의 개수
+
+            long remainder = (N + 1) % cycle; // 나머지 구하기
+            if (remainder > bitPosition) { // 나머지가 주기의 반절보다 크면 넘어선 만큼 더 더해줌.
+                result += remainder - bitPosition;
+            }
+        }
+
+        return result;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/9527
## 🧭 풀이 시간
120분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
자연수 A 부터 B 사이에 있는 모든 수를 이진수로 나타냈을 때, 생길 수 있는 1의 개수를 모두 구하기
## 🔍 풀이 방법
분할 정복, 수의 주기성
첫번째 비트: 0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1 -> 주기 2
두번째 비트: 0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1 -> 주기 4
세번째 비트: 0,0,0,0,1,1,1,1,0,0,0,0,1,1,1,1 -> 주기 8
네번째 비트: 0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1 -> 주기 16
...
비트마다 주기성을 가지고 또 하나의 주기에서 앞쪽 반절은 0, 뒤쪽 반절은 1이므로
0부터 B까지 얻을 수 있는 1의 개수를 계산하고 거기에 0부터 A-1까지의 1의 개수를 구한 것을 빼면 정답을 얻을 수 있다.
## ⏳ 회고
비트 단위로 쪼갤 생각을 못했다.
기존에는 0 ~ 1, 10 ~ 11, 100 ~ 111 이런식으로 구간을 나누어서 혼란스러웠는데
좋은 풀이였던 것 같다.