### PR TITLE
[20250809] BOJ / G5 / 동전 / 이인희

### DIFF
--- a/LiiNi-coder/202508/09 BOJ 동전.md
+++ b/LiiNi-coder/202508/09 BOJ 동전.md
@@ -1,0 +1,38 @@
+```java
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.util.StringTokenizer;
+
+public class Main {
+    private static BufferedReader br;
+
+    public static void main(String[] args) throws IOException {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+        
+        for (int tc = 0; tc < T; tc++) {
+            int n = Integer.parseInt(br.readLine());
+            int[] coins = new int[n];
+            st = new StringTokenizer(br.readLine());
+            
+            for (int i = 0; i < n; i++) {
+                coins[i] = Integer.parseInt(st.nextToken());
+            }
+            int target = Integer.parseInt(br.readLine());
+            int[] dp = new int[target + 1]; //dp[i] i원을 만드는 경우의수
+            dp[0] = 1;
+            for (int coin : coins) {
+                for (int amount = coin; amount <= target; amount++) {
+                    dp[amount] += dp[amount - coin];
+                }
+            }
+            sb.append(dp[target]).append('\n');
+        }
+        System.out.print(sb.toString());
+        br.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/9084
## 🧭 풀이 시간
25 분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
- 동전 종류 및 동전 값이 주어지고, 하나의 숫자가 들어오면, 그 숫자를 만들기 위한 사용된 동전의 종류의 수 출력
## 🔍 풀이 방법
- dp[i]: i원을 만드는 경우의수으로 dp사용
## ⏳ 회고
- 각 동전은 무한개가 있는 문제라서 단순한 1차원dp가 되는데, 만약 동전마다 정해진 개수가 존재한다면, 냅색처럼 dp[i][j]= i번째 동전까지 사용해서 j원을 만드는 경우의 수로 풀어야할것이다.