### PR TITLE
[20250809] / BOJ / G4 파일 합치기 3 / 이강현

### DIFF
--- a/lkhyun/202508/09 BOJ G4 파일 합치기 3.md
+++ b/lkhyun/202508/09 BOJ G4 파일 합치기 3.md
@@ -1,0 +1,34 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int T;
+
+    public static void main(String[] args) throws Exception {
+        T = Integer.parseInt(br.readLine());
+
+        for (int t = 0; t < T; t++) {
+            PriorityQueue<Long> pq = new PriorityQueue<>();
+
+            int K = Integer.parseInt(br.readLine());
+            st = new StringTokenizer(br.readLine());
+            for (int i = 0; i < K; i++) {  
+                pq.offer(Long.parseLong(st.nextToken()));
+            }
+            long ans = 0;
+            while(pq.size() != 1){
+                long cur1 = pq.poll();
+                long cur2 = pq.poll();
+                ans += cur1+cur2;
+                pq.offer(cur1+cur2);
+            }
+            bw.write(ans+"\n");
+        }
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/13975
## 🧭 풀이 시간
10분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
파일 합칠때 드는 비용이 두 파일 크기의 합임.
모든 파일을 합쳤을때, 최소 비용으로 합치도록 할때 그 비용 출력.
## 🔍 풀이 방법
우선 순위큐
큐에서 두개 빼서 더하고 다시 넣는거 반복, 큐 크기가 1개면 종료
## ⏳ 회고
ez