### PR TITLE
[20250808] BOJ / G5 / 빗물 / 이인희

### DIFF
--- a/LiiNi-coder/202508/08 BOJ 빗물.md
+++ b/LiiNi-coder/202508/08 BOJ 빗물.md
@@ -1,0 +1,36 @@
+```java
+import java.io.*;
+import java.util.*;
+public class Main {
+	private static BufferedReader br;
+	private static int H, W;
+	private static int[] Walls;
+	private static StringTokenizer st;
+	public static void main(String[] args) throws IOException {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		String[] temp = br.readLine().split(" ");
+		H = Integer.parseInt(temp[0]);
+		W = Integer.parseInt(temp[1]);
+		
+		st = new StringTokenizer(br.readLine());
+		int answer = 0;
+		int sum = 0;
+
+		int leftH = Integer.parseInt(st.nextToken());
+		for(int w = 1; w<W; w++) {
+			int wall = Integer.parseInt(st.nextToken());
+			if(wall < leftH) {
+				sum += leftH - wall;
+				continue;
+			}
+			leftH = wall;
+			answer += sum;
+			sum = 0;
+		}
+		answer -= sum;
+		System.out.println(answer);
+		br.close();
+		
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14719
## 🧭 풀이 시간
52 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 높이를 뜻하는 숫자들이 일렬로 나열되고, 이를 기준으로 빗물이 채워지면 몇칸 채워지는지 출력
## 🔍 풀이 방법
- **실패**
- 처음엔 왼쪽을 기준으로 세어나도록 풀어서, 오른쪽벽에 이전보다 높아졌지만, 처음 찍었던 왼쪽보다 낮은 경우를 무시해서 틀림
- 높이를 0부터 탐색하여, 비어있는 칸이 있을때마다, 오른쪽으로, 상위 왼쪽칸으로 이어지도록 bfs를 하여서 고이는 부분을 세어나가는 방법을 추후에 시도해볼것
## ⏳ 회고
- 의외로 구현에서 애를 먹은문제, 시간이 많으면 풀수있겠지만, 이런 골드5이상에 이정도 시간이 들었으면 더이상에 시간에서 풀어봤자 틀렸다고 여기는게 나을듯