### PR TITLE
[20250727] BOJ / G4 / 수들의 합 4 / 이인희

### DIFF
--- a/LiiNi-coder/202507/27 BOJ 수들의 합 4.md
+++ b/LiiNi-coder/202507/27 BOJ 수들의 합 4.md
@@ -1,0 +1,38 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static BufferedReader br;
+    private static StringTokenizer st;
+    private static int n, k;
+    private static int[] arr;
+
+    public static void main(String[] args) throws IOException {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+
+        arr = new int[n];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++)
+            arr[i] = Integer.parseInt(st.nextToken());
+
+        Map<Long, Integer> prefixCount = new HashMap<>();
+        prefixCount.put(0L, 1);
+        long sum = 0;
+        long answer = 0;
+        for (int i = 0; i < n; i++) {
+            sum += arr[i];
+            answer += prefixCount.getOrDefault(sum - k, 0);
+            prefixCount.put(sum, prefixCount.getOrDefault(sum, 0) + 1);
+            //System.out.println(sum);
+            //System.out.println(answer);
+        }
+
+        System.out.println(answer);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2015
## 🧭 풀이 시간
50 분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
N(1<=N<=200000)개의 수열이 주어진다. 이 수열의 부분합 중 에서 K가 되는 부분합의 개수 출력
## 🔍 풀이 방법
1. 누적합 사용
2. 누적합이 key, 등장 개수가 value인 hashmap을 이용
3. 누적합 - k 에서의 개수를 가져와 answer에 반영
## ⏳ 회고
- hashmap을 사용한다는 개념을 떠올리기 어려웠던 문제이다.