### PR TITLE
[20250712] BOJ / P5 / 정다각형 선분 / 권혁준

### DIFF
--- a/khj20006/202507/12 BOJ P5 정다각형 선분.md
+++ b/khj20006/202507/12 BOJ P5 정다각형 선분.md
@@ -1,0 +1,130 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+    BufferedReader br;
+    BufferedWriter bw;
+    StringTokenizer st;
+
+    public IOController() {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        st = new StringTokenizer("");
+    }
+
+    String nextLine() throws Exception {
+        String line = br.readLine();
+        st = new StringTokenizer(line);
+        return line;
+    }
+
+    String nextToken() throws Exception {
+        while (!st.hasMoreTokens()) nextLine();
+        return st.nextToken();
+    }
+
+    int nextInt() throws Exception {
+        return Integer.parseInt(nextToken());
+    }
+
+    long nextLong() throws Exception {
+        return Long.parseLong(nextToken());
+    }
+
+    double nextDouble() throws Exception {
+        return Double.parseDouble(nextToken());
+    }
+
+    void close() throws Exception {
+        bw.flush();
+        bw.close();
+    }
+
+    void write(String content) throws Exception {
+        bw.write(content);
+    }
+
+}
+
+public class Main {
+
+    static IOController io;
+
+    //
+
+    static int N, M, R;
+    static long[][] dp;
+    static boolean[][] vis;
+
+    public static void main(String[] args) throws Exception {
+
+        io = new IOController();
+
+        init();
+        solve();
+
+        io.close();
+    }
+
+    public static void init() throws Exception {
+
+        N = io.nextInt();
+        M = io.nextInt();
+        dp = new long[N][1<<N];
+        vis = new boolean[N][1<<N];
+        R = io.nextInt()-1;
+        int state = 0, last = R;
+        for(int i=1;i<M;i++) {
+            last = io.nextInt()-1;
+            state |= (1<<last);
+        }
+        dp[last][state] = 1;
+        vis[last][state] = true;
+
+    }
+
+    static void solve() throws Exception {
+
+        io.write(get(R,(1<<N)-1) + "\n");
+
+    }
+
+    static long get(int n, int k) {
+        if(dp[n][k] != 0 || vis[n][k]) return dp[n][k];
+        vis[n][k] = true;
+        int state = k | (1<<R);
+
+        boolean can = false;
+        boolean[] leftCan = new boolean[N];
+        for(int i=(n+N-1)%N,x=0;x<N-1;x++) {
+            int min = Math.min(i,n), max = Math.max(i,n);
+            if(min+N-1 == max || max-min == 1) leftCan[i] = false;
+            else leftCan[i] = can;
+            if(!can) {
+                if((state & (1<<i)) != 0) can = true;
+            }
+            i = (i+N-1)%N;
+        }
+
+        can = false;
+        boolean[] rightCan = new boolean[N];
+        for(int i=(n+1)%N,x=0;x<N-1;x++) {
+            int min = Math.min(i,n), max = Math.max(i,n);
+            if(min+N-1 == max || max-min == 1) rightCan[i] = false;
+            else rightCan[i] = can;
+            if(!can) {
+                if((state & (1<<i)) != 0) can = true;
+            }
+            i = (i+1)%N;
+        }
+
+        for(int i=0;i<N;i++) if((k & (1<<i)) != 0 && leftCan[i] && rightCan[i]) {
+            dp[n][k] += get(i, k^(1<<n));
+        }
+
+        return dp[n][k];
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/13436

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
정N각형의 어느 한 점에서 시작해서 다른 모든 꼭짓점을 한 번씩 찍고 시작점으로 돌아오려 한다.
이 때 그려지는 각 선분은 반드시 이전에 지나온 선분 중 하나와 교차해야 한다.
시작점으로부터 M-1개의 선분이 이미 그려져있을 때, 남은 경로를 정하는 방법의 수를 구해보자.

## 🔍 풀이 방법
- TSP
---
문제 생긴 게 외판원 순회 문제처럼 생겨서 그대로 풀었다.

## ⏳ 회고
이미 그려진 선분과 교차해야한다는 조건 떄문에 dp전이 조건 세우기가 까다로웠다.
문제가 너무 TSP라고 대놓고 써있는 게 좀 아쉬움