### PR TITLE
[20250720] BOJ / G4 / 젓가락으로 메추리알 집기 / 권혁준

### DIFF
--- a/khj20006/202507/20 BOJ G4 젓가락으로 메추리알 집기.md
+++ b/khj20006/202507/20 BOJ G4 젓가락으로 메추리알 집기.md
@@ -1,0 +1,23 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+    public static void main(String[] args) throws Exception {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        for(int i=1;i<=N;i++) for(int j=(i%2==1 ? 2 : 1);j<=M;j+=2) {
+            bw.write("? " + i + " " + j + "\n");
+            bw.flush();
+            if(br.readLine().equals("1")) return;
+        }
+
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/33707

## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N*M 크기의 반찬통에 메추리알이 딱 하나 존재한다.
어떤 칸에 젓가락질을 했을 때, 젓가락질한 칸에 메추리알이 있다면 집는다.
메추리알이 없다면, 메추리알이 다음 규칙에 따라 이동한다.
- 젓가락질한 칸이 메추리알이 있는 칸과 인접하다면, 메추리알은 인접한 무작위 칸 중 하나로 이동한다. 단, 방금 젓가락질한 칸이나 반찬통 밖으로는 이동하지 않는다.
- 젓가락질한 칸이 메추리알이 있는 칸과 인접하지 않는다면, 메추리알은 이동하지 않는다.

최대 NM/2 번의 젓가락질로 메추리알을 잡아보자.

## 🔍 풀이 방법
체스판의 아이디어를 떠올렸다.
<img width="736" height="603" alt="image" src="https://github.com/user-attachments/assets/c043df63-5fdc-4436-9ce7-607529cd6d60" />

체스판의 같은 색 부분에만 젓가락질을 한다고 가정하면, 두 가지 경우로 나누어진다.

1. 메추리알이 젓가락질 하는 부분과 같은 색에 있는 경우
- 무조건 잡을 수 있다.

2. 다른 색에 있는 경우
- 젓가락질 하다보면 자연스럽게 같은 색에 있는 경우로 메추리알이 이동한다.

그래서 그냥 검은 칸만 다 집어보면 된다.

## ⏳ 회고
처음에 흰색 칸을 집었다가, N*M이 홀수인 경우에 젓가락질 횟수가 모자라 틀렸었다.