### PR TITLE
[20250806] / BOJ / G4 / 인구 이동 / 이강현

### DIFF
--- a/lkhyun/202508/06 BOJ G4 인구 이동.md
+++ b/lkhyun/202508/06 BOJ G4 인구 이동.md
@@ -1,0 +1,78 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N,L,R;
+    static int[][] A;
+    static int[] di = {0,0,-1,1};
+    static int[] dj = {-1,1,0,0};
+
+    public static void main(String[] args) throws Exception {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        L = Integer.parseInt(st.nextToken());
+        R = Integer.parseInt(st.nextToken());
+
+        A = new int[N][N];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                A[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+        int ans = 0;
+        while(BFS()){
+            ans++;
+        }
+        bw.write(ans+"");
+        bw.close();
+    }
+    static boolean BFS(){
+        boolean check = false;
+        boolean[][] visited = new boolean[N][N];
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                if(!visited[i][j]){
+                    ArrayDeque<int[]> q = new ArrayDeque<>();
+                    q.offer(new int[]{i,j});
+                    visited[i][j] = true;
+
+                    int sum = 0;
+                    List<int[]> saveList = new ArrayList<>();
+                    while(!q.isEmpty()){
+                        int[] cur = q.poll();
+                        saveList.add(cur);
+
+                        sum += A[cur[0]][cur[1]];
+
+                        for (int k = 0; k < 4; k++) {
+                            int ni = cur[0] + di[k];
+                            int nj = cur[1] + dj[k];
+
+                            if(ni<0 || ni>=N || nj<0 || nj>=N || visited[ni][nj]) continue;
+
+                            int cond = Math.abs(A[ni][nj]-A[cur[0]][cur[1]]);
+                            if(cond >= L && cond <= R){
+                                q.offer(new int[]{ni,nj});
+                                visited[ni][nj] = true;
+                            }
+                        }
+                    }
+                    if(saveList.size() > 1){
+                        check = true;
+                        sum = sum/saveList.size();
+                        for (int[] s : saveList) {
+                            A[s[0]][s[1]] = sum;
+                        }
+                    }
+                }
+            }
+        }
+        return check;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16234
## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
NxN 나라에서 인접한 두 국가의 인구수 차이가 L 이상 R 이하인 경우 국경을 열어서
인구 이동을 진행한다. 이때 서로 나라간 이동이 가능한 경우 그 나라들을 연합이라고 한다.
연합에서의 인구이동은 연합내 모든 나라의 인구 수 합을 연합에 속한 나라의 수로 나누는 것이다.(소수점은 버린다)
인구이동이 일어나는 횟수를 출력하라.
## 🔍 풀이 방법
BFS
그냥 BFS하고 이동 여부 파악하고 q에 들어갔던 애들끼리만 인구수 조정하고 했음.
## ⏳ 회고
그냥 구현 하면 됐다. 함정없는 BFS 문제