### PR TITLE
 [20250730] BOJ / G4 / 가장 긴 바이토닉 부분 수열 / 이종환

### DIFF
--- a/0224LJH/202507/30 BOJ 가장 긴 바이토닉 부분 수열 .md
+++ b/0224LJH/202507/30 BOJ 가장 긴 바이토닉 부분 수열 .md
@@ -1,0 +1,58 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+    static int[] arr,lis,lds;
+    static int len,ans;
+
+
+    public static void main(String[] args) throws IOException {
+        init();
+        process();
+        print();
+    }
+
+    private static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        len = Integer.parseInt(br.readLine());
+        arr = new int[len];
+        lis = new int[len];
+        lds = new int[len];
+        ans = 0;
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < len; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+    }
+
+    private static void process() throws IOException {
+        Arrays.fill(lis, 1);
+        Arrays.fill(lds, 1);
+
+        for (int i = 1; i < len; i++) {
+            for (int j = 0; j < i; j++){
+                if (arr[i] > arr[j]) lis[i] = Math.max(lis[i], lis[j] + 1);
+            }
+        }
+
+        for (int i = len -1; i >= 0; i--) {
+            for (int j = len-1; j > i; j--){
+                if (arr[i] > arr[j]) lds[i] = Math.max(lds[i], lds[j] + 1);
+            }
+        }
+
+        for (int i = 0; i < len; i++){
+            ans = Math.max(ans, lis[i] + lds[i] - 1);
+        }
+    }
+
+    private static void print() {
+        System.out.println(ans);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11054

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
수열 A가 주어졌을 때, 그 수열의 부분 수열 중 바이토닉 수열이면서 가장 긴 수열의 길이를 구하는 프로그램을 작성하시오.

## 🔍 풀이 방법
바이토닉 수열이라고 해서 헷갈릴 수 있는데, 잘 생각해보면 그냥 lis와, 역방향 lis 이렇게 두개를 각각 구하면 간단하게 풀리는 너무나도 쉬운 문제이다. 길이도 최대 1000이라 O(n^2)방식으로 진행해도 문제가 되지 않는다

## ⏳ 회고
더 여려운것을 풀고싶다면 O(nlogn)방식의 리미트가 걸린 문제들을 시도해보자