### PR TITLE
[20250722] BOJ / P5 / 이진 검색 트리 / 권혁준

### DIFF
--- a/khj20006/202507/22 BOJ P5 이진 검색 트리.md
+++ b/khj20006/202507/22 BOJ P5 이진 검색 트리.md
@@ -1,0 +1,105 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+    BufferedReader br;
+    BufferedWriter bw;
+    StringTokenizer st;
+
+    public IOController() {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        st = new StringTokenizer("");
+    }
+
+    String nextLine() throws Exception {
+        String line = br.readLine();
+        st = new StringTokenizer(line);
+        return line;
+    }
+
+    String nextToken() throws Exception {
+        while (!st.hasMoreTokens()) nextLine();
+        return st.nextToken();
+    }
+
+    int nextInt() throws Exception {
+        return Integer.parseInt(nextToken());
+    }
+
+    long nextLong() throws Exception {
+        return Long.parseLong(nextToken());
+    }
+
+    double nextDouble() throws Exception {
+        return Double.parseDouble(nextToken());
+    }
+
+    void close() throws Exception {
+        bw.flush();
+        bw.close();
+    }
+
+    void write(String content) throws Exception {
+        bw.write(content);
+    }
+
+}
+
+public class Main {
+
+    static IOController io;
+
+    //
+
+    static final int INF = (int)1e9 + 7;
+
+    static int N;
+    static int[] dep, idx;
+    static TreeSet<Integer> set;
+
+    public static void main(String[] args) throws Exception {
+
+        io = new IOController();
+
+        init();
+        solve();
+
+        io.close();
+
+    }
+
+    public static void init() throws Exception {
+
+        N = io.nextInt();
+        dep = new int[N];
+        idx = new int[N];
+        set = new TreeSet<>();
+
+    }
+
+    static void solve() throws Exception {
+
+        set.add(io.nextInt());
+        long ans = 1;
+        for(int i=1;i<N;i++) {
+            int a = io.nextInt();
+            int right = set.higher(a) == null ? -1 : set.higher(a);
+            int left = set.lower(a) == null ? -1 : set.lower(a);
+            if(right == -1) dep[a] = dep[left]+1;
+            else if(left == -1) dep[a] = dep[right]+1;
+            else {
+                if(idx[left] > idx[right]) dep[a] = dep[left]+1;
+                else dep[a] = dep[right]+1;
+            }
+            ans += dep[a]+1;
+            idx[a] = i;
+            set.add(a);
+        }
+        io.write(ans + "\n");
+
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1539

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
0부터 N-1까지의 수가 한 번씩 등장하는 수열이 주어진다.
이 수열로 이진 검색 트리를 만들었을 때, 모든 점의 높이 합을 구해보자.

## 🔍 풀이 방법
- TreeSet
---
이진 검색 트리에 어떤 수 a가 추가되는 경우는 두 가지로 나눌 수 있다.

1. a가 어떤 수의 왼쪽 자식이 되는 경우
-> 지금까지 트리에 들어간 수들 중 **a보다 크면서 가장 작은 수**의 왼쪽 자식으로 붙게 된다.

2. a가 어떤 수의 오른쪽 자식이 되는 경우
-> 마찬가지로 지금까지 트리에 들어간 수들 중 **a보다 작으면서 가장 큰 수**의 오른쪽 자식으로 붙게 된다.

TreeSet으로 정렬된 상태에서 a의 양 옆 수를 체크하고, 그 중 더 늦게 들어간 수한테 붙게 된다.
각 점의 높이와 나온 순서를 배열로 관리해서 해결했다.

## ⏳ 회고
상쾌한 아침