### PR TITLE
[20250805] BOJ / G5 / 수강 과목 / 김수연

### DIFF
--- a/suyeun84/202508/05 BOJ G5 수강 과목.md
+++ b/suyeun84/202508/05 BOJ G5 수강 과목.md
@@ -1,0 +1,35 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class boj17845 {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static StringBuilder sb = new StringBuilder();
+
+	public static void main(String[] args) throws Exception {
+		nextLine();
+		int N = nextInt();
+		int K = nextInt();
+		int[] prior = new int[K+1];
+		int[] time = new int[K+1];
+		int[][] bag = new int[K+1][N+1];
+		
+		for (int i = 1; i <= K; i++) {
+			nextLine();
+			prior[i] = nextInt();
+			time[i] = nextInt();
+		}
+		
+		for (int i = 1; i <= K; i++) {
+			for (int j = 1; j <= N; j++) {
+				if (time[i] <= j) bag[i][j] = Math.max(bag[i-1][j], bag[i-1][j-time[i]] + prior[i]);
+				else bag[i][j] = bag[i-1][j];
+			}
+		}
+		System.out.println(bag[K][N]);
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17845
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
공부 시간의 한계를 초과하지 않으면서 과목의 중요도 합이 최대가 되도록 과목을 선택했을 때,
최대가 되는 중요도 구하기
## 🔍 풀이 방법
i번째 시간에 들을 수 있는 최대 중요도를 bag 배열에 갱신해줌
점화식 : bag[i][j] = Math.max(bag[i-1][j], bag[i-1][j-time[i]] + prior[i]);
## ⏳ 회고
전형적인 배낭문제이다