### PR TITLE
[20250714] BOJ / G5 / 1,2,3더하기4 / 설진영

### DIFF
--- a/Seol-JY/202507/14 G5 1,2,3더하기4.md
+++ b/Seol-JY/202507/14 G5 1,2,3더하기4.md
@@ -1,0 +1,31 @@
+```java
+import java.io.*;
+
+public class Main {
+   static int T;
+   static int[][] dp = new int[10_001][4];
+   
+   public static void main(String[] args) throws IOException {
+       BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+       T = Integer.parseInt(br.readLine());
+
+       dp[1][1] = 1;
+       dp[2][1] = 1;
+       dp[2][2] = 1;
+       dp[3][1] = 1;
+       dp[3][2] = 1;
+       dp[3][3] = 1;
+       
+       for (int j = 4; j <= 10000; j++) {
+           dp[j][1] = dp[j-1][1];
+           dp[j][2] = dp[j-2][1] + dp[j-2][2];
+           dp[j][3] = dp[j-3][1] + dp[j-3][2] + dp[j-3][3];
+       }
+
+       for (int i = 0; i < T; i++) {
+           int n = Integer.parseInt(br.readLine());
+           System.out.println(dp[n][1] + dp[n][2] + dp[n][3]);
+       }
+   }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/15989

## 🧭 풀이 시간
35분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
1, 2, 3을 중복 사용해서 n을 만드는 방법의 수를 구하는 문제. 단, 같은 수를 두 번 연속 사용하면 안 됨.

## 🔍 풀이 방법
DP로 품

dp[j][1] = dp[j-1][1] (마지막이 1)
dp[j][2] = dp[j-2][1] + dp[j-2][2] (마지막이 2)
dp[j][3] = dp[j-3][1] + dp[j-3][2] + dp[j-3][3] (마지막이 3)

## ⏳ 회고
단순한 1차원 DP로 접근하려다 안 됨.
중복 해결하려면 2차원 필요