### PR TITLE
[20250710] BOJ / G2 / 벽 부수고 이동하기 4 / 이강현

### DIFF
--- a/lkhyun/202507/10 BOJ G2 벽 부수고 이동하기 4.md
+++ b/lkhyun/202507/10 BOJ G2 벽 부수고 이동하기 4.md
@@ -1,0 +1,103 @@
+```java
+import java.util.*;
+import java.io.*;
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N,M;
+    static int[][] matrix;
+    static Map<String,String> parent;
+    static Map<String,Integer> dp;
+    static int[] di = {0,0,-1,1};
+    static int[] dj = {-1,1,0,0};
+
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        matrix = new int[N][M];
+
+        for (int i = 0; i < N; i++) {
+            String line = br.readLine();
+            for (int j = 0; j < M; j++) {
+                matrix[i][j] = line.charAt(j) - '0';
+            }
+        }
+
+        // 모여있는 0들 찾기
+        parent = new HashMap<>();
+        dp = new HashMap<>();
+        boolean[][] visited = new boolean[N][M];
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                if(matrix[i][j] == 0 && !visited[i][j]){
+                    BFS(i,j,visited);
+                }
+            }
+        }
+
+        //1인 곳마다 인접하고 있는 0 그룹들 더해주기
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                if(matrix[i][j] == 1){
+                    List<String> added = new ArrayList<>();
+                    for (int k = 0; k < 4; k++) {
+                        int ni = i + di[k];
+                        int nj = j + dj[k];
+                        if(ni<0 || ni>=N || nj<0 || nj>=M) continue;
+                        if(matrix[ni][nj] == 0){
+                            String cur = ni+" "+nj;
+                            String root = parent.get(cur);
+                            if(added.contains(root)) continue;
+                            matrix[i][j] += dp.get(root);
+                            added.add(root);
+                        }
+                    }
+                    if(matrix[i][j] % 10 != 0){
+                        sb.append(matrix[i][j]%10);
+                    }else{
+                        sb.append("0");
+                    }
+                }else{
+                    sb.append("0");
+                }
+            }
+            sb.append('\n');
+        }
+        bw.write(sb.toString());
+        bw.close();
+    }
+    static void BFS(int i, int j, boolean[][] visited){
+        ArrayDeque<int[]> q = new ArrayDeque<>();
+        q.add(new int[]{i,j});
+        visited[i][j] = true;
+
+        String start = i+" "+j;
+        int cnt = 0;
+
+        parent.put(start,start);
+
+        while(!q.isEmpty()){
+            int[] cur = q.poll();
+            cnt++;
+
+            for (int k = 0; k < 4; k++) {
+                int ni = cur[0] + di[k];
+                int nj = cur[1] + dj[k];
+
+                if(ni<0 || ni>=N || nj<0 || nj>=M || visited[ni][nj]) continue;
+
+                if(matrix[ni][nj] == 0){
+                    visited[ni][nj] = true;
+                    parent.put(ni+" "+nj, start);
+                    q.add(new int[]{ni,nj});
+                }
+            }
+        }
+        dp.put(start,cnt);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16946
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
M x N의 공간에서 벽은 1, 빈 공간은 0임.
모든 벽에서 갈 수 있는 칸의 수를 구하고 이를 출력.
## 🔍 풀이 방법
BFS
0이 모여있는 공간을 대표하는 i,j 값을 설정하고 나머지 i,j들은 대표하는 i,j를 가리키도록 하는 맵 하나와
공간의 대표 i,j로 저장된 그 내부의 0들의 수를 저장하는 맵을 사용함.
모든 1을 순회하며 상하좌우에서 뭉쳐있는 0들과 인접한 경우 그 공간에 있는 0들의 값을 더해줌.
## ⏳ 회고
벽에서 이동할 수 있는 칸을 10으로 나눈 나머지를 출력해야하는데, 이걸 단순히 모듈러 연산하면
순회하면서 0일때 들어가는 조건문과 겹치게 됨.
최대 1000x1000이므로 하나의 벽이 가질 수 있는 최대값은 int 변수에 충분히 담을 수 있으므로 모듈러 연산은 마지막 출력때 진행해야함.
