### PR TITLE
[20250721] BOJ / G3 / 소문난 칠공주 / 이종환

### DIFF
--- a/0224LJH/202507/21 BOJ 소문난 칠공주 .md
+++ b/0224LJH/202507/21 BOJ 소문난 칠공주 .md
@@ -1,0 +1,107 @@
+```java
+import java.awt.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashSet;
+import java.util.Set;
+
+
+public class Main {
+    static String[][] arr = new String[5][5];
+    static Set<Point> set = new HashSet<>();
+    static HashSet<Point> temp = new HashSet<>();
+    static int[] dy = { -1,0,1,0};
+    static int[] dx = { 0,1,0,-1};
+    static int ans = 0;
+
+
+    public static void main(String[] args) throws IOException {
+        init();
+        process();
+        print();
+    }
+
+    private static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        for (int i = 0; i < 5; i++) {
+            arr[i] = br.readLine().split("");
+        }
+    }
+
+    private static void process() throws IOException {
+        combination(0,0);
+    }
+
+    private static void combination(int num, int idx) {
+        if ( idx == 7) {
+            check();
+            return;
+        }
+
+        for (int i = num; i < 25; i++){
+            int y = i/5;
+            int x = i%5;
+
+            set.add(new Point(x, y));
+            combination(i+1, idx+1);
+            set.remove(new Point(x, y));
+        }
+    }
+
+    private static void check() {
+
+
+        Point first = set.iterator().next();
+
+        int sCount = 0;
+        for (Point p : set) {
+            if(arr[p.y][p.x].equals("S") ) sCount++;
+        }
+
+
+        if (sCount >= 4 && checkConnected(first)) {
+            ans++;
+        }
+
+    }
+
+    private static boolean checkConnected(Point first) {
+        temp = new HashSet<>();
+        temp.add(first);
+
+        for (int i = 0 ; i < 7; i++){
+            for (Point p : set) {
+                if (temp.contains(p)) continue;
+
+                boolean isConnected = false;
+                for (int j = 0; j <4 ; j++){
+                    int ny = p.y + dy[j];
+                    int nx = p.x + dx[j];
+
+                    if (temp.contains(new Point(nx, ny))) {
+                        isConnected = true;
+                        break;
+                    }
+                }
+
+                if (isConnected) {
+                    temp.add(p);
+                }
+            }
+        }
+
+        return temp.size() == 7;
+
+    }
+
+
+    private static void print()  {
+        System.out.println(ans);
+    }
+
+
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1941

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
여학생반의 자리 배치도가 주어졌을 때, ‘소문난 칠공주’를 결성할 수 있는 모든 경우의 수를 구하는 프로그램을 작성하시오.

칠공주는 연결되어있어야한다. 그리고 이때 S가 최소 4개 이상이어야 한다.

'S'(이다‘솜’파의 학생을 나타냄) 또는 'Y'(임도‘연’파의 학생을 나타냄)을 값으로 갖는 5*5 행렬이 공백 없이 첫째 줄부터 다섯 줄에 걸쳐 주어진다.


## 🔍 풀이 방법
25C7 가 몇만 수준인걸 보고 바로 조합으로 진행하였다.
그런데 모두 하나로 연결되어있는 걸 증명하는걸 고려안했었다.
그래서 그냥 무식하게 temp라는 세트에다가 칠공주 중 랜덤한 한 좌표 넣고, 반복문을 돌리며 연결되어있는 지 확인하였다.


## ⏳ 회고
조합으로 풀긴 했는데, set 사용 + 무식한 반복문을 써서 시간초과 간신히 안났다... 좀 더 좋은 방법이 있을 것 같다.