### PR TITLE
[20250717] BOJ / G4 / 문자열 폭발 / 신동윤

### DIFF
--- a/03do-new30/202507/17 BOJ G4 문자열 폭발.md
+++ b/03do-new30/202507/17 BOJ G4 문자열 폭발.md
@@ -1,0 +1,41 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String str = br.readLine();
+        String target = br.readLine();
+        int n = str.length();
+        int m = target.length();
+        Deque<Character> deque = new ArrayDeque<>();
+
+        for (int i = 0; i < n; i++) {
+            deque.offerFirst(str.charAt(i));
+            int idx = m-1;
+            Deque<Character> tmp = new ArrayDeque<>();
+            while (!deque.isEmpty() && idx >= 0 && deque.peekFirst() == target.charAt(idx)) {
+                tmp.offerFirst(deque.pollFirst());
+                idx--;
+            }
+            if (tmp.size() != m) {
+                while(!tmp.isEmpty()) {
+                    deque.offerFirst(tmp.pollFirst());
+                }
+            }
+        }
+
+        if (deque.isEmpty()) {
+            System.out.println("FRULA");
+        } else {
+            StringBuilder sb = new StringBuilder();
+            while (!deque.isEmpty()) {
+                sb.append(deque.pollLast());
+            }
+            System.out.println(sb);
+        }
+        br.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/9935
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 문자열이 폭발 문자열을 포함하고 있는 경우에, 모든 폭발 문자열이 폭발
- 폭발 이후 남은 문자들을 이어붙여 새로운 문자열을 만듦
- 새로운 문자열에 폭발 문자열이 있다면 폭발이 다시 일어날 수 있음
- 남은 문자열은?

## 🔍 풀이 방법
- 문자를 stack에 쌓아가면서 폭발 문자열이 의심되는 경우 pop하면서 검사

## ⏳ 회고
- 처음에는 `replaceAll`로 풀었는데 메모리 초과가 났다.
- `replaceAll`은 내부적으로 새로운 문자열을 계속 만들어야 하므로 속도도 느리고, 메모리 초과가 난다고 한다.
- 스택을 쓴다는 걸 잘 떠올리지 못하는 경우가 많은 것 같다.