### PR TITLE
[20250721] BOJ / G4 / 공유기 설치 / 이준희

### DIFF
--- a/JHLEE325/202507/21 BOJ G4 공유기 설치.md
+++ b/JHLEE325/202507/21 BOJ G4 공유기 설치.md
@@ -1,0 +1,60 @@
+```java
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    static int n, c;
+    static int[] house;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        c = Integer.parseInt(st.nextToken());
+
+        house = new int[n];
+        for (int i = 0; i < n; i++) {
+            house[i] = Integer.parseInt(br.readLine());
+        }
+
+        Arrays.sort(house);
+
+        int low = 1;
+        int high = house[n - 1] - house[0];
+        int answer = 0;
+
+        while (low <= high) {
+            int mid = (low + high) / 2;
+
+            if (canInstall(mid)) {
+                answer = mid;
+                low = mid + 1;
+            } else {
+                high = mid - 1;
+            }
+        }
+
+        System.out.println(answer);
+    }
+
+    static boolean canInstall(int distance) {
+        int count = 1;
+        int lastInstalled = house[0];
+
+        for (int i = 1; i < n; i++) {
+            if (house[i] - lastInstalled >= distance) {
+                count++;
+                lastInstalled = house[i];
+            }
+        }
+
+        return count >= c;
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2110

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
좌표평면상에 집들의 위치가 주어지고 공유기의 개수가 주어졌을 때
공유기 사이의 거리를 가장 멀리 설치하는 경우의 거리를 구하는 문제입니다.

## 🔍 풀이 방법
처음에는 이분탐색으로 양끝 설치 후 가운데 설치, 양끝과 가운데를 끝으로 하는 것으로 다시 이분탐색하는 식으로 풀이하려했으나 가운데 인덱스가 항상 가운데위치하는 점은 아닐 수도 있다는 점을 간과 했습니다.
그래서 한동안 고민하다가 접근법에 대한 힌트를 얻어서 풀이했습니다.
공유기를 설치할만한 거리를 우선 구하고
그 거리로 공유기를 설치했을 때 주어진 갯수의 공유기를 전부 설치할 수 있는지 판단하는 함수를 두어 풀이했습니다.
```java
static boolean canInstall(int distance) {
        int count = 1;
        int lastInstalled = house[0];

        for (int i = 1; i < n; i++) {
            if (house[i] - lastInstalled >= distance) {
                count++;
                lastInstalled = house[i];
            }
        }

        return count >= c;
    }
```

## ⏳ 회고
골드 4 문제 치고는 접근법이 어려웠던것 같은데 더 노력해야 될 것 같습니다.
