### PR TITLE
[20250724] BOJ / G5 / 하노이 탑 이동 순서 / 이강현

### DIFF
--- a/lkhyun/202507/24 BOJ G5 하노이 탑 이동 순서.md
+++ b/lkhyun/202507/24 BOJ G5 하노이 탑 이동 순서.md
@@ -1,0 +1,26 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static int cnt = 0;
+    static StringBuilder sb = new StringBuilder();
+    public static void main(String[] args) throws Exception {
+        int N = Integer.parseInt(br.readLine());
+        hanoi(N, 1, 2, 3);
+        bw.write(cnt+"\n");
+        bw.write(sb.toString());
+        bw.close();
+    }
+    static void hanoi(int n, int from, int temp, int to) throws Exception{
+        if(n == 0) return;
+
+        hanoi(n-1,from, to, temp); //from에서 to로 잠깐 옮겨놓음 맨 아래 빼고
+        sb.append(from).append(" ").append(to).append("\n"); //그럼 이제 from에서 원래 가고 싶은 to로 보낼 수 있으니 출력
+        cnt++;
+        hanoi(n-1,temp,from, to); //그 담에 잠깐 올려뒀던 위에 있는거 다시 to로 올려놔야하니까
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11729
## 🧭 풀이 시간
10분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
하노이 탑 이동
## 🔍 풀이 방법
재귀
N개를 옮겨야하는데 그 위에 N-1개를 옮겨둬야하니 잠깐 옮겨두고 N개를 옮기고 다시 올리는 식으로 분해해서 재귀로 푼다.
## ⏳ 회고
ez