### PR TITLE
[20250722] BOJ / G5 / 캠프 준비 / 설진영

### DIFF
--- a/Seol-JY/202507/22 BOJ G5 캠프준비.md
+++ b/Seol-JY/202507/22 BOJ G5 캠프준비.md
@@ -1,0 +1,48 @@
+ ```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        int n = Integer.parseInt(st.nextToken());
+        int l = Integer.parseInt(st.nextToken());
+        int r = Integer.parseInt(st.nextToken());
+        int x = Integer.parseInt(st.nextToken());
+        
+        int[] a = new int[n];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            a[i] = Integer.parseInt(st.nextToken());
+        }
+        
+        Arrays.sort(a);
+        
+        int answer = 0;
+        
+        for (int mask = 1; mask < (1 << n); mask++) {
+            if (Integer.bitCount(mask) < 2) continue;
+            
+            int sum = 0;
+            int min = Integer.MAX_VALUE;
+            int max = Integer.MIN_VALUE;
+            
+            for (int i = 0; i < n; i++) {
+                if ((mask & (1 << i)) != 0) {
+                    sum += a[i];
+                    min = Math.min(min, a[i]);
+                    max = Math.max(max, a[i]);
+                }
+            }
+            
+            if (sum >= l && sum <= r && max - min >= x) {
+                answer++;
+            }
+        }
+        
+        System.out.println(answer);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16938

## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
캠프에 사용할 문제 고르는 방법 개수 구하기

## 🔍 풀이 방법
단순구현으로 하면 됨, 비트로 반복 돌려서 bitcount가 2인 경우에 대해서 조건 검


## ⏳ 회고
굿
