### PR TITLE
[20250730] BOJ / G4 / 가장 긴 증가하는 부분 수열 4 / 이준희

### DIFF
--- a/JHLEE325/202507/30 BOJ G4 가장 긴 증가하는 부분 수열 4.md
+++ b/JHLEE325/202507/30 BOJ G4 가장 긴 증가하는 부분 수열 4.md
@@ -1,0 +1,55 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+
+        int[] arr = new int[n];
+        int[] dp = new int[n];
+        int[] prev = new int[n];
+        Arrays.fill(dp, 1);
+        Arrays.fill(prev, -1);
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < i; j++) {
+                if (arr[i] > arr[j] && dp[i] < dp[j] + 1) {
+                    dp[i] = dp[j] + 1;
+                    prev[i] = j;
+                }
+            }
+        }
+
+        int max = 0, idx = 0;
+        for (int i = 0; i < n; i++) {
+            if (dp[i] > max) {
+                max = dp[i];
+                idx = i;
+            }
+        }
+
+        Stack<Integer> stack = new Stack<>();
+        while (idx != -1) {
+            stack.push(arr[idx]);
+            idx = prev[idx];
+        }
+
+        System.out.println(max);
+        while (!stack.isEmpty()) {
+            System.out.print(stack.pop() + " ");
+        }
+
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14002

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
수열 중 LIS 를 구하고 그 수열 자체도 출력하는 문제입니다.

## 🔍 풀이 방법
dp를 사용해서 LIS를 구하고 그 때마다 배열을 하나 더 사용해서 이전 index를 저장했습니다.
마지막에 스택을 이용한 역추적으로 풀이했습니다.

## ⏳ 회고
요새 역추적 문제를 많이 만났던 것 같아서 수월하게 푼 것 같습니다.
