### PR TITLE
[20250722] BOJ / G4 / 카드 정렬하기 / 이준희

### DIFF
--- a/JHLEE325/202507/22 BOJ G4 카드 정렬하기.md
+++ b/JHLEE325/202507/22 BOJ G4 카드 정렬하기.md
@@ -1,0 +1,31 @@
+```java
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+        Queue<Integer> q = new PriorityQueue<>();
+
+        for (int i = 0; i < n; i++) {
+            q.add(Integer.parseInt(br.readLine()));
+        }
+
+        int result = 0;
+        while (q.size() != 1) {
+            int a = q.poll();
+            int b = q.poll();
+            result += a + b;
+            q.add(a + b);
+        }
+
+        System.out.println(result);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1715

## 🧭 풀이 시간
10분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
정렬된 카드묶음 2개를 합치는 경우 2개의 카드개수의 합 만큼 비교해야 함
카드 묶음들의 카드 갯수가 주어질 때 최소한의 비교로 전부 합치는 경우의 비교 횟수를 구하는 문제입니다.

## 🔍 풀이 방법
카드묶음들을합칠 때 적은 갯수의 카드묶음들을 반복해서 비교해야 총 비교횟수가 작아진다는 점을 파악했습니다.
입력받을 때 부터 priority 큐를 사용하여 자동으로 정렬되게 하였고 앞에서 2개씩 뽑아가며 연산을 수행했습니다.
```java
for (int i = 0; i < n; i++) {
            q.add(Integer.parseInt(br.readLine()));
        }

        int result = 0;
        while (q.size() != 1) {
            int a = q.poll();
            int b = q.poll();
            result += a + b;
            q.add(a + b);
        }
``` 

## ⏳ 회고
적은 수를 많이 더해야 한다는 부분만 파악하면 우선순위큐만 알아도 풀리는 쉬운문제였습니다.