### PR TITLE
[20250728] BOJ / G5/ 퇴사 2 / 설진영

### DIFF
--- a/Seol-JY/202507/28 BOJ G5 퇴사 2.md
+++ b/Seol-JY/202507/28 BOJ G5 퇴사 2.md
@@ -1,0 +1,33 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        
+        int[] T = new int[N + 1];
+        int[] P = new int[N + 1];
+        
+        for (int i = 1; i <= N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            T[i] = Integer.parseInt(st.nextToken());
+            P[i] = Integer.parseInt(st.nextToken());
+        }
+        
+        int[] dp = new int[N + 2];
+        
+        for (int i = N; i >= 1; i--) {
+            if (i + T[i] <= N + 1) {
+                dp[i] = Math.max(dp[i + 1], P[i] + dp[i + T[i]]);
+            } else {
+                dp[i] = dp[i + 1];
+            }
+        }
+        
+        System.out.println(dp[1]);
+        br.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/15486

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
N일 동안 상담을 진행할 수 있고, 각 날짜마다 상담에 걸리는 기간과 받을 수 있는 금액 P[i]가 주어짐
퇴사 전까지 최대 이익을 얻을 수 있도록 상담을 선택해야함 

## 🔍 풀이 방법
DP 사용
dp[i]는 i일부터 퇴사일까지 벌 수 있는 최대 수익
뒤에서부터 비교
최종 결과는 dp[1]에 있음

## ⏳ 회고
전형적인 DP 문제이긴한데 역순으로 풀어야 깔끔하게 풀림