### PR TITLE
[20250729] BOJ / G4 / PC방 요금 / 이종환

### DIFF
--- a/0224LJH/202507/29 BOJ PC방 요금.md
+++ b/0224LJH/202507/29 BOJ PC방 요금.md
@@ -1,0 +1,123 @@
+```java
+import java.awt.Point;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+
+public class Main {
+
+    static final int DAY = 1440;
+    static final int NIGHT = 1320;
+    static final int MORNING = 480;
+    static final int HOUR = 60;
+
+    static String[] rawTime;
+    static int[] playTimes;
+    static int tc, curBill,curTime,playTime;
+
+    static StringBuilder sb = new StringBuilder();
+
+
+    public static void main(String[] args) throws IOException {
+        init();
+        process();
+        print();
+    }
+
+    private static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        tc = Integer.parseInt(br.readLine());
+        rawTime = new String[tc];
+        playTimes = new int[tc];
+        for (int i = 0; i < tc; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            rawTime[i] = st.nextToken();
+            playTimes[i] = Integer.parseInt(st.nextToken());
+        }
+
+    }
+
+    private static void process() throws IOException {
+        for (int i = 0; i < tc; i++) {
+            System.out.println();
+            String rawTarget =  rawTime[i];
+
+            int hour = Integer.parseInt(rawTarget.substring(0,2));
+            int minute = Integer.parseInt(rawTarget.substring(3,5));
+
+            playTime = playTimes[i];
+            curTime = hour * 60 + minute;
+            curBill = 0;
+
+            while (playTime > 0) {
+                if (curTime  < MORNING || curTime >= NIGHT) {
+                    toMorning();
+                } else {
+                    toNight();
+                }
+            }
+
+            sb.append(curBill).append("\n");
+        }
+    }
+
+    private static void toNight() {
+        int leftTimeToNight = NIGHT -  curTime;
+        if ( leftTimeToNight > playTime) { // 밤에 도달 못함
+            curBill += (playTime/HOUR) * 1000;
+            if (playTime%HOUR != 0) curBill += 1000;
+            playTime = 0;
+        } else {
+            if (playTime - leftTimeToNight < 300) {
+                curBill += (playTime/HOUR) * 1000;
+                if (playTime%HOUR != 0) curBill += 1000;
+                playTime = 0;
+            } else {
+                curBill += (leftTimeToNight/HOUR) * 1000;
+                if (leftTimeToNight%HOUR != 0) curBill += 1000;
+                playTime -= leftTimeToNight;
+                curTime = NIGHT;
+            }
+        }
+    }
+
+    private static void toMorning() {
+        int leftTimeToMorning = MORNING - curTime;
+        if ( leftTimeToMorning < 0) leftTimeToMorning += DAY;
+
+        if ( leftTimeToMorning >= 300 ) {
+            if (playTime >= 300){
+                curBill += 5000;
+                playTime -= leftTimeToMorning;
+                curTime = MORNING;
+            } else {
+                curBill += (playTime/HOUR) * 1000;
+                if (playTime%HOUR != 0) curBill += 1000;
+                playTime = 0;
+            }
+        } else {
+            if(leftTimeToMorning > playTime  ) {
+                int tempBill = (leftTimeToMorning/HOUR) * 1000;
+                if(leftTimeToMorning%HOUR != 0) tempBill += 1000;
+
+                curBill += tempBill;
+                curTime += (tempBill/1000)*60;
+                playTime -= (tempBill/1000)*60;
+            } else {
+                curBill += (playTime/HOUR) * 1000;
+                if (playTime%HOUR != 0) curBill += 1000;
+                playTime = 0;
+            }
+        }
+
+        if (curTime > DAY) curTime -= DAY;
+
+    }
+
+    private static void print() {
+        System.out.print(sb.toString());
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/9080

## 🧭 풀이 시간
90분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
일반 요금으로 시간당 1000원 씩을 받으며, 야간 정액을 끊으면 5000원만 내고 밤 10시부터 다음날 아침 8시까지 사용할 수 있다. 이 PC방에서는 1시간에서 1분이라도 넘으면 새로운 1시간에 대한 요금을 부과한다. 그리고 이미 일반 요금으로 사용을 하다가 야간 정액을 쓰게 되면 일반 요금을 미리 계산을 하고 야간 정액을 쓸 수 있다. 즉, 일반 요금을 쓰다가 야간 정액을 쓰고 다시 일반 요금을 쓰게 되면 두 개의 일반 요금을 각각 따로 계산이 된다.

시작 시간과, 기간이 주어지면, PC방에 소요되는 최소요금을 구하여라

## 🔍 풀이 방법
결국 핵심은 밤->낮, 낮 ->밤이다. 이때를 각각 3,4가지의 케이스로 나누어서 전부 별도의 로직으로 처리해주었다.
이때 밤으로 넘어갈때 반드시 딱 오후 10시부터 시작이 아니라는 점을 잘 인지하고 해야한다.

## ⏳ 회고
분명히 이전에 상어를 하도 풀어서 구현/시뮬은 자신있었는데 이번에는 계속 조건을 하나씩 빼먹어서 한참걸렸다.... B형까지 이런거 더풀어봐야지