### PR TITLE
[20250720] BOJ / G5 / 계란으로 계란치기 / 이인희

### DIFF
--- a/LiiNi-coder/202507/19 BOJ 계란으로 계란치기.md
+++ b/LiiNi-coder/202507/19 BOJ 계란으로 계란치기.md
@@ -1,0 +1,69 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main {
+    private static BufferedReader br;
+    private static int n;
+    private static int[] ws;
+    private static int[] ss;
+    private static int answer;
+
+    public static void main(String[] args) throws IOException {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        ss = new int[n];
+        ws = new int[n];
+        for (int i = 0; i < n; i++) {
+            String[] temp = br.readLine().split(" ");
+            ss[i] = Integer.parseInt(temp[0]);
+            ws[i] = Integer.parseInt(temp[1]);
+        }
+        answer = 0;
+        dfs(0);
+        System.out.println(answer);
+        br.close();
+    }
+
+    private static void dfs(int now) {
+        if(now == n){
+            // 완탐 리프 - 깨진 계란 개수 세기
+            int count = 0;
+            for (int i = 0; i < n; i++) {
+                if(ss[i] <= 0) count++;
+            }
+            answer = Math.max(answer, count); // 반복문 밖으로 이동
+            return;
+        }
+        
+        // 현재 계란이 이미 깨져있으면 바로 다음으로
+        if(ss[now] <= 0) {
+            dfs(now + 1);
+            return;
+        }
+        
+        boolean canHit = false;
+        
+        for(int target = 0; target < n; target++) {
+            if(now == target || ss[target] <= 0) continue;
+            
+            canHit = true;
+            
+            // 서로 치기
+            ss[now] -= ws[target];
+            ss[target] -= ws[now];
+            
+            dfs(now + 1);
+            
+            // 상태 복구
+            ss[now] += ws[target];
+            ss[target] += ws[now];
+        }
+        
+        if(!canHit) {
+            dfs(now + 1);
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16987
## 🧭 풀이 시간
50 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
계란이 일렬로 나열되어있고, 계란마다 내구도와 무게가 있는데, 왼쪽에서 부터 계란을 들어올려 나머지 계란을 한개씩 치고 내려놓고, 그 다음 계란들 들어올리고... 이렇게 반복하여 맨 오른쪽까지 진행된다. 계란을 치는 것은 서로의 내구도가 서로의 무게만큼 까인다. 내구도가 0이하라면 계란은 깨진다. 깨진 계란은 서로 치는 것은 불가능. 이때 가장 많은 계란을 깨도록하는 경우에서의 깬 계란의 최댓값을 출력하는 문제
## 🔍 풀이 방법
- 기본적으로 dfs완탐을 진행하며 깨진것은 스킵하는 형식으로 백트래킹을 사용한다.
## ⏳ 회고
- 92퍼에서 자꾸 틀렸다고 나와서 한동안 고생많이 한 문제
- 깨진 것을 발견하면 다음 dfs로 넘어갈지, 아니면 그냥 skip을 할지가 많이 헷갈렸다.
  - 그냥 skip은 다음 상태트리 노드를 만들지 않겠다이고, dfs로 넘어가는 것은 노드를 만들겠다는 의미로 서로 다르다는 것을 명심하자