### PR TITLE
[20250715] BOJ / G4 / 문자열 폭발 / 이준희

### DIFF
--- a/JHLEE325/202507/15 BOJ G4 문자열 폭발.md
+++ b/JHLEE325/202507/15 BOJ G4 문자열 폭발.md
@@ -1,0 +1,41 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        String str = br.readLine();
+        String bomb = br.readLine();
+
+        StringBuilder sb = new StringBuilder();
+
+        int blen = bomb.length();
+
+        for (char c : str.toCharArray()) {
+            sb.append(c);
+
+            if (sb.length() >= blen) {
+                if (sb.substring(sb.length() - blen).equals(bomb)) {
+                    sb.delete(sb.length() - blen, sb.length());
+                }
+            }
+        }
+
+
+        if (sb.length() != 0) {
+            System.out.println(sb.toString());
+        } else {
+            System.out.println("FRULA");
+        }
+    }
+
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/9935

## 🧭 풀이 시간
120분+

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
문자열과 폭발문자열이 주어졌을 때
문자열이 폭발문자열을 포함하고 있으면 폭발문자열을 삭제하고 나머지를 이어붙입니다.
더이상 폭발하는 문자열이 없을때까지 반복한 후 결과를 출력하는 문제입니다.

## 🔍 풀이 방법
처음에는 String.replace를 활용하여 풀었으나 메모리가 초과하여 해결방법에 대해 고민했습니다.
해결방법이 떠오르지 않아 힌트를 받아 풀었습니다.

## ⏳ 회고
string 이라는 것에 매몰되어 버리면 풀수 없는 문제였던 것 같습니다.
체감 난이도가 실제 난이도보다 훨씬 높았던 것 같습니다.