### PR TITLE
[20250808] BOJ / G5 / 1, 2, 3 더하기 4 / 김수연

### DIFF
--- a/suyeun84/202508/08 BOJ G5 1, 2, 3 더하기 4.md
+++ b/suyeun84/202508/08 BOJ G5 1, 2, 3 더하기 4.md
@@ -1,0 +1,28 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class boj15989 {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+
+	public static void main(String[] args) throws Exception {
+		nextLine();
+		int T = nextInt();
+		for (int tc = 0; tc < T; tc++) {
+			nextLine();
+			int n = nextInt();
+			int[] dp = new int[n+1];
+			dp[0] = 1;
+			for (int i = 1; i <= 3; i++) {
+				for (int j = i; j <= n; j++) {
+					dp[j] += dp[j-i];
+				}
+			}
+			System.out.println(dp[n]);
+		}
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/15989
## 🧭 풀이 시간
15분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
정수 n을 1, 2, 3의 합으로 나타내는 방법의 수 구하기
## 🔍 풀이 방법
dp사용해서 1 사용 했을 때 경우 2, 3 사용했을 때 경우 차례로 더해줌
## ⏳ 회고
세상 dp들이 다 이랬으면..