### PR TITLE
[20250713] BOJ / G5 / 연속합 2 / 이인희

### DIFF
--- a/LiiNi-coder/202507/13 BOJ 연속합 2.md
+++ b/LiiNi-coder/202507/13 BOJ 연속합 2.md
@@ -1,0 +1,36 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+
+public class B13398 {
+
+	private static BufferedReader br;
+	private static int n;
+	private static int[] arr;
+	private static int[][] dp;
+
+	public static void main(String[] args) throws IOException {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		n = Integer.parseInt(br.readLine());
+		arr = new int[n];Q
+		String[] temp = br.readLine().split(" ");
+		for(int i = 0; i< n; i++)
+			arr[i] = Integer.parseInt(temp[i]);
+		
+		//dp 설정
+		dp = new int[n+1][2];
+		int answer = -1000;
+		answer = dp[0][0] = dp[0][1] = arr[0];
+		for(int i = 1; i< n; i++) {
+			dp[i][0] = Math.max(dp[i-1][0] + arr[i], arr[i]);
+			dp[i][1] = Math.max(dp[i-1][0],dp[i-1][1] + arr[i]);
+			answer = Math.max(answer, Math.max(dp[i][0], dp[i][1]));
+		}
+		
+		System.out.println(answer);
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/13398
## 🧭 풀이 시간
40 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 연속합 문제의 확장판
- 선택지로, 숫자 하나를 지울 수 있는 특권이 주어짐. 이걸 사용하든 안하든 연속합 중의 최댓값을 출력하는 문제
## 🔍 풀이 방법
- 먼저 기본 연속합의 방법은 dp로 dp[i] == `0~i번째까지의 수열의 연속합 중 i번째를 반드시 포함하는 연속합` 으로 설정하고 dp의 최댓값을 출력하는 것인데
- 숫자 하나를 지우는 것을 상정하기 위해 dp[i][1] 로 2차원 dp로 풀었다.
## ⏳ 회고
- 오랜만의 dp문제라서 연속합의 dp방법이 굉장히 생소하게 다가왔다. 이전 dp결과를 사용하지못하는 점화식이라면 과감하게 버리고 다른 방식을 빨리 찾는 연습이 되었다.