### PR TITLE
[20250710] BOJ / P4 / 불 끄기 / 설진영

### DIFF
--- a/Seol-JY/202507/10 BOJ P4 불 끄기.md
+++ b/Seol-JY/202507/10 BOJ P4 불 끄기.md
@@ -1,0 +1,64 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main {
+    static int[] map = new int[10];
+    static int sum;
+    static int minToggle = Integer.MAX_VALUE;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        for (int i = 0; i < 10; i++) {
+            String input = br.readLine();
+            for (int j = 0; j < 10; j++) {
+                if (input.charAt(j) == 'O') {
+                    map[i] |= (1 << j);
+                }
+            }
+        }
+
+        for (int firstRow = 0; firstRow < (1 << 10); firstRow++) {
+            int[] tempMap = map.clone();
+            int toggleCount = 0;
+            
+            for (int j = 0; j < 10; j++) {
+                if (isLightOn(firstRow, j)) {
+                    toggle(tempMap, 0, j);
+                    toggleCount++;
+                }
+            }
+            
+            for (int i = 1; i < 10; i++) {
+                for (int j = 0; j < 10; j++) {
+                    if (isLightOn(tempMap[i - 1], j)) {
+                        toggle(tempMap, i, j);
+                        toggleCount++;
+                    }
+                }
+            }
+            
+            if (tempMap[9] == 0) {
+                minToggle = Math.min(minToggle, toggleCount);
+            }
+        }
+        
+        System.out.println(minToggle == Integer.MAX_VALUE ? -1 : minToggle);
+    }
+
+    static boolean isLightOn(int row, int col) {
+        return (row & (1 << col)) != 0;
+    }
+
+    static void toggle(int[] map, int x, int y) {
+        map[x] ^= (1 << y);
+        
+        if (x > 0) map[x - 1] ^= (1 << y);
+        if (x < 9) map[x + 1] ^= (1 << y);
+        if (y > 0) map[x] ^= (1 << (y - 1));
+        if (y < 9) map[x] ^= (1 << (y + 1));
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14939

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
10x10 개의 전구가 있고, 전구 토글하면 인접 전구들도 같이 토글됨.
전구를 모두 끄기 위한 최소 토글 횟수 구하기, 불가능하면 -1 출력

## 🔍 풀이 방법
100개를 모두 비트로 관리할 수 는 없으니 크기 10의 배열에 각 행에 대한 비트를 저장해서 해결
첫 행은 부분집합으로 토글 여부를 결정하고,

두번째 행부터는 직전 행이 켜져있는 것들만 현재 행의 같은 열만 모두 토글하는 방식으로 해결
i) 직전 행이 켜진 경우, 현재 행에서 토글해서 꺼주지 않으면 계속 켜져있는 상태로 유지될 수 밖에 없음.
ii) 현재 행에서 조건 이외의 전구를 토글하게 되면 직전 행의 전구가 다시 켜지게 되는데, 이를 다시 끌 수는 없기 때문에 토글하여서는 안됨

마지막 행까지 왔다는 것은, 마지막 행의 직전 행 이외에는 모두 꺼져있음이 보장되므로, 전체 순회 없이 마지막 행을 확인하는 것 만으로 전구가 모두 꺼졌는지의 여부를 알 수 있음

## ⏳ 회고
알고리즘 뭐 써야 하는지 보고 풀긴함
플레까지 갈 문제는 아닌듯