### PR TITLE
[20250721] BOJ / P5 / 파산하는 왕국 / 권혁준

### DIFF
--- a/khj20006/202507/21 BOJ P5 파산하는 왕국.md
+++ b/khj20006/202507/21 BOJ P5 파산하는 왕국.md
@@ -1,0 +1,113 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+    BufferedReader br;
+    BufferedWriter bw;
+    StringTokenizer st;
+
+    public IOController() {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        st = new StringTokenizer("");
+    }
+
+    String nextLine() throws Exception {
+        String line = br.readLine();
+        st = new StringTokenizer(line);
+        return line;
+    }
+
+    String nextToken() throws Exception {
+        while (!st.hasMoreTokens()) nextLine();
+        return st.nextToken();
+    }
+
+    int nextInt() throws Exception {
+        return Integer.parseInt(nextToken());
+    }
+
+    long nextLong() throws Exception {
+        return Long.parseLong(nextToken());
+    }
+
+    double nextDouble() throws Exception {
+        return Double.parseDouble(nextToken());
+    }
+
+    void close() throws Exception {
+        bw.flush();
+        bw.close();
+    }
+
+    void write(String content) throws Exception {
+        bw.write(content);
+    }
+
+}
+
+public class Main {
+
+    static IOController io;
+
+    //
+
+    static int N;
+    static int[][] a;
+    static boolean[] dp, vis;
+
+    public static void main(String[] args) throws Exception {
+
+        io = new IOController();
+
+        for(int T=io.nextInt(); T-->0;){
+            init();
+            solve();
+        }
+
+        io.close();
+
+    }
+
+    public static void init() throws Exception {
+
+        N = io.nextInt();
+        a = new int[N][N];
+        dp = new boolean[1<<N];
+        vis = new boolean[1<<N];
+        for(int i=0;i<N;i++) for(int j=0;j<N;j++) a[i][j] = io.nextInt();
+
+    }
+
+    static void solve() throws Exception {
+
+        dp[0] = true;
+        vis[0] = true;
+        int cnt = 0;
+        for(int i=0;i<N;i++) {
+            if(get(((1<<N)-1)^(1<<i))) {
+                cnt++;
+                io.write((i+1) + " ");
+            }
+        }
+        if(cnt == 0) io.write("0");
+        io.write("\n");
+
+    }
+
+    static boolean get(int k) {
+        if(vis[k]) return dp[k];
+        vis[k] = true;
+        for(int i=0;i<N;i++) if((k & (1<<i)) != 0) {
+            int p = k^(1<<i);
+            int sum = 0;
+            if(!get(p)) continue;
+            for(int j=0;j<N;j++) if((p & (1<<j)) == 0) sum += a[i][j];
+            if(sum > 0) return (dp[k] = true);
+        }
+        return dp[k];
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/3405

## 🧭 풀이 시간
80분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N개의 왕국이 있고, D[a][b] = a왕국이 b왕국에게 빚진 금액이다.
어떤 왕국의 잔고가 음수라면, 양과 음의 부채를 모두 없애고 파산할 수 있다. (파산하는 순서에 따라 시나리오가 달라지게 된다.)
어떤 시나리오에서 단 하나의 왕국만이 파산하지 않았다면, 그 왕국은 유일한 생존국이 될 수 있다.
이러한 왕국을 모두 구해보자.

## 🔍 풀이 방법
- Bit DP
---
dp[k] = 파산한 왕국 : 1, 생존한 왕국 : 0로 나타내었을 때, 비트마스킹 k인 시나리오가 가능한 경우인지? -> boolean으로 표현

위와 같이 dp를 세우고, bit DP를 탑다운으로 돌려주었다.

## ⏳ 회고
원래 dp[n][k]처럼 2차원으로 구현했었는데, 메모리 초과 | 시간 초과로 실패했다.
구현 방식을 보니까 차원 하나를 떼도 될 것 같아서 고친 뒤 해결했다.