### PR TITLE
[20250710] BOJ / G5 / 용액 / 신동윤

### DIFF
--- a/03do-new30/202507/10 BOJ G5 용액.md
+++ b/03do-new30/202507/10 BOJ G5 용액.md
@@ -1,0 +1,35 @@
+```java
+import java.util.*;
+import java.io.*;
+public class Main {
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        int[] arr = new int[N];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int left = 0, leftIdx = 0;
+        int right = N-1, rightIdx = N-1;
+        int min = 2_000_000_000;
+        while (leftIdx < rightIdx && min > 0) {
+            int current = arr[leftIdx] + arr[rightIdx];
+            if (Math.abs(current) < min) {
+                left = leftIdx;
+                right = rightIdx;
+                min = Math.abs(current);
+            }
+
+            if (current < 0) {
+                leftIdx++;
+            } else {
+                rightIdx--;
+            }
+        }
+        System.out.println(arr[left] + " " + arr[right]);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2467

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
- 같은 양의 두 용액을 혼합한 용액의 특성값은 혼합에 사용된 각 용액의 특성값의 합이다.
- 각 용액의 특성값이 정렬된 순서로 주어졌을 때, 가장 0에 가깝게 만들 수 있는 두 용액의 특성값을 출력한다.

## 🔍 풀이 방법
- 투포인터
- 현재 혼합값의 절댓값이 최소값보다 작으면 정답 갱신
- 혼합값이 음수라면 더 큰 값을 섞어야 0에 가까워지므로 좌측 포인터 이동

## ⏳ 회고
- 오랜만에 풀어서 모든 것이 어색하다. 재활 열심히...