### PR TITLE
[20250714] BOJ / G4 / 알고스팟 / 이인희

### DIFF
--- a/LiiNi-coder/202507/14 BOJ 알고스팟.md
+++ b/LiiNi-coder/202507/14 BOJ 알고스팟.md
@@ -1,0 +1,94 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+
+public class B1261 {
+
+	private static BufferedReader br;
+	private static int m;
+	private static int n;
+	private static int[][] map;
+	private static ArrayDeque<int[]> q;
+	private static int[][] drdcs = new int[][] {
+		{0, 1},
+		{1, 0},
+		{-1, 0},
+		{0, -1}
+	};
+	private static int[][] visited;
+	public static void main(String[] args) throws IOException {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		String[] temp = br.readLine().split(" ");
+		m = Integer.parseInt(temp[0]);
+		n = Integer.parseInt(temp[1]);
+		map = new int[n][m];
+		//[i][j]에서 벽을 부순 것의 최소를 담는 배열
+		visited = new int[n][m];
+		for(int r = 0; r<n; r++) {
+			String line = br.readLine();
+			for(int c = 0; c<m; c++) {
+				if(line.charAt(c) == '1') {
+					map[r][c] = 1;
+				}else
+					map[r][c] = 0;
+				visited[r][c] = Integer.MAX_VALUE;
+			}
+		}
+		
+		q = new ArrayDeque<int[]>();
+		q.add(new int[] {0, 0, 0});
+		
+		int[] goal = new int[] {n-1, m-1};
+		int answer = 100*100;
+		while(!q.isEmpty()) {
+			int[] temp1 = q.poll();
+			int[] p = Arrays.copyOfRange(temp1, 0, 2);
+			int countOfBreakingWall = temp1[2];
+			// 종료조건
+			if(isSamePoint(p, goal)) {
+				if(countOfBreakingWall==0) {
+					answer = 0;
+					break;
+				}
+				else {
+					answer = Math.min(answer, countOfBreakingWall);
+					continue;
+				}
+			}
+			for(int[] drdc : drdcs ) {
+				int[] nextPoint = new int[]{p[0] + drdc[0], p[1]+ drdc[1]};
+				if(nextPoint[0] < 0 || nextPoint[0] >= n || nextPoint[1] < 0 || nextPoint[1] >= m)
+					continue;
+				int nextCountOfBreakingWall = countOfBreakingWall;
+				//벽이면
+				if(getValueAtPoint(map, nextPoint) == 1) {
+					if(getValueAtPoint(visited, nextPoint) > nextCountOfBreakingWall) {
+						nextCountOfBreakingWall++;
+						visited[p[0]][p[1]] = countOfBreakingWall;
+						q.addLast(new int[] {nextPoint[0], nextPoint[1], nextCountOfBreakingWall});
+					}
+				}else {
+					if(getValueAtPoint(visited, nextPoint) > nextCountOfBreakingWall) {
+						visited[p[0]][p[1]] = countOfBreakingWall;
+						q.addFirst(new int[] {nextPoint[0], nextPoint[1], nextCountOfBreakingWall});
+					}
+				}
+			}
+		}
+		
+		System.out.println(answer);
+	}
+
+	private static int getValueAtPoint(int[][] matrix, int[] p) {
+		return matrix[p[0]][p[1]];
+	}
+
+	private static boolean isSamePoint(int[] p, int[] q) {
+		return p[0] == q[0] && p[1] == q[1];
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1261
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
벽이 있는 최단거리 찾기 BFS인데, 벽은 계속 뚫어나갈 수 있음. 단, 도착지점에 도착하였을 때, 벽을 뚫은 횟수의 총합의 최솟값을 출력해야함
## 🔍 풀이 방법
- BFS사용
- 첫번째 메모리 초과가 나길래, 큐의 사이즈를 줄이기위하여, 다음지점으로 큐에 삽입을 할 때 벽이 없는 지점을 큐의 맨앞에, 벽이 있는 지점을 큐의 맨 뒤에 놓고, 큐에 삽입하기 위한 조건을 해당 칸의 벽부수기 최솟값이 최소로 갱신되는 경우에 한해서만 삽입하도록함 
## ⏳ 회고
- 이렇게 해도 두번째 메모리 초과가 나와서 잘 감이 안잡힘. 큐의 int[] 사이즈를 줄이는 방법을 고안해낼 것