### PR TITLE
[20250723] BOJ / G4 / 배수 공사 / 이강현

### DIFF
--- a/lkhyun/202507/23 BOJ G4 배수공사.md
+++ b/lkhyun/202507/23 BOJ G4 배수공사.md
@@ -1,0 +1,43 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main{
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N,X;
+    static int[] pipeLen;
+    static int[] pipeCnt;
+    static int[] dp; // dp[i] = 길이 i를 만드는 방법의 수
+
+    public static void main(String[] args) throws Exception {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        X = Integer.parseInt(st.nextToken());
+
+        pipeLen = new int[N];
+        pipeCnt = new int[N];
+        dp = new int[X+1];
+        
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            pipeLen[i] = Integer.parseInt(st.nextToken());
+            pipeCnt[i] = Integer.parseInt(st.nextToken()); 
+        }
+
+        dp[0] = 1;
+        for (int i = 0; i < N; i++) { //모든 파이프에 대하여
+            for (int j = X; j >= 0; j--) { //길이를 고려
+                for (int k = 1; k <= pipeCnt[i]; k++) {
+                    if(j - pipeLen[i]*k >= 0){
+                        dp[j] += dp[j-pipeLen[i]*k];
+                    }
+                }
+            }
+        }
+        bw.write(dp[X]+"");
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/15817
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
배수관을 만드는데 배수관이 쪼개져서 있음.
길이랑 개수가 주어지고 이를 잘 조합해서 X 길이를 만들어야함.
순서는 고려하지 않을 때, 만들 수 있는 방법의 수를 출력.
## 🔍 풀이 방법
배낭, 동전?
모든 파이프에 대해
역순 탐색으로 진행해서 현재 파이프를 고려하지 않도록 하고
반복문으로 파이프의 개수를 고려하면 됨.
## ⏳ 회고
ez