### PR TITLE
[20250803] BOJ / G5 / 강의실 배정 / 이준희

### DIFF
--- a/JHLEE325/202508/03 BOJ G5 강의실 배정.md
+++ b/JHLEE325/202508/03 BOJ G5 강의실 배정.md
@@ -1,0 +1,52 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static class study implements Comparable<study> {
+        int start, end;
+
+        study(int s, int e) {
+            start = s;
+            end = e;
+        }
+
+        @Override
+        public int compareTo(study o) {
+            if (this.start != o.start)
+                return Integer.compare(this.start, o.start);
+            return Integer.compare(this.end, o.end);
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        int N = Integer.parseInt(br.readLine());
+
+        study[] studies = new study[N];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            int s = Integer.parseInt(st.nextToken());
+            int e = Integer.parseInt(st.nextToken());
+            studies[i] = new study(s, e);
+        }
+
+        Arrays.sort(studies);
+
+        PriorityQueue<Integer> pq = new PriorityQueue<>();
+        pq.add(studies[0].end);
+
+        for (int i = 1; i < N; i++) {
+            int curStart = studies[i].start;
+            int curEnd = studies[i].end;
+            if (!pq.isEmpty() && pq.peek() <= curStart) {
+                pq.poll();
+            }
+            pq.add(curEnd);
+        }
+
+        System.out.println(pq.size());
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11000

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
강의의 개수와 각 강의들의 시작시간, 끝시간이 주어질 때 모든 수업을 가능케하는 최소의 강의실 개수를 구하는 문제입니다.

## 🔍 풀이 방법
배열을 시작시간, 끝시간 으로 정렬한 후 큐에 넣어가면서 강의실을 새로 배정했습니다.
현재 강의실을 배정해야할 강의의 시작시간이 큐에 남아있는 강의의 끝시간보다 뒤인 경우에는 그 강의실을 재사용 가능하기 때문에
poll 하고 새 강의를 다시 넣어주었습니다.

## ⏳ 회고
문제 자체를 이해하는데 시간이 좀 걸렸고
일반적인 회의실 배정 같은 그리디 문제로 접근하려다 보니 막혔습니다.
알고리즘 개념 여러개가 섞인 느낌이다 보니 골드 5의 체감보다는 어려웠던 것 같습니다.
