### PR TITLE
[20250812] BOJ / G5 / 회문 / 이강현

### DIFF
--- a/lkhyun/202508/12 BOJ G5 회문.md
+++ b/lkhyun/202508/12 BOJ G5 회문.md
@@ -1,0 +1,50 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        int T = Integer.parseInt(br.readLine());
+        
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < T; i++) {
+            String str = br.readLine();
+            sb.append(checkPalindrome(str)).append('\n');
+        }
+        
+        bw.write(sb.toString());
+        bw.close();
+    }
+    private static boolean isPalindrome(String str, int start, int end) {
+        while (start < end) {
+            if (str.charAt(start) != str.charAt(end)) {
+                return false;
+            }
+            start++;
+            end--;
+        }
+        return true;
+    }
+    
+    private static int checkPalindrome(String str) {
+        int left = 0;
+        int right = str.length() - 1;
+        
+        while (left < right) {
+            if (str.charAt(left) == str.charAt(right)) {
+                left++;
+                right--;
+            } else {
+                if (isPalindrome(str, left + 1, right) || isPalindrome(str, left, right - 1)) {
+                    return 1;
+                } else {
+                    return 2;
+                }
+            }
+        }
+        return 0;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17609
## 🧭 풀이 시간
10분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
문자열이 회문인지 유사회문인지 일반 문자열인지 체크
유사회문은 문자열에서 1개를 제거했을때 회문이 되는 경우임.
## 🔍 풀이 방법
투 포인터
왼쪽과 오른쪽에서 접근함.
다르면 왼쪽에서 한칸 건너뛰고 체크하는경우와 오른쪽에서 한칸 건너뛰고 체크하는 경우로 나눔. 둘 중 하나라도 마저 진행했을때 회문이면 유사회문
## ⏳ 회고
ez