### PR TITLE
[20250711] BOJ / G4 / 토너먼트 만들기 / 김수연

### DIFF
--- a/suyeun84/202507/11 BOJ G4 토너먼트 만들기.md
+++ b/suyeun84/202507/11 BOJ G4 토너먼트 만들기.md
@@ -1,0 +1,45 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class boj2262 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+    static int nextInt() {return Integer.parseInt(st.nextToken());}
+
+    public static void main(String[] args) throws Exception {
+        nextLine();
+        int n = nextInt();
+        nextLine();
+        List<Integer> rank = new ArrayList<>();
+        for (int i = 0; i < n; i++) rank.add(nextInt());
+        int answer = 0;
+        while (rank.size() > 1) {
+            int max = -1;
+            int idx = -1;
+
+            for (int i = 0; i < rank.size(); i++) {
+                if (rank.get(i) > max) {
+                    max = rank.get(i);
+                    idx = i;
+                }
+            }
+
+            int diff;
+            if (idx == 0) diff = Math.abs(rank.get(idx) - rank.get(idx + 1));
+            else if (idx == rank.size() - 1) diff = Math.abs(rank.get(idx) - rank.get(idx - 1));
+            else {
+                int left = Math.abs(rank.get(idx) - rank.get(idx - 1));
+                int right = Math.abs(rank.get(idx) - rank.get(idx + 1));
+                diff = Math.min(left, right);
+            }
+
+            answer += diff;
+            rank.remove(idx);
+        }
+
+        System.out.println(answer);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2262
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
n명의 사람들이 토너먼트 대회를 치를 때, 부전승을 임의로 만들며
각 시합에 임하는 두 선수의 랭킹의 차이의 합이 최소가 되는 값 구하기
## 🔍 풀이 방법
처음에는 dfs로 모든 경우의 수를 계산했는데, 메모리 초과가 떠서
그리디 알고리즘으로 가장 랭킹이 낮은 선수를 골라서 해당 선수부터 랭킹 차이가 작도록 배치
## ⏳ 회고
문제를 풀 때 더 효율적인 방법이 없는지를 계속 고민해야겠다.