### PR TITLE
[20250812] BOJ / G4 / 인구 이동 / 이준희

### DIFF
--- a/JHLEE325/202508/12 BOJ G4 인구 이동.md
+++ b/JHLEE325/202508/12 BOJ G4 인구 이동.md
@@ -1,0 +1,93 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static int n, l, r;
+    static int[][] map;
+    static boolean[][] visited;
+    static int[][] dir = {{-1, 0}, {1, 0}, {0, -1}, {0, 1}};
+
+    static List<int[]> union;
+    static int unionSum;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        l = Integer.parseInt(st.nextToken());
+        r = Integer.parseInt(st.nextToken());
+
+        map = new int[n][n];
+
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < n; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        int days = 0;
+        while (true) {
+            visited = new boolean[n][n];
+            boolean moved = false;
+
+            for (int i = 0; i < n; i++) {
+                for (int j = 0; j < n; j++) {
+                    if (visited[i][j]) continue;
+
+                    union = new ArrayList<>();
+                    unionSum = 0;
+                    bfs(new int[]{i, j});
+
+                    if (union.size() > 1) {
+                        moved = true;
+                        int avg = unionSum / union.size();
+                        for (int[] cell : union) {
+                            map[cell[0]][cell[1]] = avg;
+                        }
+                    }
+                }
+            }
+
+            if (!moved) break;
+            days++;
+        }
+
+        System.out.println(days);
+    }
+
+    static void bfs(int[] start){
+        ArrayDeque<int[]> q = new ArrayDeque<>();
+        int sr = start[0], sc = start[1];
+
+        visited[sr][sc] = true;
+        q.add(new int[]{sr, sc});
+        union.add(new int[]{sr, sc});
+        unionSum += map[sr][sc];
+
+        while (!q.isEmpty()) {
+            int[] cur = q.poll();
+            int cr = cur[0], cc = cur[1];
+
+            for (int d = 0; d < 4; d++) {
+                int nr = cr + dir[d][0];
+                int nc = cc + dir[d][1];
+                if (nr < 0 || nr >= n || nc < 0 || nc >= n) continue;
+                if (visited[nr][nc]) continue;
+
+                int diff = Math.abs(map[cr][cc] - map[nr][nc]);
+                if (diff >= l && diff <= r) {
+                    visited[nr][nc] = true;
+                    q.add(new int[]{nr, nc});
+                    union.add(new int[]{nr, nc});
+                    unionSum += map[nr][nc];
+                }
+            }
+        }
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16234

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
n*n의 맵이 있고 각 칸은 개별의 나라로 인구가 주어졌을 때
날마다 인접한 두 나라의 인구 차이가 l 이상 r 이하이면 국경이 열리고 각 인구 합의 평균으로 맞춰집니다.
이 때 더이상 국경이 열리지 않을 때 까지 걸리는 시간을 구하는 문제입니다.

## 🔍 풀이 방법
bfs를 수행하고 국경이 열리는 곳들을 list로 묶어서 유지한 후
매 수행 이후 그 list에 들어있는 곳을 평균으로 맞춰주는 식으로 풀었습니다.

## ⏳ 회고
각 분기마다 연합되는 나라들을 유지하는 방식을 빨리 떠올려서 빨리 풀 수 있었던 것 같습니다