### PR TITLE
[20250722] BOJ / G4 / 카드 정렬하기 / 신동윤

### DIFF
--- a/03do-new30/202507/22 BOJ G4 카드 정렬하기.md
+++ b/03do-new30/202507/22 BOJ G4 카드 정렬하기.md
@@ -1,0 +1,24 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        PriorityQueue<Integer> pq = new PriorityQueue<>();
+        for (int i = 0; i < N; i++) {
+            pq.offer(Integer.parseInt(br.readLine()));
+        }
+        int sum = 0;
+        while (pq.size() >= 2) {
+            int a = pq.poll();
+            int b = pq.poll();
+            pq.offer(a + b);
+            sum += a + b;
+        }
+        System.out.println(sum);
+        br.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1715
## 🧭 풀이 시간
15분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
- 숫자 카드 묶음이 주어졌을 때, 이를 하나로 합치기 위한 최소 비교 횟수 구하기
- 두 묶음을 합칠 때마다 그 크기만큼 비교가 발생

## 🔍 풀이 방법
- 매 순간 가장 작은 묶음 두 개를 합쳐주는 것이 효율적
- PriorityQueue 활용

## ⏳ 회고
- EZ