### PR TITLE
[20250713] BOJ / G5 / 탑 / 이준희

### DIFF
--- a/JHLEE325/202507/13 BOJ G5 탑
+++ b/JHLEE325/202507/13 BOJ G5 탑
@@ -1,0 +1,41 @@
+```java
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+
+        int n = Integer.parseInt(br.readLine());
+        int[] tower = new int[n];
+        int[] answer = new int[n];
+        Deque<int[]> list = new ArrayDeque<>();
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            tower[i] = Integer.parseInt(st.nextToken());
+        }
+
+        for (int i = 0; i < n; i++) {
+            int h = tower[i];
+
+            while (!list.isEmpty() && list.peek()[1] < h) {
+                list.pop();
+            }
+
+            answer[i] = list.isEmpty() ? 0 : list.peek()[0];
+
+            list.push(new int[]{i + 1, h});
+        }
+
+        for (int i = 0; i < n; i++) {
+            sb.append(answer[i] + " ");
+        }
+
+        System.out.println(sb.toString());
+    }
+}```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2493

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
탑은 항상 꼭대기에서 왼쪽으로 전파를 발사하고 그 전파는 부딪힌 첫번째 탑에 수신되고
탑의 개수와 각 탑의 높이가 주어졌을 때
각 탑의 전파가 수신되는 탑의 번호를 모두 출력하는 문제입니다

## 🔍 풀이 방법
1번 인덱스부터 시작하여 스택을 활용하여 풀었습니다
```
for (int i = 0; i < n; i++) {
            int h = tower[i];

            while (!list.isEmpty() && list.peek()[1] < h) {
                list.pop();
            }

            answer[i] = list.isEmpty() ? 0 : list.peek()[0];

            list.push(new int[]{i + 1, h});
        }
```
왼쪽의 탑 중 현재 탑보다 작은 탑은 필요가 없으므로 pop해서 지워가면서 찾았습니다

## ⏳ 회고
얼마전에 비슷한 유형의 문제를 풀었어서 쉽게 풀 수 있었으나
처음 보는 문제였으면 꽤 어려웠을 것 같습니다
