### PR TITLE
[20250716] BOJ / G5 / 경쟁적 전염 / 신동윤

### DIFF
--- a/03do-new30/202507/16 BOJ G5 경쟁적 전염.md
+++ b/03do-new30/202507/16 BOJ G5 경쟁적 전염.md
@@ -1,0 +1,75 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static int N, K, S, X, Y;
+    static int[][] arr;
+    static int[] dr = {0, 0, -1, 1};
+    static int[] dc = {-1, 1, 0, 0};
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        arr = new int[N+1][N+1];
+        for (int i = 1; i <= N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 1; j <= N; j++) {
+                arr[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+        st = new StringTokenizer(br.readLine());
+        S = Integer.parseInt(st.nextToken());
+        X = Integer.parseInt(st.nextToken());
+        Y = Integer.parseInt(st.nextToken());
+        br.close();
+
+        // bfs
+        bfs();
+        System.out.println(arr[X][Y]);
+
+    }
+    private static void bfs() {
+        PriorityQueue<int[]> pq = new PriorityQueue<>(new Comparator<int[]>() { // (바이러스가 퍼진 시간, 바이러스 번호, r, c)
+            @Override
+            public int compare(int[] o1, int[] o2) {
+                if (Integer.compare(o1[0], o2[0]) == 0) {
+                    return Integer.compare(o1[1], o2[1]);
+                } else {
+                    return Integer.compare(o1[0], o2[0]);
+                }
+            }
+        });
+
+        for (int i = 1; i <= N; i++) {
+            for (int j = 1; j <= N; j++) {
+                if (arr[i][j] > 0) {
+                    pq.offer(new int[] {0, arr[i][j], i, j});
+                }
+            }
+        }
+
+        while (!pq.isEmpty()) {
+            int[] info = pq.poll();
+            int curTime = info[0];
+            int curVirus = info[1];
+            int r = info[2];
+            int c = info[3];
+
+            if (curTime == S) continue;
+            for (int i = 0; i < 4; i++) {
+                int nr = r + dr[i];
+                int nc = c + dc[i];
+                if (nr < 1 || nr > N || nc < 1 || nc > N) {
+                    continue;
+                }
+                if (arr[nr][nc] > 0) continue;
+                arr[nr][nc] = curVirus;
+                pq.offer(new int[] {curTime + 1, curVirus, nr, nc});
+            }
+        }
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/18405

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
- 1번~K번 바이러스가 1초마다 상/하/좌/우로 퍼진다.
- 단, 매 초마다 **번호가 낮은 바이러스**가 우선적으로 퍼진다.
- S초에 (X, Y)좌표에 몇번 바이러스가 있는가?

## 🔍 풀이 방법
- 우선순위 큐를 활용한 BFS를 수행한다

## ⏳ 회고
- 오랜만에 푼 BFS
- 낮은 번호의 바이러스를 우선적으로 전파하기 위해 우선순위 큐를 활용한 것이 특징적