### PR TITLE
[20250721] BOJ / G5 / 벼락치기 / 김수연

### DIFF
--- a/suyeun84/202507/21 BOJ G5 벼락치기.md
+++ b/suyeun84/202507/21 BOJ G5 벼락치기.md
@@ -1,0 +1,37 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class boj29704 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+    static int nextInt() {return Integer.parseInt(st.nextToken());}
+
+    static int n;
+    static int t;
+    static int[] dp;
+
+    public static void main(String[] args) throws Exception {
+        nextLine();
+        n = nextInt();
+        t = nextInt();
+        dp = new int[t+1];
+
+        int all = 0;
+        while (n-- > 0) {
+            nextLine();
+            int d = nextInt();
+            int m = nextInt();
+            all += m;
+
+            for (int i = t; i >= 0; i--) {
+                if (i < d) break;
+                dp[i] = Math.max(dp[i], dp[i-d] +m);
+            }
+        }
+
+        System.out.println(all - dp[t]);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/29704
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
문제의 개수 N과 남은 제출 기한 T가 주어질 때,
최종적으로 내는 벌금이 최소가 되도록 문제를 풀어서 내야 하는 벌금의 최소값 출
## 🔍 풀이 방법
dp사용
각 문제를 못 풀때마다 내야하는 벌금 비용을 dp에 저장해두고,
마지막에 전체에서 내야하는 벌금의 최댓값 빼줌
## ⏳ 회고
dp는 어려워!