### PR TITLE
[20250729] BOJ / P5 / 별자리 / 권혁준

### DIFF
--- a/khj20006/202507/29 BOJ P5 별자리.md
+++ b/khj20006/202507/29 BOJ P5 별자리.md
@@ -1,0 +1,215 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+    BufferedReader br;
+    BufferedWriter bw;
+    StringTokenizer st;
+
+    public IOController() {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        st = new StringTokenizer("");
+    }
+
+    String nextLine() throws Exception {
+        String line = br.readLine();
+        st = new StringTokenizer(line);
+        return line;
+    }
+
+    String nextToken() throws Exception {
+        while (!st.hasMoreTokens()) nextLine();
+        return st.nextToken();
+    }
+
+    int nextInt() throws Exception {
+        return Integer.parseInt(nextToken());
+    }
+
+    long nextLong() throws Exception {
+        return Long.parseLong(nextToken());
+    }
+
+    double nextDouble() throws Exception {
+        return Double.parseDouble(nextToken());
+    }
+
+    void close() throws Exception {
+        bw.flush();
+        bw.close();
+    }
+
+    void write(String content) throws Exception {
+        bw.write(content);
+    }
+
+}
+
+enum Status {
+    BEFORE, LINE, CIRCLE, AFTER
+}
+
+public class Main {
+
+    static IOController io;
+
+    //
+
+    static int N, M;
+    static int[][] edges;
+    static int[] r;
+    static Status[] s;
+    static List<Integer>[] graph;
+
+    public static void main(String[] args) throws Exception {
+
+        io = new IOController();
+
+        init();
+        solve();
+
+        io.close();
+
+    }
+
+    static int f(int x) {return x==r[x] ? x : (r[x]=f(r[x]));}
+
+    static void init() throws Exception {
+
+        N = io.nextInt();
+        M = io.nextInt();
+        edges = new int[M][];
+        for(int i=0;i<M;i++) edges[i] = new int[]{io.nextInt(),io.nextInt(),io.nextInt()};
+        r = new int[N+1];
+        s = new Status[N+1];
+        graph = new List[N+1];
+        for(int i=1;i<=N;i++) {
+            r[i] = i;
+            s[i] = Status.BEFORE;
+            graph[i] = new ArrayList<>();
+        }
+
+    }
+
+    static void solve() throws Exception {
+
+        Arrays.sort(edges, (a,b) -> b[2]-a[2]);
+
+        int ans = edges[0][2], val = Integer.MAX_VALUE, idx = 0;
+        int lines = 0, circles = 0;
+        // weight sweeping
+        while(idx < M) {
+            int currentWeight = edges[idx][2];
+            while(idx < M && edges[idx][2] == currentWeight) {
+                int a = edges[idx][0], b = edges[idx][1];
+                int x = f(a), y = f(b);
+                if(x == y) {
+                    if(s[x] == Status.CIRCLE) {
+                        circles--;
+                        s[x] = Status.AFTER;
+                    }
+                    else if(s[x] == Status.LINE) {
+                        lines--;
+                        if(graph[a].size() > 1 || graph[b].size() > 1) {
+                            s[x] = Status.AFTER;
+                        }
+                        else {
+                            circles++;
+                            s[x] = Status.CIRCLE;
+                        }
+                    }
+                }
+                else {
+                    if(s[x] == Status.BEFORE) {
+                        r[x] = y;
+                        if(s[y] == Status.BEFORE) {
+                            lines++;
+                            s[y] = Status.LINE;
+                        }
+                        else if(s[y] == Status.LINE) {
+                            if(graph[b].size() > 1) {
+                                lines--;
+                                s[y] = Status.AFTER;
+                            }
+                        }
+                        else if(s[y] == Status.CIRCLE) {
+                            circles--;
+                            s[y] = Status.AFTER;
+                        }
+                    }
+                    else if(s[x] == Status.LINE) {
+                        r[y] = x;
+                        if(s[y] == Status.BEFORE) {
+                            if(graph[a].size() > 1) {
+                                lines--;
+                                s[x] = Status.AFTER;
+                            }
+                        }
+                        else if(s[y] == Status.LINE) {
+                            lines--;
+                            if(graph[a].size() > 1 || graph[b].size() > 1) {
+                                lines--;
+                                s[x] = Status.AFTER;
+                            }
+                        }
+                        else if(s[y] == Status.CIRCLE) {
+                            circles--;
+                            lines--;
+                            s[x] = Status.AFTER;
+                        }
+                        else {
+                            lines--;
+                            s[x] = Status.AFTER;
+                        }
+                    }
+                    else if(s[x] == Status.CIRCLE) {
+                        r[y] = x;
+                        if(s[y] == Status.BEFORE) {
+                            circles--;
+                            s[x] = Status.AFTER;
+                        }
+                        else if(s[y] == Status.LINE) {
+                            lines--;
+                            circles--;
+                            s[x] = Status.AFTER;
+                        }
+                        else if(s[y] == Status.CIRCLE) {
+                            circles-=2;
+                            s[x] = Status.AFTER;
+                        }
+                        else {
+                            circles--;
+                            s[x] = Status.AFTER;
+                        }
+                    }
+                    else {
+                        r[y] = x;
+                        if(s[y] == Status.LINE) {
+                            lines--;
+                        }
+                        else if(s[y] == Status.CIRCLE) {
+                            circles--;
+                        }
+                    }
+                    graph[a].add(b);
+                    graph[b].add(a);
+                }
+                idx++;
+            }
+
+            int res = Math.abs(lines-circles);
+            if(res <= val) {
+                ans = currentWeight;
+                val = res;
+            }
+
+        }
+
+        io.write(ans + " " + val);
+
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/29894

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
정점 N개, 간선 M개인 그래프가 주어지고, 간선에는 가중치가 달려있다.
두께가 K 이상인 간선들로만 이루어진 그래프에서, 직선과 원의 개수를 최소가 되도록 K를 정해보자.
- 직선 : 일자 그래프
- 원 : 사이클

## 🔍 풀이 방법
- 분리 집합
---
간선 리스트로 입력받아서 가중치 순서대로 정렬한다.
이 리스트를 순회하면 K값을 가중치가 큰 순서대로 정해볼 수 있다.

각 정점의 상태를 4가지로 나눴다.
- BEFORE : 아직 그래프에 추가되지 않은 정점
- LINE : 이 정점이 직선의 일부임
- CIRCLE : 이 정점이 원의 일부임
- AFTER : 직선도 원도 아님

이 때, 상태끼리의 변환 관계는 위에서 아래로 진행된다.
따라서, 각 간선이 추가될 때마다 분리 집합으로 두 정점의 루트의 상태를 확인하고, 
각각의 상태에 따라 나올 수 있는 4^2 = 16가지 경우를 모두 if문으로 나눠서 각각 처리해줬다.

16가지 경우 중, 직선 + 직선 -> 원이 되는 경우와 직선 + 직선 -> 직선이 되는 경우를 판단하기 위해 그래프의 `차수`를 관리해줬다.
직선 + 직선이 원 혹은 직선이 되려면, 두 정점의 차수가 모두 1이어야 한다.

## ⏳ 회고
if문이 16개인데 한 번밖에 안 틀려서 진짜 다행이다