### PR TITLE
[20250809] BOJ / G5 / 조 짜기 / 김수연

### DIFF
--- a/suyeun84/202508/09 BOJ G5 조 짜기.md
+++ b/suyeun84/202508/09 BOJ G5 조 짜기.md
@@ -1,0 +1,29 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class boj2229 {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+
+	public static void main(String[] args) throws Exception {
+		nextLine();
+		int N = nextInt();
+		nextLine();
+		int[] score = new int[N+1];
+		int[] dp = new int[N+1];
+		dp[0] = 0;
+		int max = 0;
+		for (int i = 1; i <= N; i++) {
+			score[i] = nextInt();
+			for (int j = i-1; j >= 1; j--) {
+				max = Math.max(max, Math.abs(score[i] - score[j]) + dp[j-1]);
+			}
+			dp[i] = max;
+		}
+		System.out.println(dp[N]);
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2229
## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
학생들의 점수가 나이 순으로 주어졌을 때,
실력 차이가 많이 나도록 조를 편성하되, 나이 차이가 많이 나면 부정적 효과가 난다.
조가 잘 짜여진 정도의 최댓값 구하기
## 🔍 풀이 방법
dp 사용
점수 입력 하나씩 받으면서 최대 차이 구하기
## ⏳ 회고
점화식을 찾고 시작하자