### PR TITLE
[20250716] BOJ / G4 / 휴게소 세우기 / 이인희

### DIFF
--- a/LiiNi-coder/202507/16 BOJ 휴게소 세우기.md
+++ b/LiiNi-coder/202507/16 BOJ 휴게소 세우기.md
@@ -1,0 +1,61 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class B1477 {
+	private static BufferedReader br;
+	private static int n;
+	private static int l;
+	private static int[] positions;
+	private static int m;
+
+	public static void main(String[] args) throws IOException {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		String[] temp = br.readLine().split(" ");
+		n = Integer.parseInt(temp[0]);
+		m = Integer.parseInt(temp[1]);
+		l = Integer.parseInt(temp[2]);
+
+		positions = new int[n + 2];
+		String[] line = br.readLine().split(" ");
+		for (int i = 0; i < n; i++) {
+			positions[i + 1] = Integer.parseInt(line[i]);
+		}
+		positions[0] = 0;
+		positions[n + 1] = l;
+
+		Arrays.sort(positions);
+
+		int left = 1;
+		int right = l;
+		int answer = 0;
+
+		while (left <= right) {
+			int mid = (left + right) / 2;
+			if (canBuild(mid)) {
+				answer = mid;
+				right = mid - 1;
+			} else {
+				left = mid + 1;
+			}
+		}
+
+		System.out.println(answer);
+	}
+
+	private static boolean canBuild(int maxDist) {
+		int needed = 0;
+		for (int i = 1; i < positions.length; i++) {
+			int dist = positions[i] - positions[i - 1];
+			// 해당 구간에서 몇 개의 휴게소가 필요한가?
+			if (dist > maxDist) {
+				needed += (dist - 1) / maxDist;
+			}
+		}
+		return needed <= m;
+	}
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1477
## 🧭 풀이 시간
50 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
좌표 0~L까지의 수평선위에서 n개의 점이 중복없이 이미 정수좌표에 찍혀있다. 그런데, m개의 점을 이제 추가로 찍어서, 모든 점 간의 모든 사이거리들의 최댓값이 최소가 되도록 m개의 점을 적절히 놓았을 때, 사이거리들의 최댓값의 최소를 출력하는 것
## 🔍 풀이 방법
애초에 문제의 정답인 최댓값을 이분탐색의 left, right, mid값으로 사용함. 이분탐색의 T/F 기준으로 `canBuild` 함수를 만들었고, 이 함수는 임시로 정해진 최댓값이 되도록 가능한지를 판단하는 함수이다.
## ⏳ 회고
### 이분탐색?
이분탐색의 아이디어를 떠올리기 쉽지않았다. 처음엔 이렇게 생각했다.
> 만약, 기존 휴게소가 2개이고, 떨어진 거리 a, b, c이고 a<b<c라고 할때, 추가로 놔야할 휴게소가 4개라면, a에 0개, b에 0개, c에 4개를 놓아서 c의 거리를 5등분 시키는 경우, a에 0, b에 1개, c에 3개를 놓아서 b를 2등분, c를 4등분 시키는 경우.... 이렇게 해서 마지막엔 a에 4개,b, c엔 0개를 놓는 경우 이렇게 나열하고, 이 중간을 찾는 것을 이분탐색으로 찾으면 되지않을까?
하지만 이 방식은 TT...TTTFFF...FFF 으로 되지않고 TFTFFFTTFFT 이렇게 섞여있을 수 있을 뿐더러 경우가 너무많다. 만약 푸는 도중에 풀이가 이상하다 싶으면 바로 선회하자.
### 정답변수 자체를 이분탐색값으로?
문제의 정답변수 값을 찾기위해 이 것을 이분탐색의 left, right, mid로 하는 컨셉의 문제는 처음이었다. 앞으론 `정답 변수자체도 이분탐색의 값이 될 수 있다는 것`을 반드시 떠올리자.