### PR TITLE
[20250726] BOJ / G5 / 두 용액 / 이인희

### DIFF
--- a/LiiNi-coder/202507/26 BOJ 두 용액.md
+++ b/LiiNi-coder/202507/26 BOJ 두 용액.md
@@ -1,0 +1,46 @@
+```java
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+
+	private static BufferedReader br;
+	private static int n;
+	private static int[] arr;
+
+	public static void main(String[] args) throws Exception {
+		br = new BufferedReader(new InputStreamReader(System.in));
+
+		n = Integer.parseInt(br.readLine());
+		arr = new int[n];
+
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		for (int i = 0; i < n; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+
+		Arrays.sort(arr);
+
+		int left = 0;
+		int right = n - 1;
+
+		int ansL = arr[left];
+		int ansR = arr[right];
+		int minGap = Math.abs(ansL + ansR);
+		while (left < right) {
+			int sum = arr[left] + arr[right];
+			if (Math.abs(sum) < minGap) {
+				minGap = Math.abs(sum);
+				ansL = arr[left];
+				ansR = arr[right];
+			}
+			if (sum < 0) left++;
+			else right--;
+		}
+
+		System.out.println(ansL + " " + ansR);
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2470
## 🧭 풀이 시간
35 분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
N개의 음수 및 양수가 주어지고, 이 N은 엄청 큼. 이 중, 2개를 선택하여서 합한 값이 0에 제일 가깝도록 2개를 선택한 것을 출력하는 문제
## 🔍 풀이 방법
1. 정렬
2. 양 끝단에서 투포인터로 점점 가깝게 하여 탐색
3. left가 right를 추월할떄까지 탐색
## ⏳ 회고
- 처음 본 순간 투포인터를 떠올리기 쉽지 않은 문제. 이것의 힌트는 N이 엄청 크다는 것과, 단 2개(== 투포인터의 투)의 용액을 섞어야한 다는 점이다. 이것을 보고 투포인터를 떠올리도록 숙지하자