### PR TITLE
[20250802] BOJ / G4 / 오큰수 / 이준희

### DIFF
--- a/JHLEE325/202508/02 BOJ G4 오큰수.md
+++ b/JHLEE325/202508/02 BOJ G4 오큰수.md
@@ -1,0 +1,41 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+        int[] arr = new int[n];
+        int[] result = new int[n];
+        Stack<Integer> stk = new Stack<>();
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        for (int i = n - 1; i >= 0; i--) {
+            while (!stk.isEmpty()) {
+                if (stk.peek() > arr[i]) {
+                    result[i] = stk.peek();
+                    break;
+                } else stk.pop();
+            }
+            if (stk.isEmpty()) result[i] = -1;
+            stk.push(arr[i]);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < n; i++) {
+            sb.append(result[i] + " ");
+        }
+
+        System.out.println(sb.toString());
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17298

## 🧭 풀이 시간
15분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
수열이 주어졌을  때 어떤 위치의 수보다 오른쪽에 있으면서 그 수보다 큰 수중 가장 왼쪽에 있는 수를 오큰수라고 합니다.
각 수의 오큰수를 모두 출력하는 문제입니다.

## 🔍 풀이 방법
스택을 이용하여 풀었습니다.
큰 값을 찾을 때 까지 pop을 하고
스택이 빈 경우에는 -1을 입력했습니다.

## ⏳ 회고
얼마전에 스택, 자료구조를 이용한 문제를 풀었던것 같은데 그 기억이 도움이 되었습니다.