### PR TITLE
[20250808] BOJ / G5 / 1, 2, 3 더하기 4 / 이강현

### DIFF
--- a/lkhyun/202508/08 BOJ G5 1, 2, 3 더하기 4.md
+++ b/lkhyun/202508/08 BOJ G5 1, 2, 3 더하기 4.md
@@ -1,0 +1,28 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+
+
+    public static void main(String[] args) throws Exception {
+        int T = Integer.parseInt(br.readLine());
+
+        for (int t = 0 ; t < T; t++){
+            int n = Integer.parseInt(br.readLine());
+            int[] dp = new int[n+1];
+            dp[0] = 1;
+            for (int i = 1; i <= 3; i++) {
+                for (int j = i; j <= n; j++) {
+                    dp[j] += dp[j-i];
+                }
+            }
+            bw.write(dp[n] + "\n");
+        }
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/15989
## 🧭 풀이 시간
10분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
1,2,3을 이용해서 n을 만드는 경우의 수
## 🔍 풀이 방법
dp
1+2와 2+1은 같으니 1,2,3 각각에 대해 n만큼에 대해서 누적으로 더하면 됨.
## ⏳ 회고
앙 동전띠