### PR TITLE
[20250711] BOJ / D4 / 히스토그램 하나 빼기 / 권혁준

### DIFF
--- a/khj20006/202507/11 BOJ D4 히스토그램 하나 빼기.md
+++ b/khj20006/202507/11 BOJ D4 히스토그램 하나 빼기.md
@@ -1,0 +1,406 @@
+# C++
+
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+using ll = long long;
+
+int N, s[500001]{}, e[500001]{}, l[500001]{}, r[500001]{};
+ll h[500001]{}, v[500001]{}, ans[500001]{};
+
+ll seg[1048576]{};
+
+class DisjointSet {
+	public:
+	int r[500001]{};
+	DisjointSet() {
+		for(int i=1;i<=500000;i++) r[i] = i;
+	}
+	int f(int x) {return x==r[x] ? x : r[x]=f(r[x]);}
+	void uni(int a, int b) {
+		int x = f(a), y = f(b);
+		if(x == y) return;
+		r[x] = y;
+	}
+};
+
+DisjointSet le, ri;
+
+void prop(int s, int e, int n){
+	if(seg[n]) {
+		if(s != e) {
+			seg[n*2] = max(seg[n*2], seg[n]);
+			seg[n*2+1] = max(seg[n*2+1], seg[n]);
+			seg[n] = 0;
+		}
+	}
+}
+
+void upt(int s, int e, int l, int r, ll v, int n) {
+	prop(s, e, n);
+	if (l > r || l > e || r < s) return;
+	if (l <= s && e <= r) {
+		seg[n] = max(seg[n], v);
+		if(s != e) {
+			seg[n*2] = max(seg[n*2], v);
+			seg[n*2+1] = max(seg[n*2+1], v);
+		}
+		return;
+	}
+	int m = (s + e) >> 1;
+	upt(s, m, l, r, v, n * 2);
+	upt(m + 1, e, l, r, v, n * 2 + 1);
+}
+
+ll find(int s, int e, int i, int n) {
+	prop(s,e,n);
+	if(s == e) return seg[n];
+	int m = (s+e)>>1;
+	if(i <= m) return find(s,m,i,n*2);
+	return find(m+1,e,i,n*2+1);
+}
+
+int main(){
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin>>N;
+	for(int i=1;i<=N;i++) {
+		s[i] = i;
+		e[i] = i;
+		cin>>h[i];
+	}
+	
+	stack<pair<int, int>> s1;
+	for(int i=N;i>=1;i--) {
+		while(!s1.empty() && s1.top().first > h[i]) {
+			int x = s1.top().second;
+			l[x] = i;
+			s1.pop();
+		}
+		s1.push({h[i],i});
+	}
+	
+	stack<pair<int, int>> s2;
+	for(int i=1;i<=N;i++) {
+		while(!s2.empty() && s2.top().first > h[i]) {
+			int x = s2.top().second;
+			r[x] = i;
+			s2.pop();
+		}
+		s2.push({h[i],i});
+	}
+
+	vector<pair<ll,ll>> infos;
+	for(int i=1;i<=N;i++) infos.push_back({h[i],i});
+	sort(infos.begin(), infos.end(), [](auto a, auto b) -> bool {
+		return a.first == b.first ? a.second < b.second : a.first > b.first;
+	});
+
+	bitset<500001> vis;
+
+	for(int x=0;x<N;) {
+		ll height = infos[x].first;
+		vector<pair<ll,ll>> li;
+		while(x<N && height == infos[x].first) {
+			int idx = infos[x].second;
+			vis[idx] = 1;
+			li.push_back(infos[x++]);
+			if(idx>1 && vis[idx-1]) {
+				le.uni(idx, idx-1);
+				ri.uni(idx-1, idx);
+			}
+			if(idx<N && vis[idx+1]) {
+				le.uni(idx+1, idx);
+				ri.uni(idx, idx+1);
+			}
+		}
+
+		for(auto [_,idx] : li) {
+			if(idx>1 && vis[idx-1]) s[idx] = le.f(idx-1);
+			else s[idx] = idx;
+
+			if(idx<N && vis[idx+1]) e[idx] = ri.f(idx+1);
+			else e[idx] = idx;
+
+			v[idx] = height * (e[idx] - s[idx] + 1);
+
+			upt(1,N,s[idx],idx-1,v[idx]-h[idx],1);
+			upt(1,N,idx+1,e[idx],v[idx]-h[idx],1);
+			upt(1,N,1,s[idx]-1,v[idx],1);
+			upt(1,N,e[idx]+1,N,v[idx],1);
+
+			if(l[idx]) {
+				int L = 0;
+				if(l[idx]>1 && vis[l[idx]-1]) L = le.f(l[idx]-1);
+				else L = l[idx];
+				ans[l[idx]] = max(ans[l[idx]], h[idx] * (e[idx] - L));
+			}
+
+			if(r[idx]) {
+				int R = 0;
+				if(r[idx]<N && vis[r[idx]+1]) R = ri.f(r[idx]+1);
+				else R = r[idx];
+				ans[r[idx]] = max(ans[r[idx]], h[idx] * (R - s[idx]));
+			}
+		}
+	}
+
+	for(int i=1;i<=N;i++) {
+		ans[i] = max(ans[i], find(1,N,i,1));
+		if(h[i] == h[i-1] && ans[i] < ans[i-1]) ans[i] = ans[i-1];
+		cout<<ans[i]<<' ';
+	}
+
+}
+```
+
+# JAVA
+
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+    BufferedReader br;
+    BufferedWriter bw;
+    StringTokenizer st;
+
+    public IOController() {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        st = new StringTokenizer("");
+    }
+
+    String nextLine() throws Exception {
+        String line = br.readLine();
+        st = new StringTokenizer(line);
+        return line;
+    }
+
+    String nextToken() throws Exception {
+        while (!st.hasMoreTokens()) nextLine();
+        return st.nextToken();
+    }
+
+    int nextInt() throws Exception {
+        return Integer.parseInt(nextToken());
+    }
+
+    long nextLong() throws Exception {
+        return Long.parseLong(nextToken());
+    }
+
+    double nextDouble() throws Exception {
+        return Double.parseDouble(nextToken());
+    }
+
+    void close() throws Exception {
+        bw.flush();
+        bw.close();
+    }
+
+    void write(String content) throws Exception {
+        bw.write(content);
+    }
+
+}
+
+class DisjointSet {
+    int[] r;
+
+    DisjointSet(int size) {
+        r = new int[size + 1];
+        for (int i = 1; i <= size; i++) r[i] = i;
+    }
+
+    int find(int x) {
+        return x == r[x] ? x : (r[x] = find(r[x]));
+    }
+
+    // a를 b에 붙임
+    void union(int a, int b) {
+        int x = find(a), y = find(b);
+        if (x == y) return;
+        r[x] = y;
+    }
+
+}
+
+class SegTree {
+    long[] tree;
+
+    SegTree(int size) {
+        tree = new long[size * 4];
+    }
+
+    void propagation(int s, int e, int n) {
+        if(tree[n] != 0) {
+            if(s != e) {
+                tree[n*2] = Math.max(tree[n*2], tree[n]);
+                tree[n*2+1] = Math.max(tree[n*2+1], tree[n]);
+                tree[n] = 0;
+            }
+        }
+    }
+
+    void update(int s, int e, int l, int r, long v, int n) {
+        propagation(s, e, n);
+        if (l > r || l > e || r < s) return;
+        if (l <= s && e <= r) {
+            tree[n] = Math.max(tree[n], v);
+            if(s != e) {
+                tree[n*2] = Math.max(tree[n*2], v);
+                tree[n*2+1] = Math.max(tree[n*2+1], v);
+            }
+            return;
+        }
+        int m = (s + e) >> 1;
+        update(s, m, l, r, v, n * 2);
+        update(m + 1, e, l, r, v, n * 2 + 1);
+    }
+
+    long find(int s, int e, int i, int n) {
+        propagation(s, e, n);
+        if(s == e) return tree[n];
+        int m = (s+e)>>1;
+        if(i <= m) return find(s,m,i,n*2);
+        return find(m+1,e,i,n*2+1);
+    }
+
+}
+
+public class Main {
+
+    static IOController io;
+
+    //
+
+    static int N;
+    static int[] s, e, l, r;
+    static long[] h, v, ans;
+    static DisjointSet left, right;
+    static SegTree seg;
+
+    public static void main(String[] args) throws Exception {
+
+        io = new IOController();
+
+        init();
+        solve();
+
+        io.close();
+    }
+
+    public static void init() throws Exception {
+
+        N = io.nextInt();
+        left = new DisjointSet(N + 1);
+        right = new DisjointSet(N + 1);
+        s = new int[N + 1];
+        e = new int[N + 1];
+        h = new long[N + 1];
+        for (int i = 1; i <= N; i++) {
+            h[i] = io.nextLong();
+            s[i] = i;
+            e[i] = i;
+        }
+        l = new int[N + 1];
+        r = new int[N + 1];
+        v = new long[N + 1];
+        ans = new long[N+1];
+        seg = new SegTree(N);
+
+    }
+
+    static void solve() throws Exception {
+
+        // 정보 정렬 후 분리 집합으로 v, s, e 구하기
+        // 이 때, lazy등으로 max갱신까지 같이 할 수 있으면 하기
+
+        // l 구하기
+        Stack<int[]> s1 = new Stack<>();
+        for(int i=N;i>=1;i--) {
+            while(!s1.isEmpty() && s1.peek()[0] > h[i]) l[s1.pop()[1]] = i;
+            s1.push(new int[]{(int)h[i], i});
+        }
+
+        // r 구하기
+        Stack<int[]> s2 = new Stack<>();
+        for(int i=1;i<=N;i++) {
+            while(!s2.isEmpty() && s2.peek()[0] > h[i]) r[s2.pop()[1]] = i;
+            s2.push(new int[]{(int)h[i], i});
+        }
+
+        long[][] infos = new long[N][2];
+        for (int i = 1; i <= N; i++) infos[i - 1] = new long[]{h[i], i};
+        Arrays.sort(infos, (a, b) -> a[0] == b[0] ? Long.compare(a[1], b[1]) : Long.compare(b[0], a[0]));
+
+        boolean[] vis = new boolean[N+1];
+
+        for(int x=0;x<N;) {
+            long height = infos[x][0];
+            List<long[]> list = new ArrayList<>();
+            while(x<N && height==infos[x][0]) {
+                int idx = (int)infos[x][1];
+                vis[idx] = true;
+                list.add(infos[x++]);
+                if(idx>1 && vis[idx-1]) {
+                    left.union(idx, idx-1);
+                    right.union(idx-1, idx);
+                }
+                if(idx<N && vis[idx+1]) {
+                    left.union(idx+1, idx);
+                    right.union(idx, idx+1);
+                }
+            }
+
+            // 여기부터
+
+            for(long[] info:list) {
+                int idx = (int)info[1];
+
+                if(idx>1 && vis[idx-1]) {
+                    s[idx] = left.find(idx-1);
+                }
+                else s[idx] = idx;
+
+                if(idx<N && vis[idx+1]) {
+                    e[idx] = right.find(idx+1);
+                }
+                else e[idx] = idx;
+
+                v[idx] = height * (e[idx] - s[idx] + 1);
+
+                seg.update(1, N, s[idx], idx-1, v[idx]-h[idx], 1);
+                seg.update(1, N, idx+1, e[idx], v[idx]-h[idx], 1);
+
+                seg.update(1, N, 1, s[idx]-1, v[idx], 1);
+                seg.update(1, N, e[idx]+1, N, v[idx], 1);
+
+                if(l[idx] != 0) {
+                    int L = 0;
+                    if(l[idx]>1 && vis[l[idx]-1]) L = left.find(l[idx]-1);
+                    else L = l[idx];
+                    ans[l[idx]] = Math.max(ans[l[idx]], h[idx] * (e[idx] - L));
+                }
+
+                if(r[idx] != 0) {
+                    int R = 0;
+                    if(r[idx]<N && vis[r[idx]+1]) R = right.find(r[idx]+1);
+                    else R = r[idx];
+                    ans[r[idx]] = Math.max(ans[r[idx]], h[idx] * (R - s[idx]));
+                }
+            }
+
+        }
+
+        for(int i=1;i<=N;i++) {
+            ans[i] = Math.max(ans[i], seg.find(1,N,i,1));
+            if(h[i] == h[i-1] && ans[i] < ans[i-1]) ans[i] = ans[i-1];
+            io.write(ans[i] + " ");
+        }
+
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/25611

## 🧭 풀이 시간
150분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
높이가 각각 H[i]인, N개의 막대로 이루어진 히스토그램이 있다.
S[i]를 i번째 막대를 제외하고 이어붙인 히스토그램에서의 최대 직사각형 넓이라고 할 때,
1 <= i <= N에 대해 S[i]를 모두 구해보자.

## 🔍 풀이 방법
- 세그먼트 트리
- 분리 집합
---
여기서 막대를 제외시키는 작업이 없다면, 그냥 <a href="https://www.acmicpc.net/problem/1725">히스토그램 문제</a>가 된다.
이 문제를 푸는 방법은 `세그먼트 트리`, `스택`, `분할 정복` 등등 다양한 풀이가 존재하지만, `분리 집합`을 이용한 풀이도 존재한다.

분리 집합으로 히스토그램 문제를 푸는 방법은 간략하게, 
높은 막대부터 히스토그램에 차례로 추가시키며 좌우로 이미 추가된 막대들과 분리 집합으로 이어주는 것이다.

여기서 i번째 막대를 추가시킬 때, 양옆으로 이어진 막대들은 모두 i번째 막대보다 높이가 높거나 같다는 것을 이용한다.

그러면, i번째 막대를 뺐을 때 좌, 우에 있는 연결된 모든 막대들에 대해, (i번째 막대를 포함하는 최대 직사각형) - H[i]라는 값이 답의 후보가 될 수 있다.
또, i번째 막대와 연결되지 않은 다른 모든 막대들에 대해, (i번째 막대를 포함하는 최대 직사각형)이 답의 후보가 될 수 있다.

이처럼 여러 구간에 대해 max연산을 수행해서 정답을 갱신해야 하는데, 이를 깡으로 구현하면 시간 초과이기 때문에 max를 관리하는 `세그먼트 트리`를 사용한다.

이 외에도 정답이 될 수 있는 경우의 수가 존재한다.
i번째 막대를 기준으로, 좌 우에 있는 막대 중 처음으로 H[i]보다 높이가 낮은 막대를 각각 L, R이라고 해보자.
그러면 L번째 막대가 사라졌을 때, L의 좌측으로 연결된 끝부터 i의 우측으로 연결된 끝까지가 모두 H[i] 높이를 수용할 수 있는 형태가 된다. 따라서, S[L]의 값도 갱신시킬 수 있다.

같은 논리로 R번째 막대가 사라졌을 때, R의 우측으로 연결된 끝지점부터 i의 왼쪽으로 연결된 끝까지가 모두 H[i]를 수용할 수 있다.

각 막대에 대한 L, R을 구할 때는 <a href="https://www.acmicpc.net/problem/17298">오큰수</a> 문제처럼 스택으로 구할 수 있다.

이렇게 모든 조건을 다 고려해서 갱신을 마친 뒤 정답을 구해줬다.

## ⏳ 회고
자바로 다 짜놨는데 시간 초과가 떴다.
자바가 느려서 그렇겠거니 하고 C++로 다시 짜니까 맞음