### PR TITLE
[20250712] BOJ / G5 / 최소비용구하기 / 이준희

### DIFF
--- a/JHLEE325/202507/12 BOJ G5 최소비용구하기
+++ b/JHLEE325/202507/12 BOJ G5 최소비용구하기
@@ -1,0 +1,68 @@
+```java
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+    static class Node implements Comparable<Node> {
+        int idx, cost;
+
+        Node(int idx, int cost) {
+            this.idx = idx;
+            this.cost = cost;
+        }
+
+        @Override
+        public int compareTo(Node o) {
+            return Integer.compare(this.cost, o.cost);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+
+        int n = Integer.parseInt(br.readLine());
+        int m = Integer.parseInt(br.readLine());
+
+        List<List<Node>> graph = new ArrayList<>();
+        for (int i = 0; i <= n; i++)
+            graph.add(new ArrayList<>());
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+            int c = Integer.parseInt(st.nextToken());
+            graph.get(from).add(new Node(to, c));
+        }
+
+        st = new StringTokenizer(br.readLine());
+        int start = Integer.parseInt(st.nextToken());
+        int end = Integer.parseInt(st.nextToken());
+
+        int[] dist = new int[n + 1];
+        Arrays.fill(dist, Integer.MAX_VALUE);
+        dist[start] = 0;
+
+        PriorityQueue<Node> pq = new PriorityQueue<>();
+        pq.offer(new Node(start, 0));
+
+        while (!pq.isEmpty()) {
+            Node cur = pq.poll();
+            int now = cur.idx;
+
+            if (cur.cost > dist[now]) continue;
+
+            for (Node next : graph.get(now)) {
+                if (dist[next.idx] > dist[now] + next.cost) {
+                    dist[next.idx] = dist[now] + next.cost;
+                    pq.offer(new Node(next.idx, dist[next.idx]));
+                }
+            }
+        }
+        System.out.println(dist[end]);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1916

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
도시의 개수와 도시를 이동하는 버스의 정보가 주어졌을 때
주어지는 시작도시로부터 목적지도시까지의 최소비용을 구하는 문제입니다

## 🔍 풀이 방법
우선순위큐를 이용한 다익스트라를 사용하여 풀었습니다.

## ⏳ 회고
커밋 날짜를 잘 확인합시다