### PR TITLE
[20250715] BOJ / G4 / 이중 우선순위 큐 / 설진영

### DIFF
--- a/Seol-JY/202507/15 G4 7662 이중 우선순위 큐.md
+++ b/Seol-JY/202507/15 G4 7662 이중 우선순위 큐.md
@@ -1,0 +1,46 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+   public static void main(String[] args) throws IOException {
+       BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+       StringBuilder sb = new StringBuilder();
+       
+       int T = Integer.parseInt(br.readLine());
+       
+       while (T-- > 0) {
+           TreeMap<Integer, Integer> map = new TreeMap<>();
+           int k = Integer.parseInt(br.readLine());
+           
+           for (int i = 0; i < k; i++) {
+               StringTokenizer st = new StringTokenizer(br.readLine());
+               String op = st.nextToken();
+               int n = Integer.parseInt(st.nextToken());
+               
+               if (op.equals("I")) {
+                   map.put(n, map.getOrDefault(n, 0) + 1);
+                   continue;
+               }
+
+                if (map.isEmpty()) continue;
+                
+                int key = (n == 1) ? map.lastKey() : map.firstKey();
+                if (map.get(key) == 1) {
+                    map.remove(key);
+                } else {
+                    map.put(key, map.get(key) - 1);
+                }
+           }
+           
+           if (map.isEmpty()) {
+               sb.append("EMPTY\n");
+           } else {
+               sb.append(map.lastKey()).append(" ").append(map.firstKey()).append("\n");
+           }
+       }
+       
+       System.out.print(sb);
+   }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/7662

## 🧭 풀이 시간
35분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
앞뒤에서 뺄 수 있는 이중 우선순위 큐를 만들기

## 🔍 풀이 방법
TreeMap을 사용해서 키의 정렬을 보장하고,
여러 값이 들어올때를 핸들링함

## ⏳ 회고
처음에 PriorityQueue를 두 개 사용해서 풀려고 하다가, TreeMap이 떠올라 구현함