### PR TITLE
[20250720] BOJ / G4 / 소트 / 이종환

### DIFF
--- a/0224LJH/202507/20 BOJ 소트 .md
+++ b/0224LJH/202507/20 BOJ 소트 .md
@@ -1,0 +1,85 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+
+public class Main {
+
+    static int len,changeCnt,left;
+    static int[] arr;
+
+
+    public static void main(String[] args) throws IOException {
+        init();
+        process();
+        print();
+    }
+
+    private static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        len = Integer.parseInt(br.readLine());
+        arr = new int[len];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < len; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+        changeCnt = Integer.parseInt(br.readLine());
+        left = changeCnt;
+    }
+
+    private static void process() {
+        //i번 인덱스를 조사하는데 n번의 기회가 남았을 때,
+        //지금 인덱스에서 1~n칸만큼 떨어진 숫자들 중 가장 큰 값 찾음.
+        //제일 큰 값을 i번 인덱스에 넣고, 나머지 값들은 다 한칸씩 미룸
+        //남은 횟수 갱신
+        //이를 끝까지 가거나, 기회를 다 쓰면 끝
+        int curIdx = 0;
+        while (curIdx < len-1 && left > 0 ){
+            int max = arr[curIdx];
+            int maxIdx = curIdx;
+
+            for (int i = curIdx+1; (i < len && i <= curIdx + left  ); i++) {
+                if (arr[i] > max){
+                    max = arr[i];
+                    maxIdx = i;
+                }
+            }
+
+            rangeSwap(curIdx, maxIdx);
+            left -= maxIdx - curIdx;
+            curIdx++;
+        }
+
+
+    }
+
+    private static void rangeSwap(int fromIdx, int toIdx) {
+        for (int i = toIdx; i > fromIdx; i--) {
+            swap(i, i-1);
+        }
+    }
+
+    private static void swap(int tIdx1, int tIdx2) {
+        int tmp = arr[tIdx1];
+        arr[tIdx1] = arr[tIdx2];
+        arr[tIdx2] = tmp;
+    }
+
+
+
+    private static void print()  {
+        for (int i = 0; i < len; i++) {
+            System.out.print(arr[i] + " ");
+        }
+    }
+
+
+
+}
+
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1083

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
크기가 N인 배열 A가 있다. 배열에 있는 모든 수는 서로 다르다. 이 배열을 소트할 때, 연속된 두 개의 원소만 교환할 수 있다. 그리고, 교환은 많아봐야 S번 할 수 있다. 이때, 소트한 결과가 사전순으로 가장 뒷서는 것을 출력한다.

## 🔍 풀이 방법
N의 최댓값이 50인거에 힌트를 얻었다. 
- i번 인덱스를 조사하는데 n번의 기회가 남았을 때,
- 지금 인덱스에서 1~n칸만큼 떨어진 숫자들 중 가장 큰 값 찾음.
- 제일 큰 값을 i번 인덱스에 넣고, 나머지 값들은 다 한칸씩 미룸
- 남은 횟수 갱신
- 이를 끝까지 가거나, 기회를 다 쓰면 끝
이 로직으로 진행하였다.

이때 위치 바꾸는 것은 시간복잡도가 여유로울 것이라 생각해서 전부 swap을 통해 진행하였다.

## ⏳ 회고
N의 최댓값을 크게하면 굉장히 어려운 문제가 될것같다