### PR TITLE
[20250804] BOJ / D5 / 반평면 땅따먹기 / 권혁준

### DIFF
--- a/khj20006/202508/04 BOJ D5 반평면 땅따먹기.md
+++ b/khj20006/202508/04 BOJ D5 반평면 땅따먹기.md
@@ -1,0 +1,169 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+    BufferedReader br;
+    BufferedWriter bw;
+    StringTokenizer st;
+
+    public IOController() {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        st = new StringTokenizer("");
+    }
+
+    String nextLine() throws Exception {
+        String line = br.readLine();
+        st = new StringTokenizer(line);
+        return line;
+    }
+
+    String nextToken() throws Exception {
+        while (!st.hasMoreTokens()) nextLine();
+        return st.nextToken();
+    }
+
+    int nextInt() throws Exception {
+        return Integer.parseInt(nextToken());
+    }
+
+    long nextLong() throws Exception {
+        return Long.parseLong(nextToken());
+    }
+
+    double nextDouble() throws Exception {
+        return Double.parseDouble(nextToken());
+    }
+
+    void close() throws Exception {
+        bw.flush();
+        bw.close();
+    }
+
+    void write(String content) throws Exception {
+        bw.write(content);
+    }
+
+}
+
+class Line {
+    long a, b;
+    Line(long a, long b) {
+        this.a = a;
+        this.b = b;
+    }
+    long get(long x) {
+        return a*x + b;
+    }
+}
+
+class Node {
+    int l, r;
+    long s, e;
+    Line line;
+    Node(long s, long e, Line line) {
+        this.l = -1;
+        this.r = -1;
+        this.s = s;
+        this.e = e;
+        this.line = line;
+    }
+}
+
+class LiChao {
+    List<Node> tree;
+    LiChao(long s, long e) {
+        tree = new ArrayList<>();
+        tree.add(new Node(s, e, new Line(0, -(long)1e18-1)));
+    }
+
+    void update(int n, Line line) {
+        long s = tree.get(n).s, e = tree.get(n).e, m = (s+e)>>1;
+
+        Line low = tree.get(n).line, high = line;
+        if(low.get(s) > high.get(s)) {
+            low = line;
+            high = tree.get(n).line;
+        }
+
+        if(low.get(e) <= high.get(e)) {
+            tree.get(n).line = high;
+            return;
+        }
+
+        if(low.get(m) <= high.get(m)) {
+            tree.get(n).line = high;
+            if(tree.get(n).r == -1) {
+                tree.get(n).r = tree.size();
+                tree.add(new Node(m+1,e,new Line(0, -(long)1e18-1)));
+            }
+            update(tree.get(n).r, low);
+        }
+        else {
+            tree.get(n).line = low;
+            if(tree.get(n).l == -1) {
+                tree.get(n).l = tree.size();
+                tree.add(new Node(s,m,new Line(0, -(long)1e18-1)));
+            }
+            update(tree.get(n).l, high);
+        }
+    }
+
+    long query(int n, long x) {
+        if(n == -1) return -(long)1e18 - 1;
+        long s = tree.get(n).s, e = tree.get(n).e, m = (s+e)>>1;
+        long v = tree.get(n).line.get(x);
+        if(x <= m) return Math.max(v, query(tree.get(n).l, x));
+        return Math.max(v, query(tree.get(n).r, x));
+    }
+}
+
+public class Main {
+
+    static IOController io;
+
+    //
+
+    static int Q;
+    static LiChao tree;
+
+    public static void main(String[] args) throws Exception {
+
+        io = new IOController();
+
+        init();
+        solve();
+
+        io.close();
+
+    }
+
+    static void init() throws Exception {
+
+        Q = io.nextInt();
+        tree = new LiChao(-(long)1e12, (long)1e12);
+
+    }
+
+    static void solve() throws Exception {
+
+        while(Q-->0) {
+            int op = io.nextInt();
+
+            if(op == 1) {
+                long a = io.nextLong();
+                long b = io.nextLong();
+                tree.update(0, new Line(a,b));
+            }
+            else {
+                long x = io.nextLong();
+                io.write(tree.query(0, x) + "\n");
+            }
+
+        }
+
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/12795

## 🧭 풀이 시간
45분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
직선 `y = ax + b`를 좌표평면에 추가하면, 해당 직선으로 인해 나누어지는 두 반평면 중 (0, -INF)를 포함하는 반평면을 먹을 수 있다.
직선을 추가하는 작업과, 특정 x좌표에서의 먹은 영역 중 y좌표 최댓값을 구하는 작업이 총 Q회 주어지면 작업을 처리해보자.

## 🔍 풀이 방법
- 볼록 껍질을 이용한 최적화
---
직선 관리를 효율적으로 하기 위해, 볼록 껍질을 이용한 최적화를 적용
구간 [-1e12, 1e12]에 대해 Li-Chao 트리로 특정 구간에서 최대가 되는 직선들을 관리한다.

## ⏳ 회고
오랜만에 해서 가물가물하다