### PR TITLE
[20250812] BOJ / G5 / 숫자고르기 / 이인희

### DIFF
--- a/LiiNi-coder/202508/12 BOJ 숫자고르기.md
+++ b/LiiNi-coder/202508/12 BOJ 숫자고르기.md
@@ -1,0 +1,53 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+import java.util.ArrayList;
+import java.util.Collections;
+
+public class Main {
+    private static BufferedReader br;
+    private static StringTokenizer st;
+    private static int N;
+    private static int[] arr;
+    private static boolean[] visited;
+    private static boolean[] onPath;
+    private static ArrayList<Integer> result;
+
+    public static void main(String[] args) throws IOException {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine().trim());
+        arr = new int[N + 1];
+        for (int i = 1; i <= N; i++) {
+            arr[i] = Integer.parseInt(br.readLine().trim());
+        }
+        visited = new boolean[N + 1];
+        result = new ArrayList<>();
+        for (int i = 1; i <= N; i++) {
+            onPath = new boolean[N + 1];
+            dfs(i, i);
+        }
+
+        Collections.sort(result);
+        System.out.println(result.size());
+        for (int num : result) {
+            System.out.println(num);
+        }
+
+    }
+
+    private static void dfs(int start, int current) {
+        if (onPath[current]) {
+            if (current == start) {
+                result.add(start);
+            }
+            return;
+        }
+        onPath[current] = true;
+        int next = arr[current];
+        dfs(start, next);
+        onPath[current] = false;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2668
## 🧭 풀이 시간
40 분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
- 세로 두 줄, 가로로 N개의 칸으로 이루어진 표가 있다. 첫째 줄의 각 칸에는 정수 1, 2, …, N이 차례대로 들어 있고 둘째 줄의 각 칸에는 1이상 N이하인 정수가 들어 있다. 첫째 줄에서 숫자를 적절히 뽑으면, 그 뽑힌 정수들이 이루는 집합과, 뽑힌 정수들의 바로 밑의 둘째 줄에 들어있는 정수들이 이루는 집합이 일치한다. 이러한 조건을 만족시키도록 정수들을 뽑되, 최대로 많이 뽑는 방법을 출력
## 🔍 풀이 방법
- 각 칸마다 dfs를 돌려 사이클을 찾아내는 것. 사이클의 방문경로를 정답에 추가
## ⏳ 회고
- 문제 유형을 모르면 꽤나 헤멜뻔한 문제. 사이클이란 개념을 떠올리기 어려웠따..