### PR TITLE
[20250812] BOJ / P3 / 슈퍼 트리 뽀개기 / 권혁준

### DIFF
--- a/khj20006/202508/12 BOJ P3 슈퍼 트리 뽀개기.md
+++ b/khj20006/202508/12 BOJ P3 슈퍼 트리 뽀개기.md
@@ -1,0 +1,123 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+	BufferedReader br;
+	BufferedWriter bw;
+	StringTokenizer st;
+
+	public IOController() {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		st = new StringTokenizer("");
+	}
+
+	String nextLine() throws Exception {
+		String line = br.readLine();
+		st = new StringTokenizer(line);
+		return line;
+	}
+
+	String nextToken() throws Exception {
+		while (!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+
+	int nextInt() throws Exception {
+		return Integer.parseInt(nextToken());
+	}
+
+	long nextLong() throws Exception {
+		return Long.parseLong(nextToken());
+	}
+
+	double nextDouble() throws Exception {
+		return Double.parseDouble(nextToken());
+	}
+
+	void close() throws Exception {
+		bw.flush();
+		bw.close();
+	}
+
+	void write(String content) throws Exception {
+		bw.write(content);
+	}
+
+}
+
+public class Main {
+
+	static IOController io;
+
+	//
+
+	static int N;
+	static long K;
+	static List<int[]>[] graph;
+	static long[] v;
+	static PriorityQueue<Long>[] s;
+	static int ans = 0;
+
+	public static void main(String[] args) throws Exception {
+
+		io = new IOController();
+
+		init();
+		solve();
+
+		io.close();
+
+	}
+
+	static void init() throws Exception {
+
+		N = io.nextInt();
+		K = io.nextLong();
+		graph = new ArrayList[N+1];
+		v = new long[N+1];
+		s = new PriorityQueue[N+1];
+		for(int i=1;i<=N;i++) {
+			graph[i] = new ArrayList<>();
+			s[i] = new PriorityQueue<>((a,b) -> Long.compare(b,a));
+			s[i].add(0L);
+		}
+		for(int i=1;i<N;i++) {
+			int a = io.nextInt();
+			int b = io.nextInt();
+			int c = io.nextInt();
+			graph[a].add(new int[]{b,c});
+			graph[b].add(new int[]{a,c});
+		}
+
+	}
+
+	static void solve() throws Exception {
+
+		dfs(1,0);
+		io.write(ans + "\n");
+
+	}
+
+	static void dfs(int n, int p) {
+		for(int[] e:graph[n]) if(e[0] != p) {
+			int i = e[0], x = e[1];
+			dfs(i,n);
+			if(s[i].size() > s[n].size()) {
+				v[i] += x;
+				for(long j:s[n]) s[i].add(j+v[n]-v[i]);
+				s[n].clear();
+				s[n] = s[i];
+				v[n] = v[i];
+			}
+			else {
+				for(long j:s[i]) s[n].add(j+x+v[i]-v[n]);
+			}
+		}
+		while(!s[n].isEmpty() && s[n].peek() + v[n] > K) s[n].poll();
+		ans = Math.max(ans, s[n].size());
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/30691

## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
정점 N개인 트리의 각 간선엔 가중치가 달려있다.
어떤 정점을 골라서, 그 정점을 포함하여 정점의 자손들 중 거리가 K 이하인 모든 자손들을 뽀갤 수 있다.
최대 몇 개를 뽀갤 수 있는지 구해보자.

## 🔍 풀이 방법
- 우선순위 큐
- smaller to larger
---
DFS로 리프 정점부터 올라오면서 각 노드 별로 `해당 정점까지 오는 경로의 거리`를 우선순위 큐로 관리한다.

두 노드의 정보를 합칠 때는 smaller to larger로 합쳐주는데, 자식 사이즈가 부모 사이즈보다 큰 경우를 대비하기 위해 가상의 가중치 배열 v를 둬서 실제로는 거리가 K-v[n] 일 때 우선순위 큐에서 poll해준다.

## ⏳ 회고
좀 헷갈림