### PR TITLE
[20250726] BOJ / G5 / 집합의 표현 / 이준희

### DIFF
--- a/JHLEE325/202507/26 BOJ G5 집합의 표현.md
+++ b/JHLEE325/202507/26 BOJ G5 집합의 표현.md
@@ -53,4 +53,5 @@ public class Main {
         }
     }
 }
+
 ```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1717

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
0~n까지 각각 한개씩 원소로 갖는 집합이 있고 합집합, 또는 원소가 같은 집합에 있는지 확인하는 연산을 진행할 때
해당 시점에 원소가 같은 집합에 있으면 YES, 아니면 NO를 출력하는 문제입니다.

## 🔍 풀이 방법
유니온 파인드 를 활용하여 합집합을 계산하여 풀었습니다.

## ⏳ 회고
처음에 단순 parent 배열로 비교했다가 틀렸었는데 union(0, 1), union(2, 3), union(1, 3) 순으로 연산을 진행했을 때 0, 1, 2, 3 의 원소는 모두 같은 집합에 있지만 parent 배열에서는 {0, 0, 0, 2} 로 3번 인덱스의 부모 배열이 0으로 통합되지 않는 것을 파악하는데 시간이 조금 걸렸습니다.
또 대체로 n이 주어지면 n-1까지 쓰는게 일반적이나 이 문제에서는 아니었기에 문제를 꼼꼼히 읽어야겠습니다.
