### PR TITLE
[20250813] BOJ / G4 / 샘터 / 이인희

### DIFF
--- a/LiiNi-coder/202508/13 BOJ 샘터.md
+++ b/LiiNi-coder/202508/13 BOJ 샘터.md
@@ -1,0 +1,53 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+    private static BufferedReader br;
+    private static StringTokenizer st;
+
+    public static void main(String[] args) throws IOException {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+        Queue<Integer> q = new LinkedList<>();
+        HashSet<Integer> visited = new HashSet<>();
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            int x = Integer.parseInt(st.nextToken());
+            q.offer(x);
+            visited.add(x);
+        }
+
+        long answer = 0;
+        int distance = 1;
+        int builtCount = 0;
+        int[] dxs = { -1, 1 };
+
+        outer: // naming가능한 break문
+        while (!q.isEmpty()) {
+            int size = q.size();
+            for (int t = 0; t < size; t++) {
+                int x = q.poll();
+                for (int d : dxs) {
+                    int nx = x + d;
+                    if (visited.contains(nx))
+                        continue;
+                    visited.add(nx);
+                    q.offer(nx);
+                    answer += distance;
+                    builtCount++;
+                    if (builtCount == k)
+                        break outer;
+                }
+            }
+            distance++;
+        }
+        System.out.println(answer);
+        br.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/18513
## 🧭 풀이 시간
40 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 수평선에 정수 좌표만있다. 샘이 n개, 집은 m개가 수평선의 좌표에 한칸에 하나씩만 차지한다. 집과 가장 가까운 샘의 거리가 불행도로 측정. n, m, 샘 좌표가 주어질때, 모든 집의 불행도합의 최소를 반환
## 🔍 풀이 방법
- BFS기반 그리디
## ⏳ 회고
1. BFS 에 대해서 조금 색다르게 진행함
  - 한 사이클에 bfs의 모든걸 꺼내고 이를 모두 for문으로 탐색
```java
while (!q.isEmpty()) {
            int size = q.size();
            for (int t = 0; t < size; t++) {
```
2. for문이 중첩되어있는 상태에서 가장 안쪽에서 여러개의 for문을 한꺼번에 break해버리는법 : `이름: for,while ...... break 이름;`