### PR TITLE
[20250801] BOJ / G4 / 키 순서 / 이준희

### DIFF
--- a/JHLEE325/202508/01 BOJ G4 키 순서.md
+++ b/JHLEE325/202508/01 BOJ G4 키 순서.md
@@ -1,0 +1,49 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        boolean[][] arr = new boolean[n][n];
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken()) - 1;
+            int b = Integer.parseInt(st.nextToken()) - 1;
+            arr[a][b] = true;
+        }
+
+        for (int k = 0; k < n; k++) {
+            for (int i = 0; i < n; i++) {
+                for (int j = 0; j < n; j++) {
+                    if (arr[i][k] && arr[k][j])
+                        arr[i][j] = true;
+                }
+            }
+        }
+
+        int cnt = 0;
+        for (int i = 0; i < n; i++) {
+            boolean isknow = true;
+            for (int j = 0; j < n; j++) {
+                if (i == j)
+                    continue;
+                if (!arr[i][j] && !arr[j][i])
+                    isknow = false;
+            }
+            if (isknow)
+                cnt++;
+        }
+
+        System.out.println(cnt);
+    }
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2458

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
학생들의 수와 두 학생간의 키 비교 정보들이 주어졌을 때
자신의 키가 몇번째인지 알 수 있는 학생의 수를 구하는 문제입니다.

## 🔍 풀이 방법
boolean 배열을 이용하여 키 대소정보를 저장하고
플로이드 워셜을 통해 전파하여 배열을 완성했습니다.
추후 i번째 학생으로 순회할 때 j 번째보다 큰지 작은지 판단할 수 없는 경우를 계산했습니다.

## ⏳ 회고
A형 취득 문제였을 때는 틀렸는데 이번에는 맞췄습니다.
입력 받을 때 생각없이 양방향 모두 true 처리해버려서 고생할 뻔 했습니다
