### PR TITLE
[20250805] BOJ / G5 / ABCDE / 이준희

### DIFF
--- a/JHLEE325/202508/05 BOJ G5 ABCDE.md
+++ b/JHLEE325/202508/05 BOJ G5 ABCDE.md
@@ -1,0 +1,57 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static int n, m;
+    static List<Integer>[] friends;
+    static boolean[] visited;
+    static boolean found = false;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        friends = new ArrayList[n];
+        for (int i = 0; i < n; i++) friends[i] = new ArrayList<>();
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            friends[a].add(b);
+            friends[b].add(a);
+        }
+
+        visited = new boolean[n];
+        for (int i = 0; i < n && !found; i++) {
+            visited[i] = true;
+            dfs(i, 1);
+            visited[i] = false;
+        }
+
+        System.out.println(found ? 1 : 0);
+    }
+
+    static void dfs(int cur, int depth) {
+        if (found) return;
+        if (depth == 5) {
+            found = true;
+            return;
+        }
+
+        for (int next : friends[cur]) {
+            if (visited[next]) continue;
+            visited[next] = true;
+            dfs(next, depth + 1);
+            visited[next] = false;
+            if (found) return;
+        }
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/13023

## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
친구관계가 주어질 때 A->B->C->D->E 처럼 5명이 연속으로 친구가 되는 경우에 1 앞선 경우가 없으면 0을 출력하는 문제입니다.

## 🔍 풀이 방법
dfs를 이용하여 풀었습니다.
5명이 연속해서 친구가 되면 플래그를 true로 하여 이를 판단하여 출력하였습니다.

## ⏳ 회고
n이 2000이었기 때문에 최대 2억번 연산이고 시간제한이 2초라서 인접행렬로 풀었는데 시간초과가 발생해서 인접리스트로 바꿨습니다.
문제 조건을 잘 파악하여 사용해야겠습니다.