### PR TITLE
[20250731] BOJ / G3 / 최소비용 구하기 2 / 이준희

### DIFF
--- a/JHLEE325/202507/31 BOJ G3 최소비용 구하기 2.md
+++ b/JHLEE325/202507/31 BOJ G3 최소비용 구하기 2.md
@@ -1,0 +1,89 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static class Node implements Comparable<Node> {
+        int dest, cost;
+        Node(int dest, int cost) {
+            this.dest = dest;
+            this.cost = cost;
+        }
+
+        @Override
+        public int compareTo(Node o) {
+            return this.cost - o.cost;
+        }
+    }
+
+    static int n, m, start, destination;
+    static List<List<Node>> graph = new ArrayList<>();
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        n = Integer.parseInt(br.readLine());
+        m = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i <= n; i++) {
+            graph.add(new ArrayList<>());
+        }
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int s = Integer.parseInt(st.nextToken());
+            int d = Integer.parseInt(st.nextToken());
+            int c = Integer.parseInt(st.nextToken());
+            graph.get(s).add(new Node(d, c));
+        }
+
+        st = new StringTokenizer(br.readLine());
+        start = Integer.parseInt(st.nextToken());
+        destination = Integer.parseInt(st.nextToken());
+
+        dijkstra(start, destination);
+    }
+
+    static void dijkstra(int start, int end) {
+        int[] dist = new int[n + 1];
+        int[] prev = new int[n + 1];
+        Arrays.fill(dist, Integer.MAX_VALUE);
+        Arrays.fill(prev, -1);
+
+        PriorityQueue<Node> pq = new PriorityQueue<>();
+        dist[start] = 0;
+        pq.add(new Node(start, 0));
+
+        while (!pq.isEmpty()) {
+            Node cur = pq.poll();
+
+            if (dist[cur.dest] < cur.cost) continue;
+
+            for (Node next : graph.get(cur.dest)) {
+                if (dist[next.dest] > dist[cur.dest] + next.cost) {
+                    dist[next.dest] = dist[cur.dest] + next.cost;
+                    prev[next.dest] = cur.dest;
+                    pq.add(new Node(next.dest, dist[next.dest]));
+                }
+            }
+        }
+
+        List<Integer> path = new ArrayList<>();
+        int cur = end;
+        while (cur != -1) {
+            path.add(cur);
+            cur = prev[cur];
+        }
+        Collections.reverse(path);
+
+        System.out.println(dist[end]);
+        System.out.println(path.size());
+        for (int p : path) {
+            System.out.print(p + " ");
+        }
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11779

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
도시와 그 도시 사이를 이동하는 버스 정보가 주어졌을 때
주어진 출발점에서 도착점까지의 최소비용 경로에 포함된 도시 갯수와 그 도시를 출력하는 문제입니다.,

## 🔍 풀이 방법
다익스트라를 이용해 최소비용을 구하면서 prev 배열에 출발했던 도시의 인덱스를 저장했습니다.
계산이 완료된 후 prev을 역추적하여 경로 및 방문 도시 개수를 파악했습니다.

## ⏳ 회고
최근 역추적 문제가 심심치않게 보이는데 점점 숙달 되는 것 같습니다.
다익스트라와 역추적에 관한 개념만 있었다면 G3까지는 아닌 것 같습니다.
