### PR TITLE
[20250726] BOJ / G3 / 괄호 추가하기 / 설진영

### DIFF
--- a/Seol-JY/202507/26 BOJ G3 괄호 추가하기.md
+++ b/Seol-JY/202507/26 BOJ G3 괄호 추가하기.md
@@ -1,0 +1,55 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int N;
+    static String expression;
+    static int maxResult = Integer.MIN_VALUE;
+    
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        expression = br.readLine();
+        
+        if (N == 1) {
+            System.out.println(expression.charAt(0) - '0');
+            return;
+        }
+        
+        dfs(0, expression.charAt(0) - '0');
+        System.out.println(maxResult);
+    }
+    
+    static void dfs(int idx, int currentValue) {
+        if (idx >= N - 1) {
+            maxResult = Math.max(maxResult, currentValue);
+            return;
+        }
+        
+        char operator = expression.charAt(idx + 1);
+        int nextNum = expression.charAt(idx + 2) - '0';
+        
+        int nextValue = calculate(currentValue, operator, nextNum);
+        dfs(idx + 2, nextValue);
+        
+        if (idx + 4 < N) {
+            char nextOperator = expression.charAt(idx + 3);
+            int nextNextNum = expression.charAt(idx + 4) - '0';
+            
+            int bracketResult = calculate(nextNum, nextOperator, nextNextNum);
+            int resultWithBracket = calculate(currentValue, operator, bracketResult);
+            dfs(idx + 4, resultWithBracket);
+        }
+    }
+    
+    static int calculate(int a, char operator, int b) {
+        switch (operator) {
+            case '+': return a + b;
+            case '-': return a - b;
+            case '*': return a * b;
+            default: return 0;
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16637

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
길이가 N인 수식에 괄호를 추가해서 최댓값을 구하는 문제
- 수식은 0~9 정수와 +, -, × 연산자로 구성
- 연산자 우선순위는 모두 동일해서 왼쪽부터 순서대로 계산

## 🔍 풀이 방법
DFS + 백트래킹으로 모든 경우의 수 탐색
각 연산자 위치에서 괄호를 넣을지 말지 선택하는 문제, 괄호를 넣으면 해당 연산을 먼저 계산하고, 안 넣으면 순차적으로 계산

## ⏳ 회고
그냥 DFS로 각 단계에서 괄호를 넣을지 말지만 결정하면 됨