### PR TITLE
[20250725] BOJ / G4 / 합이 0 / 이인희

### DIFF
--- a/LiiNi-coder/202507/25 BOJ 합이 0.md
+++ b/LiiNi-coder/202507/25 BOJ 합이 0.md
@@ -1,0 +1,69 @@
+```java
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+	private static BufferedReader br;
+	private static int n;
+	private static int[] arr;
+
+	public static void main(String[] args) throws Exception {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		n = Integer.parseInt(br.readLine());
+
+		arr = new int[n];
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		for (int i = 0; i < n; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+
+		Arrays.sort(arr);
+
+		long count = 0;
+
+		for (int i = 0; i < n - 2; i++) {
+			int fixed = arr[i];
+			int left = i + 1;
+			int right = n - 1;
+
+			while (left < right) {
+				int sum = fixed + arr[left] + arr[right];
+
+				if (sum == 0) {
+					if (arr[left] == arr[right]) {
+						int length = right - left + 1;
+						count += (long) length * (length - 1) / 2;
+						break;
+					}
+
+					int leftVal = arr[left];
+					int rightVal = arr[right];
+					int leftCnt = 0;
+					int rightCnt = 0;
+
+					while (left <= right && arr[left] == leftVal) {
+						leftCnt++;
+						left++;
+					}
+
+					while (left <= right && arr[right] == rightVal) {
+						rightCnt++;
+						right--;
+					}
+
+					count += (long) leftCnt * rightCnt;
+
+				} else if (sum < 0) {
+					left++;
+				} else {
+					right--;
+				}
+			}
+		}
+
+		System.out.println(count);
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/3151
## 🧭 풀이 시간
40 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N개의 숫자가 주어질 때 합이 0이 되는 3인조를 만들 수 있는 경우의 수를 출력하기
## 🔍 풀이 방법
- 정렬 + 투포인터로 사용하고 첫번째 숫자를 고정하고 나머지 두 숫자를 투포인터로 구함
## ⏳ 회고
- left * right 의 값이 int를 넘을 수 있다는 것을 간과해서 시간이 좀 지체되었었다. 곱하기는 자료형을 반드시 신경써줘.