### PR TITLE
[20250730] BOJ / G4 / 이중 우선순위 큐 / 이인희

### DIFF
--- a/LiiNi-coder/202507/30 BOJ 이중 우선순위 큐.md
+++ b/LiiNi-coder/202507/30 BOJ 이중 우선순위 큐.md
@@ -1,0 +1,43 @@
+```java
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+import java.util.TreeMap;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+
+        for(int t = 0; t<T; t++){
+            int K = Integer.parseInt(br.readLine());
+            TreeMap<Integer, Integer> map = new TreeMap<>();
+
+            for (int i = 0; i < K; i++) {
+                StringTokenizer st = new StringTokenizer(br.readLine());
+                String command = st.nextToken();
+                int value = Integer.parseInt(st.nextToken());
+
+                if (command.equals("I")) {
+                    map.put(value, map.getOrDefault(value, 0) + 1);
+                } else if (command.equals("D")) {
+                    if (map.isEmpty())
+                        continue;
+                    int key = (value == 1) ? map.lastKey() : map.firstKey();
+                    int count = map.get(key);
+                    if (count == 1) {
+                        map.remove(key);
+                    } else {
+                        map.put(key, count - 1);
+                    }
+                }
+            }
+            if (map.isEmpty()) {
+                System.out.println("EMPTY");
+            } else {
+                System.out.println(map.lastKey() + " " + map.firstKey());
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/7662
## 🧭 풀이 시간
60 분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
이중 우선순위 큐: 우선순위 큐의 삽입은 동일, 삭제일땐 가장 높은 데이터를 지우거나 가장 낮은 데이터를 지우는 것에서 다름
이 이중 우선순위 큐에 대해 삭제, 삽입이 input으로 여러번 주어지고, 그 중 하나의 상태에서 큐안에 존재하는 최댓값과 최솟값을 출력하는 프로그램
## 🔍 풀이 방법
- TreeMap을 이용하면, firstkey, lastkey를 사용할 수 있다. 이를 이용하여 쉽게 구할 수 있다.
## ⏳ 회고
우선순위 큐 두개를 사용하는 방법을 시도하다가 잘 안풀렸다. 그래서 찾아본 결과 TreeMap을 이용해, 가장 높은키, 낮은 키를 O(logN)에 구할 수 있다는 것을 알았다. 또한, 우선순위 큐 두개를 활용하는 방법을 사용하기 위해선 이를 동기화 해주는 HashMap을 사용하면 된다고한다. 나중에 다시 풀어볼것.