### PR TITLE
[20250728] BOJ / G5 / 가희와 프로세스 1 / 김수연

### DIFF
--- a/suyeun84/202507/28 BOJ G5 가희와 프로세스 1.md
+++ b/suyeun84/202507/28 BOJ G5 가희와 프로세스 1.md
@@ -1,0 +1,57 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class boj21773 {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	
+	public static void main(String[] args) throws Exception {
+		nextLine();
+		int T = nextInt();
+		int n = nextInt();
+		PriorityQueue<Process> pq = new PriorityQueue<>();
+		for (int i = 0; i < n; i++) {
+			nextLine();
+			int a = nextInt();
+			int b = nextInt();
+			int c = nextInt();
+			pq.add(new Process(a, b, c));
+		}
+		
+		for (int i = 0; i < T; i++) {
+			if (pq.isEmpty()) break;
+			Process process = pq.poll();
+			bw.write(process.id + "\n");
+			
+			process.time -= 1;
+			if (process.time > 0) {
+				process.level -= 1;
+				pq.add(process);
+			}
+		}
+		bw.flush();
+	}
+	
+	static class Process implements Comparable<Process> {
+		int id;
+		int time;
+		int level;
+
+		public Process(int id, int time, int level) {
+			this.id = id;
+			this.time = time;
+			this.level = level;
+		}
+		@Override
+		public int compareTo(Process o) {
+			if (level == o.level)
+				return id - o.id;
+			return o.level - level;
+		}
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/21773
## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
가희가 1초부터 T초일 때까지, 스케쥴러가 선택한 프로세스의 ID 구하기
- 선택되지 않았으면 프로세스의 우선순위 1 상승
- 선택됐으면 실행을 마치는 데 필요한 시간 1 감소
## 🔍 풀이 방법
우선순위 큐 써서 우선순위가 높은 순, id가 작은 순으로 정렬해줌
+ 선택된 프로세스 제외의 모든 프로세스의 우선순위를 1 높이는 대신
   선택된 프로세스의 우선순위를 1 낮췄다.
## ⏳ 회고
처음에는 System.out.println을 써서 정답을 출력했는데, 시간 초과가 떠서 BufferedWriter를 이용했다.
귀찮아서 안썼는데 앞으로는 좀 써야겠다..