### PR TITLE
[20250721] BOJ / G4 / 공유기 설치 / 설진영

### DIFF
--- a/Seol-JY/202507/21 G4 공유기 설치.md
+++ b/Seol-JY/202507/21 G4 공유기 설치.md
@@ -1,0 +1,53 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        int N = Integer.parseInt(st.nextToken());
+        int C = Integer.parseInt(st.nextToken());
+        
+        int[] houses = new int[N];
+        for (int i = 0; i < N; i++) {
+            houses[i] = Integer.parseInt(br.readLine());
+        }
+        
+        Arrays.sort(houses);
+        
+        int left = 1;
+        int right = houses[N - 1] - houses[0];
+        int answer = 0;
+        
+        while (left <= right) {
+            int mid = (left + right) / 2;
+            
+            if (canInstall(houses, C, mid)) {
+                answer = mid;
+                left = mid + 1;
+            } else {
+                right = mid - 1;
+            }
+        }
+        
+        System.out.println(answer);
+    }
+    
+    private static boolean canInstall(int[] houses, int C, int distance) {
+        int count = 1;
+        int lastPos = houses[0];
+        
+        for (int i = 1; i < houses.length; i++) {
+            if (houses[i] - lastPos >= distance) {
+                count++;
+                lastPos = houses[i];
+                if (count >= C) return true;
+            }
+        }
+        
+        return false;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2110

## 🧭 풀이 시간
35분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N개의 집에 C개의 공유기를 설치하되, 가장 인접한 두 공유기 사이의 거리를 최대한 크게 하는 문제

## 🔍 풀이 방법
파라메트릭 서치 사용

- 집 좌표 정렬 후 최소거리를 매개변수로 설정
- 특정 거리로 C개 공유기 설치 가능한지 탐욕적으로 확인
- 가능하면 거리를 늘리고, 불가능하면 거리를 줄임

## ⏳ 회고
전형적인 파라메트릭 서치 문제. 거리를 기준으로 이진탐색하는 발상만 떠올리면 구현은 어렵지 않음. 정렬 후 탐욕적 배치가 핵심