### PR TITLE
[20250802] BOJ / G5 / 1학년 / 이인희

### DIFF
--- a/LiiNi-coder/202508/02 BOJ 1학년.md
+++ b/LiiNi-coder/202508/02 BOJ 1학년.md
@@ -1,0 +1,45 @@
+```java
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    static int N;
+    static int[] A;
+    static long[][] dp; // [index][sum], sum은 0이상 20미만
+    static long dfs(int idx, int result) {
+        if (result < 0 || result > 20) return 0;
+        if (idx == 0) {
+            // idx==0이면 a = a 인것 1개의 경우의수 아니면 a = b형태라 0의 경우의수
+            return (result == A[0])? 1 : 0;
+        }
+        if (dp[idx][result] != -1) return dp[idx][result];
+
+        long count = 0; // 경우의수
+        count += dfs(idx - 1, result + A[idx]);
+        count += dfs(idx - 1, result - A[idx]);
+        dp[idx][result] = count;
+        return count;
+    }
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        A = new int[N];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            A[i] = Integer.parseInt(st.nextToken());
+        }
+
+        dp = new long[N][21]; // 인덱스: 0~N-1, sum: 0~20
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j <= 20; j++) {
+                dp[i][j] = -1;
+            }
+        }
+
+        System.out.println(dfs(N - 2, A[N - 1]));
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/5557
## 🧭 풀이 시간
40 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 어떤 수열이 주어지고, 이 수열의 맨 끝의 두 숫자 사이에 = 이 들어가고, 나머지 숫자 사이에 + 아니면 - 를 넣어 등식이 성립되는 경우의 수 전부출력. 단, 도중의 연산 결과는 0이상 20이하인것들만 경우의 수로 셈
## 🔍 풀이 방법
- dp를 이용하였고, 탑다운 방식으로 적용
```
예를 들어서 
8 3 2 4 8 7 2 4 0 8 8 이렇게 입력이 주어지면, 0번째부터 10번째까지의 결과 값이 a[10] + a[9]인 16일수도 있고,
a[10]-a[9]인 0 일수있고, 이를 또 구하기 위해서 0번째부터 9번쨰까지의 결과 값이 16 + a[8]일수있고, 16 - a[8] 일수있고..
```
## ⏳ 회고
- 아직 dp에 익숙하지않아, 탑다운으로 밖에 풀이 방법이 들지않았다. 그리고 dfs로 진행하다 이전에 계산한 결과를 표현하기 위해 dp[index][sum]을 사용하여 더이상 dfs가 가지치기하지않도록 한다는 것을 염두하자