### PR TITLE
[20250726] BOJ / G4 / 오큰수 / 이강현

### DIFF
--- a/lkhyun/202507/26 BOJ G4 오큰수.md
+++ b/lkhyun/202507/26 BOJ G4 오큰수.md
@@ -1,0 +1,43 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int[] arr;
+    static int[] NGE;
+
+    public static void main(String[] args) throws Exception {
+        int N = Integer.parseInt(br.readLine());
+        arr = new int[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+        if(N == 1){
+            bw.write("-1");
+            bw.close();
+            return;
+        }
+
+        NGE = new int[N];
+        ArrayDeque<Integer> stk = new ArrayDeque<>();
+        stk.push(0);
+        for (int i = 1; i < N; i++) {
+            while(!stk.isEmpty() && arr[stk.peek()]<arr[i]){
+                NGE[stk.poll()] = arr[i];
+            }
+            stk.push(i);
+        }
+        while(!stk.isEmpty()){
+            NGE[stk.poll()] = -1;
+        }
+        for (int i = 0; i < N; i++) {
+            bw.write(NGE[i]+" ");
+        }
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17298
## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
현재 위치의 수 기준으로 오른쪽에 있으면서 가장 처음에 나오는 수를 오큰수라고 함.
모든 수의 오큰수를 출력
## 🔍 풀이 방법
스택
걍 스택의 꼭대기보다 크면 빼면서 오큰수로 저장하고 현재 위치 수 스택에 집어넣어.
## ⏳ 회고
ez