### PR TITLE
[20250728] BOJ / G4 / 가장 긴 바이토닉 부분 수열 / 이준희

### DIFF
--- a/JHLEE325/202507/28 BOJ G4 가장 긴 바이토닉 부분 수열.md
+++ b/JHLEE325/202507/28 BOJ G4 가장 긴 바이토닉 부분 수열.md
@@ -1,0 +1,50 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+
+        int[] arr = new int[n];
+        int[] dp1 = new int[n];
+        int[] dp2 = new int[n];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        for (int i = 0; i < n; i++) {
+            dp1[i] = 1;
+            for (int j = 0; j < i; j++) {
+                if (arr[j] < arr[i]) {
+                    dp1[i] = Math.max(dp1[i], dp1[j] + 1);
+                }
+            }
+        }
+
+        for (int i = n - 1; i >= 0; i--) {
+            dp2[i] = 1;
+            for (int j = n - 1; j >= i; j--) {
+                if (arr[j] < arr[i]) {
+                    dp2[i] = Math.max(dp2[i], dp2[j] + 1);
+                }
+            }
+        }
+
+        int result = 0;
+
+        for (int i = 0; i < n; i++) {
+            result = Math.max(result, dp1[i] + dp2[i] - 1);
+        }
+
+        System.out.println(result);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11054

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
S1 < S2 < ... Sk-1 < Sk > Sk+1 > ... SN-1 > SN을 만족하는 수열을 바이토닉 수열이라고 할 때
주어진 수열에서 가장 긴 바이토닉 부분 수열을 구하는 문제입니다.

## 🔍 풀이 방법
n이 크지 않기 때문에 가장 긴 증가하는 부분수열
가장 긴 감소하는 부분수열을 각각 구하고
그 길이를 합치는 식으로 구했습니다.

## ⏳ 회고
dp 입문용 문제인거 같습니다. 난이도가 고평가된듯
