### PR TITLE
[20250721] BOJ / G5 / 넴모넴모 (Easy) / 이인희

### DIFF
--- a/LiiNi-coder/202507/21 BOJ 넴모넴모 (Easy).md
+++ b/LiiNi-coder/202507/21 BOJ 넴모넴모 (Easy).md
@@ -1,0 +1,63 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+//TIP 코드를 <b>실행</b>하려면 <shortcut actionId="Run"/>을(를) 누르거나
+// 에디터 여백에 있는 <icon src="AllIcons.Actions.Execute"/> 아이콘을 클릭하세요.
+public class Main {
+    private static BufferedReader br;
+    private static int answer;
+    private static int[][] map;
+    private static int m;
+    private static int n;
+
+    public static void main(String[] args) throws IOException {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        var temp = br.readLine().split(" ");
+        n = Integer.parseInt(temp[0]);
+        m = Integer.parseInt(temp[1]);
+        map = new int[n][m];
+        answer = 0;
+        dfs(0);
+        System.out.println(answer);
+        br.close();
+    }
+
+    private static void dfs(int idx) {
+        //종료
+        if(idx == n*m){
+            answer++;
+            return;
+        }
+        //idx에 네모 없는 것으로 진행
+        int r = idx / m;
+        int c = idx % m;
+        map[r][c] = 0;
+        dfs(idx+1);
+
+        if(isValid(idx)){
+            map[r][c] = 1;
+            dfs(idx+1);
+        }
+    }
+
+    private static boolean isValid(int idx) {
+        int r = idx/m;
+        int c = idx% m;
+        boolean isFirstCol = c == 0;
+        if(isFirstCol) return true;
+        if(r == 0){
+            return true;
+        }
+        boolean leftDown = (map[r][c-1] == 1);
+        boolean leftUp = (map[r-1][c-1] == 1);
+        boolean rightUp = (map[r-1][c] == 1);
+        if(leftDown && leftUp && rightUp){
+            return false;
+        }else{
+            return true;
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14712
## 🧭 풀이 시간
25 분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
n, m이 인풋으로 주어지고, n행, m열의 map에서 각 칸마다 네모를 놓을 수도, 안놓을 수 도 있다. 이때, 2x2네모가 완성되면 이 2x2 네모는 사라진다. 이때, 네모가 놓여질 수 있는 총 가짓수를 출력하는 문제
## 🔍 풀이 방법
- 1<= n, m <=25, 1<= n*m <= 25 인것을 보아, n, m은 매우 작음
- 그러므로 좌측 상단부터 한 칸 씩 dfs 완탐을 돌리지만, 네모가 완성될 때, 다음 dfs로 가지 않게 하여 백트래킹을 한다
- 네모가 완성되는 로직은 `isVaild()` 로 구현
## ⏳ 회고
- False, True들을 계산하여 이들을 토대로 참 거짓을 만들어 내야한다면, 이들을 조합하는 것은 시간 낭비이니까, False, True 각각 마다 boolean 변수 이름을 지어주고, if(변수 들의 조합) 을 이용하여 return false, return true하도록 하자. 