### PR TITLE
[20250722] BOJ / G5 / 두 개의 탑 / 이강현

### DIFF
--- a/lkhyun/202507/22 BOJ G5 두 개의 탑.md
+++ b/lkhyun/202507/22 BOJ G5 두 개의 탑.md
@@ -1,0 +1,44 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    
+    public static void main(String[] args) throws Exception {
+        int N = Integer.parseInt(br.readLine());
+        int[] point = new int[N];
+        int totalSum = 0;
+        
+        for (int i = 0; i < N; i++) {
+            point[i] = Integer.parseInt(br.readLine());
+            totalSum += point[i];
+        }
+        
+        int left = 0;
+        int right = 1;
+        int clockwiseSum = point[0];
+        int max = 0;
+        
+        while (left < N) {
+            int counterClockwiseSum = totalSum - clockwiseSum;
+            int distance = Math.min(clockwiseSum, counterClockwiseSum);
+            max = Math.max(max, distance);
+            
+            if (clockwiseSum < counterClockwiseSum) {
+                clockwiseSum += point[right];
+                right = (right + 1) % N;
+            } else {
+                clockwiseSum -= point[left];
+                left++;
+            }
+            
+            if (left == right) break;
+        }
+        
+        bw.write(Integer.toString(max));
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2118
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
1부터 N개의 지점에 두개의 탑을 놓을 거임.
이 둘 사이의 거리가 가장 멀어지게 끔 세운다고 할때, 그 거리를 출력
## 🔍 풀이 방법
투 포인터
투 포인터로 같은 방향을 향해 가되, 매 순간 시계방향 합과 반시계방향 합을 비교해서 그 중 작은 것을 이용해서 최댓값을 업데이트함.
## ⏳ 회고
투 포인터로 반대방향으로 가는 것만 생각하다보니 오래 걸렸고, 시작점에 따라 나올 수 있는게 달라질 수 있기에 풀이 방법을 떠올리기 어려웠다. 같은 방향으로 가면서 매 순간 업데이트 하는 방식이 새로웠고 시작점이 달라서 풀이가 어렵다면 이러한 방법을 생각해보면 좋을 것 같다.