### PR TITLE
[20250729] BOJ / G5 / 강의실 배정 / 이강현

### DIFF
--- a/lkhyun/202507/29 BOJ G5 강의실 배정.md
+++ b/lkhyun/202507/29 BOJ G5 강의실 배정.md
@@ -1,0 +1,35 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N;
+
+    public static void main(String[] args) throws Exception {
+        N = Integer.parseInt(br.readLine());
+        List<int[]> arr = new LinkedList<>();
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            arr.add(new int[]{Integer.parseInt(st.nextToken()),Integer.parseInt(st.nextToken())});
+        }
+        Collections.sort(arr,(a,b) -> a[0] - b[0]);
+
+        PriorityQueue<Integer> pq = new PriorityQueue<>();
+
+        int ans = 1;
+        for (int[] cur : arr) {
+            while(!pq.isEmpty() && pq.peek() <= cur[0]){
+                pq.poll();
+            }
+            pq.offer(cur[1]);
+            ans = Math.max(ans,pq.size());
+        }
+        bw.write(ans+"");
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11000
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
강의실에서는 한개의 수업만 가능하다.
수업의 시작과 끝나는 시간이 주어졌을때, 최소한의 강의실로 모든 수업을 끝내도록 한다.
이때 강의실의 수를 출력
## 🔍 풀이 방법
우선순위 큐, 정렬
시작시간 기준 정렬을 하고 우선 순위큐에 강의들의 종료시간을 넣어둔다.
우선순위큐의 peek와 다음 수업의 시작시간을 비교했을때, 아직 peek가 더 작다면 종료되고 수업을 시작한다는 의미이므로 큐에서 제거한다.(강의실 재사용)
매 순간 pq의 사이즈를 체크하여 큐의 사이즈가 가장 클때의 값이 동시에 수업을 진행하기 위한 최소 강의실의 수이다.
## ⏳ 회고
회의실 배정 문제인줄알고 일단 종료시간으로 정렬해놓고 생각하다 오래걸렸다.
뭔가 묘하게 달라서 좀 어려웠다.