### PR TITLE
[20250708] BOJ / G2 / 공항 / 이강현

### DIFF
--- a/lkhyun/202507/8 BOJ G2 공항.md
+++ b/lkhyun/202507/8 BOJ G2 공항.md
@@ -1,0 +1,42 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main{
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static int G,P;
+    static int[] nextBlank;
+    static int count = 0;
+    public static void main(String[] args) throws Exception{
+        G = Integer.parseInt(br.readLine());
+        P = Integer.parseInt(br.readLine());
+        nextBlank = new int[G+1]; //빈 공간 가리키기
+        
+        for (int i = 1; i <= G; i++) {
+            nextBlank[i] = i;
+        }
+
+        for (int i = 1; i <= P; i++) {
+            int gi = Integer.parseInt(br.readLine());
+            int blank = find(gi); //빈 공간 찾기
+            if(blank == 0){
+                break;
+            }else{
+                count++;
+                nextBlank[blank] = nextBlank[blank-1];
+            }
+        }
+        
+        bw.write(String.valueOf(count));
+        bw.close();
+    }
+    static int find(int gi){
+        if(nextBlank[gi] == gi){
+            return gi;
+        }else{
+            return nextBlank[gi] = find(nextBlank[gi]);
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/10775
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
G개의 게이트에 P개의 비행기를 도킹하려함.
비행기들은 들어올때 gi라는 값을 가지고 들어오는데 이때, gi는 1부터 gi 사이의 게이트에 해당 비행기를 도킹한다는 의미임.
최대한 많은 비행기를 도킹하려고 함.
비행기를 도킹할 수 없으면 현재까지 도킹한 비행기의 수를 출력.
## 🔍 풀이 방법
그리디, 분리 집합
nextBlank[i] = 1부터 i까지의 게이트 중 가장 큰 번호를 가진 빈 게이트
비행기를 도킹시킨 두 게이트들이 인접하게 되면 작은 번호가 가리키는 빈 게이트를 큰 번호도 가리키게 함.
## ⏳ 회고
늘 같은 방식으로 union-find를 진행했는데, merge를 함에 있어서 이번 문제는 확실하게 더 작은 번호가 가리키는 빈 게이트를 큰 번호가 가리키지 않으면 풀리지 않는 문제였다.
또한 find를 할때 재귀적으로 Root를 가리키게끔 세팅하지 않으면 시간 복잡도 문제가 발생하므로 꼭 최적화가 필요한 문제였다.