### PR TITLE
[20250810] BOJ / G4 / 세수의 합 / 이강현

### DIFF
--- a/lkhyun/202508/10 BOJ G4 세수의 합.md
+++ b/lkhyun/202508/10 BOJ G4 세수의 합.md
@@ -1,0 +1,38 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static int N;
+    static int[] arr;
+
+    public static void main(String[] args) throws Exception {
+        N = Integer.parseInt(br.readLine());
+        arr = new int[N];
+
+        for (int i = 0; i < N; i++) {
+            arr[i] = Integer.parseInt(br.readLine());
+        }
+        Arrays.sort(arr);
+        
+        Set<Integer> sums = new HashSet<>();
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                sums.add(arr[i] + arr[j]);
+            }
+        }
+
+        a: for (int i = N-1; i >= 0; i--) {
+            for (int j = 0; j <= i; j++) {
+                if(sums.contains(arr[i] - arr[j])){
+                    bw.write(arr[i] + "");
+                    break a;
+                }
+            }
+        }
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2295
## 🧭 풀이 시간
180분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
배열이 주어짐. 
세 수의 합이 배열 안에 있을때, 가장 큰 합을 출력.
## 🔍 풀이 방법
hashset, 반복문 풀기?
원래 4개의 수를 찾아야하니까 N^4인데 
식을 a+b = c -d로 변형해서
a+b를 O(N^2)으로 저장해두고 c-d를 O(N^2)으로 찾으면 된다.

## ⏳ 회고
이분 탐색으로 어거지로 풀라다가 실패.
혁준아 반례 찾았음
7
20
30
50
70
80
90
100
초반에 70으로 잡고 시작하고 100부터 시작하니까 이거보다 무조건 작아서 범위 확장하는데,
20 30 50이 100이라서 거기를 고려 안하더라고