### PR TITLE
[20250803] BOJ / G5 / 4와 7 / 김수연

### DIFF
--- a/suyeun84/202508/03 BOJ G5 4와 7.md
+++ b/suyeun84/202508/03 BOJ G5 4와 7.md
@@ -1,0 +1,30 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class boj2877 {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static StringBuilder sb = new StringBuilder();
+
+	public static void main(String[] args) throws Exception {
+		nextLine();
+		int K = nextInt() + 1;
+		
+		int num = 0;
+        while(K != 0){
+            num = K % 2;
+            sb.append(num);
+            K = K / 2;
+        }
+        StringBuilder result = new StringBuilder();
+        for(int i = sb.toString().length() - 2; i >= 0; i--){
+            if(sb.charAt(i) == '0') result.append(4);
+            else result.append(7);
+        }
+        System.out.println(result.toString());
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2877
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
4와 7로 이루어진 수 중에서 K번째 작은 수 구하기
## 🔍 풀이 방법
K+1해서 이진수를 구하고,
맨 끝자리 수 빼고 이를 4와 7로 교환해주었다.
## ⏳ 회고
비트마스킹을 사용해서도 풀어봐야겠다.