### PR TITLE
[20250728] BOJ / G5 / 회문 / 이인희

### DIFF
--- a/LiiNi-coder/202507/28 BOJ 회문.md
+++ b/LiiNi-coder/202507/28 BOJ 회문.md
@@ -1,0 +1,52 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+
+        for(int t = 0; t<T; t++) {
+            String s = br.readLine();
+            System.out.println(check(s));
+        }
+    }
+    static boolean ishwae(String s, int left, int right) {
+        while (left < right) {
+            if (s.charAt(left) != s.charAt(right)) return false;
+            left++;
+            right--;
+        }
+        return true;
+    }
+
+    static int check(String s) {
+        int left = 0;
+        int right = s.length() - 1;
+
+        while (left < right) {
+            if (s.charAt(left) == s.charAt(right)) {
+                left++;
+                right--;
+            } else {
+                if (ishwae(s, left + 1, right) || ishwae(s, left, right - 1)) {
+                	//유사회문
+                    return 1;
+                } else {
+                    return 2;
+                }
+            }
+        }
+        return 0;
+    }
+
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17609
## 🧭 풀이 시간
35 분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
- 앞 뒤 방향으로 볼때 같은 순서인 것을 회문이라고 한다. 또, 한글자를 제거하였을때, 회문이 되는 건 유사회문이라한다. 문자열이 여러개 주어지고, 각각마다 회문, 유사회문, 그외 를 판단한는 문제
## 🔍 풀이 방법
- 양옆에서 부터 투포인터로 점점 좁혀나가서 알파벳 맞는 지 체크
- 만약 알파벳이 불일치한다면, 왼쪽을 한칸 띄운것에서 체크하는 것과, 오른쪽을 한칸 띄운것에서 체크하는 것으로 판단 재시도
## ⏳ 회고
- 양옆을 같이 비교한다는 점에서 투포인터를 떠올렸음. 단, 유사회문을 어떻게 판단할지 시간이 좀 걸림.