### PR TITLE
[20250714] BOJ / G1 / 트리의 순회 / 이강현

### DIFF
--- a/lkhyun/202507/14 BOJ G1 트리의 순회.md
+++ b/lkhyun/202507/14 BOJ G1 트리의 순회.md
@@ -1,0 +1,50 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main{
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N;
+    static int[] inOrder;
+    static int[] postOrder;
+    static int[] findInOrderIdxByValue;
+
+    static int[] preOrder;
+    static int preOrderIdx = 1;
+
+    public static void main(String[] args) throws Exception{
+        N = Integer.parseInt(br.readLine());
+        inOrder = new int[N+1];
+        postOrder = new int[N+1];
+        findInOrderIdxByValue = new int[N+1];
+        preOrder = new int[N+1];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= N; i++) {
+            inOrder[i] = Integer.parseInt(st.nextToken());
+            findInOrderIdxByValue[inOrder[i]] = i;
+        }
+        st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= N; i++) {
+            postOrder[i] = Integer.parseInt(st.nextToken());
+        }
+        search(1,N,1,N);
+        for (int i = 1; i <= N; i++) {
+            bw.write(preOrder[i]+" ");
+        }
+        bw.close();
+    }
+    static void search(int InStart, int InEnd, int PostStart, int PostEnd){
+        if(PostStart > PostEnd) return;
+        int rootIdx = findInOrderIdxByValue[postOrder[PostEnd]];
+        preOrder[preOrderIdx++] = postOrder[PostEnd];
+        int leftSize = rootIdx - InStart;
+        int rightSize = InEnd - rootIdx;
+
+        search(InStart, rootIdx-1,PostStart,PostStart+leftSize-1);
+        search(rootIdx+1, InEnd, PostEnd-rightSize, PostEnd-1);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2263
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
이진 트리에 중복없는 값들이 저장되어 있다.
inorder와 postorder가 주어질때, preorder를 출력하라.
## 🔍 풀이 방법
분할 정복
<img width="684" height="482" alt="image" src="https://github.com/user-attachments/assets/084b0e80-b3c2-4729-8921-4155b5d12a6b" />
inorder는 왼쪽 서브트리 탐색, 출력, 오른쪽 서브트리 탐색
postorder는 왼쪽 서브트리 탐색, 오른쪽 서브트리 탐색, 출력
따라서 postorder의 맨 마지막 값이 전체 트리의 root이다.
트리의 root를 찾고 이 값이 inorder의 어디에 있는지 알면 그 값을 기준으로 해당 트리의 왼쪽 서브트리와 오른쪽 서브트리의 범위를 특정지을 수 있다.
왼쪽 서브트리의 크기와 오른쪽 서브트리의 크기를 알면 postorder에서도 서브트리들의 범위를 특정지을 수 있다.
이를 반복해가며 root를 찾을 때마다 출력하면 preorder를 구할 수 있다.

## ⏳ 회고
postorder의 맨 마지막이 트리의 root라는 힌트를 통해 해결할 수 있었다.
역으로 preorder가 주어진다면 맨 앞이 root라는 힌트를 통해 응용문제를 해결할 수 있을 것 같다.
