### PR TITLE
[20250714] BOJ / G5 / 감소하는 수 / 김수연

### DIFF
--- a/suyeun84/202507/14 BOJ G5 감소하는 수.md
+++ b/suyeun84/202507/14 BOJ G5 감소하는 수.md
@@ -1,0 +1,31 @@
+ ```java
+import java.util.*;
+import java.io.*;
+
+public class boj1038 {
+    static List<Long> arr = new ArrayList<>();
+
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+
+        if(N <= 10) System.out.println(N);
+        else{
+            for(int i = 0; i < 10; i++) set(i, 1);
+            if(N >= arr.size()) System.out.println(-1);
+            else{
+                Collections.sort(arr);
+                System.out.println(arr.get(N));
+            }
+        }
+    }
+
+    static void set(long num, int val){
+        if(val > 10) return;
+        arr.add(num);
+        for(int i = 0; i < num % 10; i++){
+            set((num * 10) + i, val + 1);
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1038
## 🧭 풀이 시간
45분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
정수 X의 자릿수가 가장 큰 자릿수부터 작은 자릿수까지 감소한다면, 그 수를 감소하는 수라고 함
N번째 감소하는 수를 구하기 / 없으면 -1 출
## 🔍 풀이 방법
재귀함수 이용해서 현재 자릿수의 수보다 작은 수를 그 뒤에 계속 추가
## ⏳ 회고
간단한데 어렵다..