### PR TITLE
[20250713] BOJ / P4 / Home Sweet Home / 권혁준

### DIFF
--- a/khj20006/202507/13 BOJ P4 Home Sweet Home.md
+++ b/khj20006/202507/13 BOJ P4 Home Sweet Home.md
@@ -1,0 +1,138 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+    BufferedReader br;
+    BufferedWriter bw;
+    StringTokenizer st;
+
+    public IOController() {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        st = new StringTokenizer("");
+    }
+
+    String nextLine() throws Exception {
+        String line = br.readLine();
+        st = new StringTokenizer(line);
+        return line;
+    }
+
+    String nextToken() throws Exception {
+        while (!st.hasMoreTokens()) nextLine();
+        return st.nextToken();
+    }
+
+    int nextInt() throws Exception {
+        return Integer.parseInt(nextToken());
+    }
+
+    long nextLong() throws Exception {
+        return Long.parseLong(nextToken());
+    }
+
+    double nextDouble() throws Exception {
+        return Double.parseDouble(nextToken());
+    }
+
+    void close() throws Exception {
+        bw.flush();
+        bw.close();
+    }
+
+    void write(String content) throws Exception {
+        bw.write(content);
+    }
+
+}
+
+public class Main {
+
+    static IOController io;
+
+    //
+
+    static final long INF = (long)1e18 + 7;
+
+    static int N, M, K;
+    static List<int[]>[] graph;
+
+    public static void main(String[] args) throws Exception {
+
+        io = new IOController();
+
+        init();
+        solve();
+
+        io.close();
+    }
+
+    public static void init() throws Exception {
+
+        N = io.nextInt();
+        M = io.nextInt();
+        K = io.nextInt();
+        graph = new ArrayList[N+1];
+        for (int i = 1; i <= N; i++) graph[i] = new ArrayList<>();
+        for (int i = 1; i <= M; i++) {
+            int a = io.nextInt();
+            int b = io.nextInt();
+            int c = io.nextInt();
+            graph[a].add(new int[]{b,c});
+            graph[b].add(new int[]{a,c});
+        }
+
+    }
+
+    static void solve() throws Exception {
+
+        // 다익스트라 돌리기
+        long[] dist = new long[N+1];
+        Arrays.fill(dist, INF);
+        PriorityQueue<long[]> pq = new PriorityQueue<>((a,b) -> Long.compare(a[0],b[0]));
+        dist[1] = 0;
+        pq.offer(new long[]{0,1});
+        while(!pq.isEmpty()) {
+            long[] cur = pq.poll();
+            int n = (int)cur[1];
+            long d = cur[0];
+            if(d > dist[n]) continue;
+            for(int[] e : graph[n]) {
+                if(dist[e[0]] > d + e[1]) {
+                    dist[e[0]] = d + e[1];
+                    pq.offer(new long[]{dist[e[0]], e[0]});
+                }
+            }
+        }
+
+        // dist 정렬
+        long[] arr = new long[N];
+        for(int i=1;i<=N;i++) arr[i-1] = dist[i];
+        Arrays.sort(arr);
+
+        // 단순 그래프를 만족하지 않는 경우 먼저 제외
+        long answer = 0;
+        for(int i=1;i<=N;i++) for(int[] e:graph[i]) {
+            int j = e[0], c = e[1];
+            if(i<j) continue;
+            answer -= Math.max(0L, (K - Math.abs(dist[i] - dist[j]) + 1));
+        }
+
+        // 답 구하기
+        long prevSum = 0;
+        int lastIndex = 0;
+        for(int i=1;i<N;i++) {
+            while(arr[i] - arr[lastIndex] > K) {
+                prevSum -= arr[lastIndex++];
+            }
+            answer += (long)(i-lastIndex)*(K-arr[i]+1) + prevSum;
+            prevSum += arr[i];
+        }
+
+        io.write(answer + "\n");
+
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/33958

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
정점 N개, 간선 M개에 간선에 가중치가 달려있는 `단순 양방향 연결 그래프`가 주어진다.
이 그래프에서 1번 점과 n번 점 사이의 최단 거리를 dist[n]이라 한다.

이 그래프에 간선을 하나 추가했을 때, `단순 양방향 연결 그래프`의 성질이 깨지지 않도록 하며, 모든 점 i에 대해 dist[i]의 값이 줄어들지 않도록 간선을 추가하는 경우의 수를 구해보자.

## 🔍 풀이 방법
- 다익스트라
- 투 포인터
---
어떤 간선 (u, v, w)를 추가했다고 가정하자.
추가한 뒤에 모든 점의 dist[i] 값이 줄어들지 않으려면, $abs(dist[u] - dist[v]) <= w$여야 한다.

즉, 문제 조건에 따라 $abs(dist[u] - dist[v]) <= w <= K$가 되도록 u, v, w를 잘 정해주는 것이 목적이다.

뜬금없지만, dist배열을 정렬시켜놓고 생각해보면 답을 어떻게 구해야 하는지 아주 잘 보인다.

정렬시킨 dist배열에서 $dist[i] - dist[j] <= K$인 j를 잘 정하면, 정답의 개수에 $(i-j)*(K-dist[i]+1) - (dist[j] + ... dist[i-1])$만큼 더해지게 된다.
그리고 dist배열이 정렬되어 있으므로 이 i,j는 투 포인터로 쉽게 관리할 수 있다.

마지막으로, `단순 양방향 연결 그래프`의 성질이 깨지게 되는 경우를 정답에서 제외시키면 된다.
이 경우는 이미 존재하는 간선을 추가한 경우 뿐이고, O(M)에 처리 가능하다.

## ⏳ 회고
중간에 음수가 되는 경우를 고려하지 못해서 틀렸었다.
문제 진짜 좋은듯