### PR TITLE
[20250726] BOJ / G5 / 주기문으로 바꾸기 / 이종환

### DIFF
--- a/0224LJH/202507/26 BOJ  주기문으로 바꾸기.md
+++ b/0224LJH/202507/26 BOJ  주기문으로 바꾸기.md
@@ -1,0 +1,73 @@
+```java
+import java.awt.Point;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+
+    static int depth,leafCnt;
+    static int [] edges,maxSum,dp;
+
+
+    static int ans;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        process();
+        print();
+    }
+
+    private static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        depth = Integer.parseInt(br.readLine());
+        leafCnt = 1 << depth;
+        ans = 0;
+        edges = new int [leafCnt*2];
+        maxSum = new int [leafCnt*2]; //maxSum: 자신부터 리프노드까지의 가중치 합 중 최댓값
+        dp = new int[leafCnt*2]; // 1번노드부터 i번노드까지 왔을 때 가중치 합의 최대치
+
+        //edge[i] -> i/2번 노드에서 i번 노드로 오는데 드는 가중치
+        // 노드가 1번부터 시작하기에 엣지 0,1번은 없다.
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 2; i < edges.length; i++) {
+            edges[i] = Integer.parseInt(st.nextToken());
+        }
+    }
+
+    private static void process() throws IOException {
+        makeMaxSumArr(1);
+
+        int totalMaxSum = maxSum[1];
+
+        for (int i = 2; i < edges.length; i++) {
+            int curSum =  dp[i/2] + edges[i];
+            int goal = totalMaxSum - maxSum[i];
+
+            edges[i] += goal - curSum;
+            dp[i] = dp[i/2] + edges[i];
+        }
+
+        for (int i = 2; i < edges.length; i++) {
+            ans += edges[i];
+        }
+
+    }
+
+    private static int makeMaxSumArr(int nodeNum) {
+        if (nodeNum *2 >= edges.length) return maxSum[nodeNum];// == 0
+        int left = makeMaxSumArr(nodeNum*2) + edges[2*nodeNum];
+        int right = makeMaxSumArr(2*nodeNum+1)  +edges[2*nodeNum+1];
+
+        return maxSum[nodeNum] =  + Math.max(left, right);
+    }
+
+
+    private static void print() {
+        System.out.println(ans);
+    }
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1512

## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
주어진 DNA가 길이 L일 때, 이걸 길이 M보다 작거나 같은 주기문으로 바꿀 때, 바꾸는 문자열의 개수를 최소로 하는 프로그램을 작성하시오.

## 🔍 풀이 방법
주기길이 p라 가정하고 각각의 케이스에서 
i i+p i+2p i+3p... 이 위치의 문자들의 갯수를 카운팅했다.

그렇게 나온 것들중에 a,t,g,c중에 무엇이 제일 많이 나왔는 지를 파악 후, 총 개수에서 뺐다.
-> 이게 바꿔야하는 문자의 개수이기에 이걸 모든 케이스에서 비교해서 구하였다.

## ⏳ 회고
간?신히 골드인듯.
문자 개수 아이디어 아니였으면 무조건 실버였다.