### PR TITLE
[20250804] BOJ / G5 / 선수과목 / 이준희

### DIFF
--- a/JHLEE325/202508/04 BOJ G5 선수과목.md
+++ b/JHLEE325/202508/04 BOJ G5 선수과목.md
@@ -1,0 +1,51 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        StringBuilder sb = new StringBuilder();
+
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        List<List<Integer>> graph = new ArrayList<>(n + 1);
+        for (int i = 0; i <= n; i++) graph.add(new ArrayList<>());
+
+        int[] indeg = new int[n + 1];
+        int[] semester = new int[n + 1];
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            graph.get(a).add(b);
+            indeg[b]++;
+        }
+
+        Deque<Integer> q = new ArrayDeque<>();
+        for (int i = 1; i <= n; i++) {
+            if (indeg[i] == 0) {
+                semester[i] = 1;
+                q.offer(i);
+            }
+        }
+
+        while (!q.isEmpty()) {
+            int cur = q.poll();
+            for (int nxt : graph.get(cur)) {
+                semester[nxt] = Math.max(semester[nxt], semester[cur] + 1);
+                if (--indeg[nxt] == 0) q.offer(nxt);
+            }
+        }
+
+        for (int i = 1; i <= n; i++) {
+            sb.append(semester[i]).append(' ');
+        }
+        System.out.println(sb.toString().trim());
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14567

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
각 과목들의 선수과목이 주어졌을 때
각 과목을 들을 수 있는 가장 빠른 학기들을 구하는 문제입니다.

## 🔍 풀이 방법
각 과목들의 선수과목 정보들이 주어지기 때문에
위상정렬을 이용해서 풀었습니다.

## ⏳ 회고
선수과목이 여러개일 수도 있는 경우를 빠르게 인지해야 하는 것이 포인트였습니다.
