### PR TITLE
[20250727] BOJ / G5 / 가희와 프로세스 1 / 이강현

### DIFF
--- a/lkhyun/202507/27 BOJ G5 가희와 프로세스 1.md
+++ b/lkhyun/202507/27 BOJ G5 가희와 프로세스 1.md
@@ -1,0 +1,43 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int T,N;
+    public static void main(String[] args) throws Exception {
+        st = new StringTokenizer(br.readLine());
+        int T = Integer.parseInt(st.nextToken());
+        int N = Integer.parseInt(st.nextToken());
+        
+        PriorityQueue<int[]> pq = new PriorityQueue<>((a,b)->{
+            if(a[2] == b[2]){
+                return Integer.compare(a[0],b[0]);
+            }else{
+                return Integer.compare(b[2],a[2]);
+            }
+        });
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            int id = Integer.parseInt(st.nextToken());
+            int remain = Integer.parseInt(st.nextToken());
+            int prior = Integer.parseInt(st.nextToken());
+            pq.offer(new int[]{id,remain,prior});
+        }
+
+        for (int i = 1; i <= T; i++) {
+            int[] cur = pq.poll();
+            bw.write(cur[0]+"\n");
+            if(--cur[1] > 0){
+                cur[2]--;
+                pq.offer(cur);
+            }
+        }
+        
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/21773
## 🧭 풀이 시간
15분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
프로세스들을 스케쥴러가 고르는 문제
각 프로세스들은 id, 남은 시간, 우선순위를 가짐.
스케쥴러는 프로세스를 우선순위가 높은 것부터, 같다면 id가 낮은 것부터 1초 실행하고 시간이 남았다면 다시 고려대상으로 둠.
이때 T초동안 선택된 프로세스의 id를 출력
## 🔍 풀이 방법
우선순위 큐
comparator만 설정하면 풀리는 ez 문제
실행한 프로세스를 제외한 나머지 우선순위를 1씩 올린다고 어그로 끄는거를 실행한 프로세스의 우선순위를 1 낮추는 걸로 해결함.
## ⏳ 회고
ez