### PR TITLE
[20250712] BOJ / G5 / 숏코딩의 왕 브실이 / 이종환

### DIFF
--- a/0224LJH/202507/12 BOJ 숏코딩의 왕 브실이.md
+++ b/0224LJH/202507/12 BOJ 숏코딩의 왕 브실이.md
@@ -1,0 +1,63 @@
+```java
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+    static int len,maxRemoveCnt, ans;
+    static int[] arr,minArr,maxArr;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        process();
+        print();
+    }
+
+    private static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        len = Integer.parseInt(st.nextToken());
+        maxRemoveCnt = Integer.parseInt(st.nextToken());
+        arr = new int[len];
+        ans = Integer.MIN_VALUE;
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < len; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+    }
+
+    private static void process() {
+        getMinAndMaxArr();
+        for (int i = 0; i <= maxRemoveCnt; i++) {
+            int end = (len-1) -  i;
+            int start = maxRemoveCnt - i;
+
+            ans = Math.max(maxArr[end] - arr[start], ans);
+        }
+    }
+
+    private static void getMinAndMaxArr() {
+        minArr = new int[len]; // 0~i번까지의 숫자중 최솟값
+        maxArr = new int[len]; // len-1 ~ len-1-i번까지의 숫자 중 최댓값
+
+        minArr[0] = arr[0];
+        for (int i = 1; i < len; i++) {
+            minArr[i] = Math.min(minArr[i-1], arr[i]);
+        }
+        maxArr[len-1] = arr[len-1];
+        for (int i = len-2; i >= 0; i--) {
+            maxArr[i] = Math.max(maxArr[i+1], arr[i]);
+        }
+    }
+
+    private static void print()  {
+        System.out.println(ans);
+    }
+
+
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/29726

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
<img width="151" height="78" alt="image" src="https://github.com/user-attachments/assets/13fb7259-feb9-4526-9fb0-2e4d5432f60d" />

위 식과 같은 계산을 통해 행복도를 구한다. 이때 수열에서 최대 m개의 숫자를 제거할 수 있을 때 최대 행복도를 구하자.


## 🔍 풀이 방법

처음에는 좀 당황했는데, 잘 생각해보니 결국 수열의 끝값 - 첫값 이다.
그렇기에 끝에서 몇번째에서 처음에서 몇번째를 뺼 지만 정하면 되는 것이었다.

물론 m개가 아니라 '최대 m개'이기에 단순하게 0~m개 제거 시 값을 일일히 계산하면 시간이 터진다.
그렇기에 
- i번째 항에 0~i번 값중 가장 작은 값을 보관하는 ``minArr``
- i번째 항에 len-1 ~ len-1-i번 값 중 가장 큰 값을 보관하는 ``maxArr``
이 두 개의 배열을 도입 한 후, 이를 통해 O(n)으로 계산하여 해결하였다.

## ⏳ 회고
풀이법을 알고나면 정말 쉬운문제