### PR TITLE
[20250809] BOJ / G2 / 저울 / 이종환

### DIFF
--- a/0224LJH/202508/9 BOJ  저울.md
+++ b/0224LJH/202508/9 BOJ  저울.md
@@ -1,0 +1,60 @@
+```java
+import java.awt.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+import java.util.List;
+
+
+public class Main {
+
+    static int size,ans;
+    static int[] arr;
+
+
+
+    public static void main(String[] args) throws IOException {
+        init();
+        process();
+        print();
+    }
+
+    private static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        size = Integer.parseInt(br.readLine());
+        arr = new int[size];
+        ans = 0;
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        for (int i = 0; i < size; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+
+    }
+
+    private static void process() throws IOException {
+        Arrays.sort(arr);
+
+        if ( arr[0] != 1) return;
+        ans = 1;
+
+        for (int i = 1; i < arr.length; i++) {
+            if (arr[i] > ans +1) {
+                return;
+            }
+            ans += arr[i];
+
+        }
+
+
+
+    }
+
+
+    private static void print() {
+        System.out.println(ans+1);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2437

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
무게가 양의 정수인 N개의 저울추가 주어질 때, 이 추들을 사용하여 측정할 수 없는 양의 정수 무게 중 최솟값을 구하는 프로그램을 작성하시오.

예를 들어, 무게가 각각 3, 1, 6, 2, 7, 30, 1인 7개의 저울추가 주어졌을 때, 이 추들로 측정할 수 없는 양의 정수 무게 중 최솟값은 21이다. 

## 🔍 풀이 방법
처음에는 전형적인 dp 방식으로 접근했는데, 그러면 메모리가 터져버렸다.
그래서 잘 생각해보니 무게가 가벼운것부터 하나씩 추가하며 어디까지 만들 수 있나 확인하면 아주 간단했다.


## ⏳ 회고
