### PR TITLE
[20250729] BOJ / G5 / 두 용액 / 이준희

### DIFF
--- a/JHLEE325/202507/29 BOJ G5 두 용액.md
+++ b/JHLEE325/202507/29 BOJ G5 두 용액.md
@@ -1,0 +1,44 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+        int[] arr = new int[n];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.sort(arr);
+
+        int left = 0;
+        int right = n - 1;
+        int temp = 2000000000;
+        int l = 0, r = 0;
+
+        while (left < right) {
+            int x = arr[left];
+            int y = arr[right];
+            int sum = x + y;
+            if (Math.abs(x + y) < Math.abs(temp)) {
+                temp = sum;
+                l = x;
+                r = y;
+            }
+            if (sum > 0)
+                right -= 1;
+            else left += 1;
+        }
+
+        System.out.println(l + " " + r);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2470

## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
산성 용액과 알칼리성 용액 각각의 특성값들이 주어졌을 때 두 용액의 혼합 결과가 중성(0)에 가장 가까운 짝을 구하는 문제입니다.

## 🔍 풀이 방법
입력받은 배열을 정렬한 후
투포인터를 이용하여 양쪽 끝에서부터 비교해가며 풀었습니다.

## ⏳ 회고
전체 입력수가 최대 10만이어서 Arrays.sort가 안됐으면 골치가 아팠을 것 같은데 다행입니다