### PR TITLE
[20250724] BOJ / G3 / 이진 트리 / 이종환

### DIFF
--- a/0224LJH/202507/24 BOJ  이진 트리.md
+++ b/0224LJH/202507/24 BOJ  이진 트리.md
@@ -1,0 +1,73 @@
+```java
+import java.awt.Point;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+
+    static int depth,leafCnt;
+    static int [] edges,maxSum,dp;
+
+
+    static int ans;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        process();
+        print();
+    }
+
+    private static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        depth = Integer.parseInt(br.readLine());
+        leafCnt = 1 << depth;
+        ans = 0;
+        edges = new int [leafCnt*2];
+        maxSum = new int [leafCnt*2]; //maxSum: 자신부터 리프노드까지의 가중치 합 중 최댓값
+        dp = new int[leafCnt*2]; // 1번노드부터 i번노드까지 왔을 때 가중치 합의 최대치
+
+        //edge[i] -> i/2번 노드에서 i번 노드로 오는데 드는 가중치
+        // 노드가 1번부터 시작하기에 엣지 0,1번은 없다.
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 2; i < edges.length; i++) {
+            edges[i] = Integer.parseInt(st.nextToken());
+        }
+    }
+
+    private static void process() throws IOException {
+        makeMaxSumArr(1);
+
+        int totalMaxSum = maxSum[1];
+
+        for (int i = 2; i < edges.length; i++) {
+            int curSum =  dp[i/2] + edges[i];
+            int goal = totalMaxSum - maxSum[i];
+
+            edges[i] += goal - curSum;
+            dp[i] = dp[i/2] + edges[i];
+        }
+
+        for (int i = 2; i < edges.length; i++) {
+            ans += edges[i];
+        }
+
+    }
+
+    private static int makeMaxSumArr(int nodeNum) {
+        if (nodeNum *2 >= edges.length) return maxSum[nodeNum];// == 0
+        int left = makeMaxSumArr(nodeNum*2) + edges[2*nodeNum];
+        int right = makeMaxSumArr(2*nodeNum+1)  +edges[2*nodeNum+1];
+
+        return maxSum[nodeNum] =  + Math.max(left, right);
+    }
+
+
+    private static void print() {
+        System.out.println(ans);
+    }
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/13325
## 🧭 풀이 시간
80분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
포화이진트리에 들어 있는 모든 에지들의 가중치가 주어졌을 때, 어떤 에지들의 가중치를 증가시켜서 루트에서 모든 리프까지의 거리가 같게 하면서 에지 가중치들의 총합이 최소가 되도록 하는 프로그램을 작성하시오


## 🔍 풀이 방법

처음부터 리프노트부터 특정 노드 까지의 가중치의 합을 저장하는 array를 재귀를 통해 만들었다.
그러나 이후 계속해서 빡구현으로 풀려고 했으나, 헛다리만 짚다가 우연히 문제 태그에 DP가 있는 걸 보고, 바로 역으로 루트노드부터 리프노드까지 진행하면서의 가중치의 합을 저장하는 array를 만들어서 해결하였다.

## ⏳ 회고
트리를 오랜만에 보니까 헷갈린다.. 내일도 비슷한거 풀어야지...