### PR TITLE
[20250713] BOJ / G3 / 세 용액 / 신동윤

### DIFF
--- a/03do-new30/202507/13 BOJ G3 세 용액.md
+++ b/03do-new30/202507/13 BOJ G3 세 용액.md
@@ -1,0 +1,50 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int N;
+    static long[] arr, answer;
+    static long minAbs;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        arr = new long[N];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            arr[i] = Long.parseLong(st.nextToken());
+        }
+        Arrays.sort(arr);
+        minAbs = 3_000_000_000L;
+        for (int startIdx = 0; startIdx < N-2; startIdx++) {
+            twoPointer(startIdx);
+        }
+        for (long num : answer) {
+            System.out.print(num + " ");
+        }
+        br.close();
+    }
+
+    private static void twoPointer(int startIdx) {
+        int leftIdx = startIdx + 1;
+        int rightIdx = N-1;
+        while (leftIdx < rightIdx) {
+            long currentVal = arr[startIdx] + arr[leftIdx] + arr[rightIdx];
+            long currentAbs = Math.abs(currentVal);
+            if (currentAbs < minAbs) {
+                minAbs = currentAbs;
+                answer = new long[] {arr[startIdx], arr[leftIdx], arr[rightIdx]};
+            }
+            if (currentVal < 0) {
+                leftIdx++;
+            } else if (currentVal > 0) {
+                rightIdx--;
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2473

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
- 세 용액을 골라 용액 특성값의 합이 0에 가장 가깝게 만들어야 한다.

## 🔍 풀이 방법
- 저번에 푼 [용액](https://www.acmicpc.net/problem/2467)문제와 유사한 문제
- 세 용액을 골라야 하므로, 하나는 기준으로 설정하여 고정해두고, 투 포인터 기법으로 나머지 두 용액을 고르면 된다.
- 세 용액을 골랐을 때, 최대 값은 30억정도까지 가능하므로 `long`

## ⏳ 회고
- `long`으로 세 용액을 합친 값을 관리해야겠다는 생각까지는 도달했으나, 각 용액 특성값의 입력을 `int`형태로 받았고, 합 계산 수행 시 오버플로우 발생하여 처음 제출에서 fail을 받았음.
- `long`사용이 필요하다면 `int`와 혼용하지 말고 `long`으로 모든 값을 관리해주자 ⭐
