### PR TITLE
[20250720] BOJ / G5 / Icy Perimeter / 설진영

### DIFF
--- a/Seol-JY/202507/20 G5 Icy Perimeter.md
+++ b/Seol-JY/202507/20 G5 Icy Perimeter.md
@@ -1,0 +1,64 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int n;
+    static char[][] map;
+    static boolean[][] vis;
+    static int[] dx = {-1, 1, 0, 0};
+    static int[] dy = {0, 0, -1, 1};
+    static int area, perimeter;
+    
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        
+        map = new char[n][n];
+        vis = new boolean[n][n];
+        
+        for (int i = 0; i < n; i++) {
+            map[i] = br.readLine().toCharArray();
+        }
+        
+        int maxArea = 0;
+        int minPeri = Integer.MAX_VALUE;
+        
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                if (map[i][j] != '#' || vis[i][j]) continue;
+                
+                area = 0;
+                perimeter = 0;
+                dfs(i, j);
+                
+                if (area > maxArea || (area == maxArea && perimeter < minPeri)) {
+                    maxArea = area;
+                    minPeri = perimeter;
+                }
+            }
+        }
+        
+        System.out.println(maxArea + " " + minPeri);
+    }
+    
+    static void dfs(int x, int y) {
+        vis[x][y] = true;
+        area++;
+        
+        for (int i = 0; i < 4; i++) {
+            int nx = x + dx[i];
+            int ny = y + dy[i];
+            
+            if (nx < 0 || nx >= n || ny < 0 || ny >= n || map[nx][ny] == '.') {
+                perimeter++;
+                continue;
+            }
+            
+            if (map[nx][ny] == '#' && !vis[nx][ny]) {
+                dfs(nx, ny);
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17025

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
N×N 그리드에서 '#'로 표현된 얼음덩어리들이 있을 때, 가장 큰 면적을 가진 덩어리의 면적과 둘레 구하기
면적이 같다면 둘레가 작은 것을 선택.

## 🔍 풀이 방법
DFS로 연결된 섬 탐색하기 -> 면젹 계산하면서 동시에 둘레도 계산
조건따라서 결과 출력

## ⏳ 회고
전형적인 DFS 섬찾기 문제인데, 둘레 계산이 추가