### PR TITLE
[20250803] BOJ / G5 / 태상이의 훈련소 생활 / 이인희

### DIFF
--- a/LiiNi-coder/202508/03 BOJ 태상이의 훈련소 생활.md
+++ b/LiiNi-coder/202508/03 BOJ 태상이의 훈련소 생활.md
@@ -1,0 +1,49 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.StringTokenizer;
+
+public class Main {
+	private static int M;
+	private static int N;
+	private static BufferedReader br;
+	private static int[] A;
+	private static int[] diffArr;
+
+	public static void main(String[] args) throws IOException {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		String[] temp = br.readLine().split(" ");
+		N = Integer.parseInt(temp[0]);
+		M = Integer.parseInt(temp[1]);
+		diffArr = new int[N+1]; // 차분배
+		A = new int[N];
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		for(int i = 0; i<N; i++)
+			A[i] = Integer.parseInt(st.nextToken());
+		for(int m = 0; m<M; m++) {
+			st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken())-1;
+			int b = Integer.parseInt(st.nextToken()) ;
+			int diff = Integer.parseInt(st.nextToken());
+			diffArr[a] += diff;
+			diffArr[b] += -diff;
+		}
+		for(int i = 1; i<N; i++) {
+			diffArr[i] += diffArr[i-1];
+		}
+		//System.out.println(Arrays.toString(diffArr));
+		StringBuilder sb = new StringBuilder();
+		for(int i = 0; i<N;i++) {
+			A[i] += diffArr[i];
+			sb.append(A[i]);
+			sb.append(" ");
+		}
+		System.out.println(sb.toString());
+		br.close();
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/19951
## 🧭 풀이 시간
35 분

## 👀 체감 난이도
- [ ] 상
- [X] 중
- [ ] 하
## ✏️ 문제 설명
- 수열에서 어느 범위구간의 일괄 덧셈, 및 일괄 뺄셈 명령어가 수많이 들어가있다. 이 일괄을 계속 행하는 것은 시간상 오래걸리니, 이 일괄들을 한번에 처리하여 딱 한번만 범위 일괄 연산을 하도록 하여라.
## 🔍 풀이 방법
- `차분배열` : 1번째부터 3번째까지 4를 더한다고 하면, 차분배열[1] = 4, 차분배열[3+1] = -4 이렇게 표기한다. 그러다 연산이 모두 끝나면 차분배열을 누적합시킨다. 그렇다면 드디어 최종 차이배열이 생성되고, 원본과 이 차이배열을 더하면 된다.
## ⏳ 회고
- B형문제에서 이를 사용한 문제가 나왔다. 차분배열 개념은 넌지시 사용하였으나, 이를 누적합시키면 원하는 최종 차이배열이 생긴다는 것을 알아내지 못했다. 이제 외우자
- `구간 일괄 연산` == `차분배열` + 연산 모두 끝나면 `차분배열을 누적합`