### PR TITLE
[20250718] BOJ / G4 / 구간 나누기 2 / 이인희

### DIFF
--- a/LiiNi-coder/202507/18  BOJ 구간 나누기 2.md
+++ b/LiiNi-coder/202507/18  BOJ 구간 나누기 2.md
@@ -1,0 +1,59 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+	private static BufferedReader br;
+	private static int n;
+	private static int k;
+	private static int[] arr;
+
+	public static void main(String[] args) throws IOException {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		var temp = br.readLine().split(" ");
+		n = Integer.parseInt(temp[0]);
+		k = Integer.parseInt(temp[1]);
+
+		arr = new int[n];
+		var st = new StringTokenizer(br.readLine());
+		for (int i = 0; i < n; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+
+		int left = 0;
+		int right = 10000;
+		int answer = 10000;
+
+		while (left <= right) {
+			int mid = (left + right) / 2;
+			if (canDivide(mid)) {
+				answer = mid;
+				right = mid - 1;
+			} else {
+				left = mid + 1;
+			}
+		}
+
+		System.out.println(answer);
+	}
+
+	private static boolean canDivide(int maxGap) {
+		int count = 1;
+		int min = arr[0];
+		int max = arr[0];
+
+		for (int i = 1; i < n; i++) {
+			min = Math.min(min, arr[i]);
+			max = Math.max(max, arr[i]);
+			if (max - min > maxGap) {
+				count++;
+				min = arr[i];
+				max = arr[i];
+			}
+		}
+		return count <= k;
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/13397
## 🧭 풀이 시간
35 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
어떠한 N길이 수열이 주어지고, 이를 M조각으로 토막낼수있다. 토막난 조각의 구간을 조각내부의 최대숫자와 최소숫자의 차로 정의할 때, N, M, 수열이 주어지고 조각의 구간의 최댓값이 최소가 되도록 하는 경우의 최소값을 출력하는 문제
## 🔍 풀이 방법
- 이분탐색의 정답변수 자체가 이분탐색의 대상이 되는 문제
- 이분탐색의 TF판별 함수로, 구간을 만들어가며 실제 구간의 최대값의 최소가 만족하는지를 반환하도록 구현
## ⏳ 회고
보통 코테 문제는 경우의 수를 만들고, 정답인지를 판단하는 것이다.
하지만 여러 이분탐색 문제를 푸니, 먼저 정답인 수를 가정하고, 이것이 가능한 경우인지를 판단하는 방식인 `정답 변수 자체가 이분탐색의 대상이 됨`도 또한 생각해야한다.
최대의 최소, 최소의 최대, 값이 이상하게 많음, 완탐으로 힘듬 이러한 힌트들이 있을 때 이분탐색을 떠올려보자.