### PR TITLE
[20250805] BOJ / G5 / 진우의 달 여행 (Large) / 이인희

### DIFF
--- a/LiiNi-coder/202508/05 BOJ 진우의 달 여행 (Large).md
+++ b/LiiNi-coder/202508/05 BOJ 진우의 달 여행 (Large).md
@@ -1,0 +1,63 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main {
+	private static BufferedReader br;
+
+	public static void main(String[] args) throws IOException {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		String[] temp = br.readLine().split(" ");
+		int n = Integer.parseInt(temp[0]);
+		int m = Integer.parseInt(temp[1]);
+
+		int[][] map = new int[n][m];
+		for (int i = 0; i < n; i++) {
+			temp = br.readLine().split(" ");
+			for (int j = 0; j < m; j++) {
+				map[i][j] = Integer.parseInt(temp[j]);
+			}
+		}
+
+		int[][][] dp = new int[n][m + 2][3];
+		int INF = Integer.MAX_VALUE;
+
+		for (int c = 1; c <= m; c++) {
+			for (int d = 0; d < 3; d++) {
+				dp[0][c][d] = map[0][c - 1]; // map은 0-based
+			}
+		}
+		for (int r = 1; r < n; r++) {
+			for (int c = 1; c <= m; c++) {
+				for (int dc : new int[] { -1, 0, 1 }) {
+					int dp2index = dc + 1;
+					int targetC = c + dc;
+					if (targetC < 1 || targetC > m) {
+						dp[r][c][dp2index] = INF;
+						continue;
+					}
+
+					int minPrev = INF;
+					for (int prevD = 0; prevD < 3; prevD++) {
+						if (prevD == dp2index) continue; // 같은 방향 연속 이동 금지
+						minPrev = Math.min(minPrev, dp[r - 1][targetC][prevD]);
+					}
+					if (minPrev == INF)
+						dp[r][c][dp2index] = INF;
+					else
+						dp[r][c][dp2index] = minPrev + map[r][c - 1];
+				}
+			}
+		}
+
+		int answer = INF;
+		for (int c = 1; c <= m; c++) {
+			for (int d = 0; d < 3; d++) {
+				answer = Math.min(answer, dp[n - 1][c][d]);
+			}
+		}
+		System.out.println(answer);
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17485
## 🧭 풀이 시간
40 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
nm매트릭스에 각 칸마다 수치가있고, 이 칸을 지나면서 해당 수치만큼 소모연료량이 올라감. 최종적으로 맨 윗줄에서 아랫줄로 이동하면서 가장 취소 소모연료량합산을 출력. 단, 아랫줄로 내려가는 것만 가능하며, 이전에 이동한 방향을 똑같이 이동할순없다.
## 🔍 풀이 방법
- DP사용(dp[r][c][d] = point(r, c)에서 d방향으로 왔을때 가장 최소 소모연료량 총합)
## ⏳ 회고
- 3중for문 앞에서 어떻게 이전 방향을 continue할수있도록 코드를 짤까 코드 구조에서 시간을 많이 잡아먹음.