### PR TITLE
[20250711] BOJ / G2 / 1의 개수 세기 / 이인희

### DIFF
--- a/LiiNi-coder/202507/11 BOJ 1의 개수 세기.md
+++ b/LiiNi-coder/202507/11 BOJ 1의 개수 세기.md
@@ -1,0 +1,67 @@
+# 코드
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.math.BigInteger;
+
+public class Main {
+    private static BufferedReader br;
+
+    public static void main(String[] args) throws IOException {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        String[] temp1 = br.readLine().split(" ");
+        BigInteger l = new BigInteger(temp1[0]);
+        BigInteger r = new BigInteger(temp1[1]);
+
+        BigInteger result = BigInteger.ZERO;
+
+        for (int exponent = 0; exponent <= 63; exponent++) {
+            BigInteger blockSize = BigInteger.ONE.shiftLeft(exponent);
+            if (blockSize.compareTo(r) > 0) break;
+
+            BigInteger lBlockIdx = l.divide(blockSize);
+            BigInteger rBlockIdx = r.divide(blockSize);
+
+            if (lBlockIdx.equals(rBlockIdx)) {
+                if (getBitAtBlock(lBlockIdx)) {
+                    result = result.add(r.subtract(l).add(BigInteger.ONE));
+                }
+            } else {
+                if (getBitAtBlock(lBlockIdx)) {
+                    BigInteger lEnd = blockSize.multiply(lBlockIdx.add(BigInteger.ONE));
+                    result = result.add(lEnd.subtract(l));
+                }
+                if (getBitAtBlock(rBlockIdx)) {
+                    BigInteger rStart = blockSize.multiply(rBlockIdx);
+                    result = result.add(r.subtract(rStart).add(BigInteger.ONE));
+                }
+
+                // C
+                BigInteger offsetBlock = rBlockIdx.subtract(lBlockIdx).subtract(BigInteger.ONE);
+                BigInteger half = offsetBlock.divide(BigInteger.TWO);
+                if (offsetBlock.mod(BigInteger.TWO).equals(BigInteger.ZERO)) {
+                    result = result.add(blockSize.multiply(half));
+                } else {
+                    if (getBitAtBlock(rBlockIdx)) {
+                        result = result.add(blockSize.multiply(half));
+                    } else {
+                        result = result.add(blockSize.multiply(half).add(blockSize));
+                    }
+                }
+            }
+        }
+
+        System.out.println(result);
+        br.close();
+    }
+
+    private static boolean getBitAtBlock(BigInteger idx) {
+        return idx.mod(BigInteger.TWO).equals(BigInteger.ONE);
+    }
+}
+
+```
+
+#결과
+맞았습니다!!	14484kB	104ms


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/9527
## 🧭 풀이 시간
90분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
엄청 큰 수 사이의 모든 숫자를 이진수하였을때, 1의 개수를 모두 더하기
## 🔍 풀이 방법
2^0자리는 0101010... 2^1자리는 00110011.... 2^2자리는 0000111100001111.... 임을 이용하여서, 0, 1, 2 이렇게 while돌리며, 인풋 첫숫자가 포함된 block, 인풋 두번째 숫자가 포함된 block을 판단하여 1의 개수를 계산해나감
## ⏳ 회고
이런 숫자 세는거에서 너무 약하다... 그리고, 결과가 오버플로우나서 gpt한테 자료형을 맞춰달라고 도움을 요청해버렸다... 자바 자료형 공부도 하자