### PR TITLE
[20250731] BOJ / G5 / 두 수의 합 / 설진영

### DIFF
--- a/Seol-JY/202507/31 BOJ G5 두 수의 합.md
+++ b/Seol-JY/202507/31 BOJ G5 두 수의 합.md
@@ -1,0 +1,54 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        
+        int t = Integer.parseInt(br.readLine());
+        
+        for (int tc = 0; tc < t; tc++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int n = Integer.parseInt(st.nextToken());
+            int k = Integer.parseInt(st.nextToken());
+            
+            int[] arr = new int[n];
+            st = new StringTokenizer(br.readLine());
+            for (int i = 0; i < n; i++) {
+                arr[i] = Integer.parseInt(st.nextToken());
+            }
+            
+            Arrays.sort(arr);
+            
+            int left = 0;
+            int right = n - 1;
+            int minDiff = Integer.MAX_VALUE;
+            int count = 0;
+            
+            while (left < right) {
+                int sum = arr[left] + arr[right];
+                int diff = Math.abs(sum - k);
+                
+                if (diff < minDiff) {
+                    minDiff = diff;
+                    count = 1;
+                } else if (diff == minDiff) {
+                    count++;
+                }
+                
+                if (sum < k) {
+                    left++;
+                } else {
+                    right--;
+                }
+            }
+            
+            sb.append(count).append('\n');
+        }
+        
+        System.out.print(sb);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/9024

## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
n개의 정수로 이루어진 수열에서 두 수를 골라 그 합이 k에 가장 가까운 경우의 수를 구하는 문제

## 🔍 풀이 방법
투포인터 사용 left, right 포인터로 양 끝에서 시작해서 합을 계산

## ⏳ 회고
투 포인터 기본 문제인듯