### PR TITLE
[20250724] BOJ / G4 / 부분합 / 이인희

### DIFF
--- a/LiiNi-coder/202507/24 BOJ 부분합.md
+++ b/LiiNi-coder/202507/24 BOJ 부분합.md
@@ -1,0 +1,49 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+//TIP 코드를 <b>실행</b>하려면 <shortcut actionId="Run"/>을(를) 누르거나
+// 에디터 여백에 있는 <icon src="AllIcons.Actions.Execute"/> 아이콘을 클릭하세요.
+public class Main {
+    private static BufferedReader br;
+    private static int[] arr;
+    private static int s;
+    private static int n;
+
+    public static void main(String[] args) throws IOException {
+       br = new BufferedReader(new InputStreamReader(System.in));
+       String[] temp = br.readLine().split(" ");
+       n = Integer.parseInt(temp[0]);
+       s = Integer.parseInt(temp[1]);
+       arr = new int[n];
+       int i = 0;
+       for(String token: br.readLine().split(" ")){
+           arr[i++] = Integer.parseInt(token);
+       }
+
+       int r = 0;
+       int l = 0;
+       int sum = 0;
+       int answer = Integer.MAX_VALUE;
+       while(l < arr.length){
+           if(r == arr.length){
+               sum -= arr[l++];
+           }else
+               if(sum < s){
+                   // 오른쪽에서 하나 추가해서 더해줘야함
+                   sum += arr[r++];
+               }else{
+                   // 왼쪽에서 하나 제거해서 빼줘야함
+                   sum -= arr[l++];
+               }
+           if(sum >= s) answer = Math.min(answer, r - l);
+       }
+       if(answer == Integer.MAX_VALUE){
+           System.out.println(0);
+       }else
+           System.out.println(answer);
+       br.close();
+   }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1806
## 🧭 풀이 시간
25 분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
자연수 수열과 클 수 있는 자연수 S가 주어지고, 이 수열은 엄청 길 수 있다. 이 때 부분수열의 합 중에서 합이 S를 넘는 부분수열 중에서 가장 짧은 부분 수열의 길이를 출력
## 🔍 풀이 방법
- 수열이 엄청 길 수 있다는 점을 보아 투포인터 사용
## ⏳ 회고
- 투포인터긴 하나, 이건 특이하게 가장 짧은 부분 순열의 길이를 출력하는 것이므로, R Index가 맨 끝까지 간다고 while을 끝내면 안된다. 
- R Index가 맨 오른쪽을 넘어도, L Index을 오른쪽으로 늘려가며, 맨 끝의 부분순열들도 모두 체크해야한다. 이걸 체크 안하고 그냥 R Index가 끝났다고 바로 while문을 끝내버려서 처음엔 틀렸다고 나왔다.