### PR TITLE
[20250717] BOJ / G1 / 배열 정렬 / 이강현

### DIFF
--- a/lkhyun/202507/17 BOJ G1 배열 정렬.md
+++ b/lkhyun/202507/17 BOJ G1 배열 정렬.md
@@ -1,0 +1,70 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N,M;
+    static int[] arr;
+    static int[][] manipulation;
+    static int[] correct;
+    static int ans = -1;
+
+    public static void main(String[] args) throws Exception {
+        N = Integer.parseInt(br.readLine());
+        arr = new int[N+1];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= N; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+        correct = Arrays.copyOf(arr, N+1);
+        Arrays.sort(correct);
+
+        M = Integer.parseInt(br.readLine());
+        manipulation = new int[M][3];
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            int c = Integer.parseInt(st.nextToken());
+            manipulation[i] = new int[]{a,b,c};
+        }
+
+        dijkstra();
+
+        bw.write(ans+"");
+        bw.close();
+    }
+    static void dijkstra(){
+        PriorityQueue<int[]> pq = new PriorityQueue<>((a,b) -> a[0]-b[0]);
+        Map<String, Integer> dist =  new HashMap<>();
+        pq.offer(arr);
+        dist.put(Arrays.toString(Arrays.copyOfRange(arr,1,N+1)),0);
+
+        while (!pq.isEmpty()){
+            int[] cur = pq.poll();
+            String curString = Arrays.toString(Arrays.copyOfRange(cur,1,N+1));
+
+            if(dist.get(curString) < cur[0]) continue;
+
+            for(int i = 0; i<M; i++){
+                int[] next = Arrays.copyOf(cur,N+1);
+                next[manipulation[i][1]] = cur[manipulation[i][0]];
+                next[manipulation[i][0]] = cur[manipulation[i][1]];
+                int newDist = dist.get(curString) + manipulation[i][2];
+                next[0] = newDist;
+                String nextString = Arrays.toString(Arrays.copyOfRange(next,1,N+1));
+                if(dist.get(nextString) == null || newDist < dist.get(nextString)){
+                    dist.put(nextString, newDist);
+                    pq.offer(next);
+                }
+            }
+        }
+        ans = dist.getOrDefault(Arrays.toString(Arrays.copyOfRange(correct,1,N+1)), -1);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/28707
## 🧭 풀이 시간
90분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
크기가 N인 배열을 정렬해라.
근데 M개의 특정한 두 개의 인덱스끼리만 바꿀 수 있다.
바꾸는데 비용이 든다.
정렬하는데 드는 최소 비용을 출력해라.
## 🔍 풀이 방법
다익스트라, 해시를 이용한 맵
## ⏳ 회고
다익스트라인데, int 배열로 했던 distance 기록을 맵으로 기록하는 것으로 바꾼거임.
근데 애초에 다익스트라라고 생각하는 것도 좀 힘들고 int[]로 상태 저장해둔다는 게 좀 까다로웠음. 대혁준