### PR TITLE
[20250708] BOJ / G4 / 오큰수 / 설진영

### DIFF
--- a/Seol-JY/202507/08 BOJ G4 오큰수.md
+++ b/Seol-JY/202507/08 BOJ G4 오큰수.md
@@ -1,0 +1,32 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        int N = Integer.parseInt(br.readLine());
+        int[] arr = new int[N];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) arr[i] = Integer.parseInt(st.nextToken());
+
+        int[] ans = new int[N];
+        Arrays.fill(ans, -1);
+
+        Deque<Integer> stack = new ArrayDeque<>();
+        for (int i = 0; i < N; i++) {
+            while (!stack.isEmpty() && arr[stack.peek()] < arr[i]) {
+                ans[stack.pop()] = arr[i];
+            }
+            stack.push(i);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int x : ans) sb.append(x).append(' ');
+        bw.write(sb.toString().trim());
+        bw.flush();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17298

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
수열의 각 원소에 대해 오른쪽에서 가장 가까운 더 큰 수(오큰수)를 찾는 문제. 해당하는 수가 없으면 -1 출력

## 🔍 풀이 방법
스택에 인덱스를 저장하여 아직 오큰수를 찾지 못한 원소 관리

## ⏳ 회고
스택에 인덱스 저장해서 푸느게 핵심