### PR TITLE
[20250803] BOJ / G4 / 타일 채우기 / 이강현

### DIFF
--- a/lkhyun/202508/03 BOJ G4 타일 채우기.md
+++ b/lkhyun/202508/03 BOJ G4 타일 채우기.md
@@ -1,0 +1,30 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N;
+    static int[] dp;
+
+    public static void main(String[] args) throws Exception {
+        int N = Integer.parseInt(br.readLine());
+        if(N%2 == 1){
+            bw.write("0");
+            bw.close();
+            return;
+        }
+
+        dp = new int[N+1];
+        dp[0] = 1;
+        dp[2] = 3;
+        for (int i = 4; i <= N; i++) {
+            dp[i] = 4*dp[i-2] - dp[i-4];
+        }
+        bw.write(dp[N]+"");
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2133
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
3xN의 타일을 1x2와 2x1의 타일로 채우는 경우의 수 출력.

## 🔍 풀이 방법
dp
<img width="768" height="295" alt="image" src="https://github.com/user-attachments/assets/3ccdb588-169b-4a58-b858-292c7c9bf846" />
2칸을 채우는 경우는 위와 같음.
그러면 i번째에서 dp[i-2] * 3을 하면 됨.

<img width="749" height="336" alt="image" src="https://github.com/user-attachments/assets/1cdeb8f5-f7db-440c-9f6e-80f54497c2c3" />
근데 위처럼 딱 2칸을 맞춰서 놓지 않을 수도 있음. 근데 이 경우는 결국 강제적으로 결정됨. 해당 칸에서 결정할 수 없음. 즉 dp[i-2]를 추가로 더해주면 됨.

그럼 dp[i]는 4 * dp[i-2] 일텐데, 중복이 있음.
<img width="578" height="301" alt="image" src="https://github.com/user-attachments/assets/35651ad9-e4fd-4376-9efc-96d48e31ae91" />
이 경우는 두번 더해졌을 거임. 따라서 dp[i-4]를 한번 빼줌.

## ⏳ 회고
타일 채우기 문제는 일단 몇개를 놔보고 경우의 수를 정립한 후에 맨 마지막 부분을 어떻게 채울지 생각하는 것에서 시작하는 것 같음.