### PR TITLE
[20250718] BOJ / G5 / 옥상 정원 꾸미기 / 이강현

### DIFF
--- a/lkhyun/202507/18 BOJ G5 옥상 정원 꾸미기.md
+++ b/lkhyun/202507/18 BOJ G5 옥상 정원 꾸미기.md
@@ -1,0 +1,38 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main{
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static int N;
+    static int[] buildings;
+    static long ans = 0;
+    public static void main(String[] args) throws Exception {
+        N = Integer.parseInt(br.readLine());
+        buildings = new int[N];
+
+        for (int i = 0; i < N; i++) {
+            buildings[i] = Integer.parseInt(br.readLine());
+        }
+
+        ArrayDeque<Integer> key = new ArrayDeque<>();
+        ArrayDeque<Integer> value = new ArrayDeque<>();
+        key.push(0);
+        value.push(buildings[0]);
+        for (int i = 1; i < N; i++) {
+            while(!key.isEmpty() && buildings[i] >= value.peek()){
+                value.pop();
+                ans += i - key.pop() - 1;
+            }
+            key.push(i);
+            value.push(buildings[i]);
+        }
+        while(!key.isEmpty()){
+            ans += N - key.pop() - 1;
+        }
+        bw.write(ans+"");
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/6198
## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
N개의 건물이 있고 각 건물에서 오른쪽을 바라봤을 때, 자신의 건물보다 작아야 옥상의 정원을 볼 수 있음.
모든 건물들이 볼 수 있는 정원 수의 총합을 출력.
## 🔍 풀이 방법
스택
## ⏳ 회고
총합 long에 저장하자.
그외엔 ez