### PR TITLE
[20250718] BOJ / P5 / 전봇대 / 권혁준

### DIFF
--- a/khj20006/202507/18 BOJ P5 전봇대.md
+++ b/khj20006/202507/18 BOJ P5 전봇대.md
@@ -1,0 +1,102 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+    BufferedReader br;
+    BufferedWriter bw;
+    StringTokenizer st;
+
+    public IOController() {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        st = new StringTokenizer("");
+    }
+
+    String nextLine() throws Exception {
+        String line = br.readLine();
+        st = new StringTokenizer(line);
+        return line;
+    }
+
+    String nextToken() throws Exception {
+        while (!st.hasMoreTokens()) nextLine();
+        return st.nextToken();
+    }
+
+    int nextInt() throws Exception {
+        return Integer.parseInt(nextToken());
+    }
+
+    long nextLong() throws Exception {
+        return Long.parseLong(nextToken());
+    }
+
+    double nextDouble() throws Exception {
+        return Double.parseDouble(nextToken());
+    }
+
+    void close() throws Exception {
+        bw.flush();
+        bw.close();
+    }
+
+    void write(String content) throws Exception {
+        bw.write(content);
+    }
+
+}
+
+public class Main {
+
+    static IOController io;
+
+    //
+
+    static int N;
+    static long[] a;
+
+    public static void main(String[] args) throws Exception {
+
+        io = new IOController();
+
+        init();
+        solve();
+
+        io.close();
+
+    }
+
+    public static void init() throws Exception {
+
+        N = io.nextInt();
+        a = new long[N];
+        for(int i=0;i<N;i++) a[i] = io.nextInt();
+
+    }
+
+    static void solve() throws Exception {
+
+        long s = 1, e = 1000000000, m1 = s + (e-s)/3, m2 = s + (e-s)*2/3;
+        while(e-s > 5) {
+            long res1 = getDist(m1);
+            long res2 = getDist(m2);
+            if(res1 > res2) s = m1;
+            else e = m2;
+            m1 = s + (e-s)/3;
+            m2 = s + (e-s)*2/3;
+        }
+        long ans = Long.MAX_VALUE;
+        for(int k=(int)s;k<=e;k++) ans = Math.min(ans, getDist(k));
+        io.write(ans + "\n");
+
+    }
+
+    static long getDist(long x) {
+        long res = 0;
+        for(int i=1;i<N;i++) res += Math.abs(x*i - a[i]);
+        return res;
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/8986

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
수직선상에 전봇대가 N개 존재한다.
가장 왼쪽에 있는 전봇대를 고정시키고, 모든 인접한 전봇대 사이의 거리를 동일하게 만들려고 할 때, 전봇대들의 이동 거리 합을 최소화 해보자.

## 🔍 풀이 방법
- 삼분 탐색
---
뭔가 이분 탐색처럼 생겼는데, 완탐해보니 이동거리 합의 모양이 볼록하다는 걸 알았다.
<img width="1107" height="662" alt="image" src="https://github.com/user-attachments/assets/352e313a-0a8d-4fed-81d3-de0ac08b2ec7" />

-> 삼분 탐색으로 가능한 범위를 좁혀 답을 구했다.

## ⏳ 회고
1. 그래프 개형을 그려보고 볼록하다는 걸 관찰하는 것
2. 볼록하다는 걸 보고 삼분 탐색을 떠올리는 것
두 가지가 연습이 안 되어있으면 좀 헤멨을 것 같다