### PR TITLE
[20250726] BOJ / G5 / 합분해 / 김수연

### DIFF
--- a/suyeun84/202507/26 BOJ G5 합분해.md
+++ b/suyeun84/202507/26 BOJ G5 합분해.md
@@ -1,0 +1,29 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class boj2225 {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	
+	public static void main(String[] args) throws Exception {
+		nextLine();
+		int N = nextInt();
+		int K = nextInt();
+		
+		long [][]dp=new long [N+1][K+1];
+		
+		for(int i = 1; i <= N; i++) {
+			for(int j = 1; j <= K; j++) {
+				dp[i][j] = 1; 
+				for(int k = 1; k <= N; k++) {
+					dp[i][j] += dp[k][j-1] % 1000000000;
+				}
+			}
+		}	
+		System.out.println(dp[N][K] % 1000000000);
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2225
## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
0부터 N까지 정수 K개를 더해서 그 합이 N이 되는 경우의 수 구하기
## 🔍 풀이 방법
dp 사용
점화식 : dp[i][j] += dp[k][j-1] % 1000000000;
## ⏳ 회고
저번에 푼 dp랑 비슷했다.