### PR TITLE
[20250728] BOJ / G4 / 가장 긴 증가하는 부분 수열 4 / 이종환

### DIFF
--- a/0224LJH/202507/28 BOJ 가장 긴 증가하는 부분 수열 4.md
+++ b/0224LJH/202507/28 BOJ 가장 긴 증가하는 부분 수열 4.md
@@ -1,0 +1,76 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    static int size, maxLen;
+    static int[] arr;
+    static int[] dp, ans;
+
+
+    public static void main(String[] args) throws IOException {
+        init();
+        process();
+        print();
+    }
+
+    private static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        size = Integer.parseInt(br.readLine());
+        arr = new int[size];
+        dp = new int[size];
+        ans = new int[size];
+        maxLen = 1;
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < size; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+    }
+
+    private static void process() {
+        for (int i = 0; i < size; i++) {
+            dp[i] = 1;
+            for (int j = 0; j < i; j++) {
+                if (arr[j] < arr[i]) {
+                    dp[i] = Math.max(dp[i], dp[j] + 1);
+                }
+            }
+            maxLen = Math.max(maxLen, dp[i]);
+        }
+
+        int lastIndex = -1;
+        for (int i = size - 1; i >= 0; i--) {
+            if (dp[i] == maxLen) {
+                lastIndex = i;
+                break;
+            }
+        }
+
+        // 2. 역추적하면서 수열 구성
+        int ansIndex = maxLen - 1;
+        int currentLen = maxLen;
+
+        for (int i = lastIndex; i >= 0; i--) {
+            if (dp[i] == currentLen) {
+                ans[ansIndex--] = arr[i];
+                currentLen--;
+            }
+        }
+    }
+
+    private static void print() {
+        System.out.println(maxLen);
+        for (int i = 0; i < maxLen; i++) {
+            System.out.print(ans[i]);
+            if (i < maxLen - 1) System.out.print(" ");
+        }
+        System.out.println();
+    }
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14002

## 🧭 풀이 시간
30 분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
첫째 줄에 수열 A의 가장 긴 증가하는 부분 수열의 길이를 출력한다.

둘째 줄에는 가장 긴 증가하는 부분 수열을 출력한다. 그러한 수열이 여러가지인 경우 아무거나 출력한다.

## 🔍 풀이 방법
대놓고 LIS 문제이다. 단 역추적 로직이 필요하여서, 그 부분만 조심스럽게 접근하여 해결하였다.

## ⏳ 회고
진짜 1학기보다 잘 못하는게 느껴진다... 다시 열심히 해야지...