### PR TITLE
[20250813] BOJ / D5 / Cat Exercise / 권혁준

### DIFF
--- a/khj20006/202508/13 BOJ D5 Cat Exercise.md
+++ b/khj20006/202508/13 BOJ D5 Cat Exercise.md
@@ -1,0 +1,144 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+	BufferedReader br;
+	BufferedWriter bw;
+	StringTokenizer st;
+
+	public IOController() {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		st = new StringTokenizer("");
+	}
+
+	String nextLine() throws Exception {
+		String line = br.readLine();
+		st = new StringTokenizer(line);
+		return line;
+	}
+
+	String nextToken() throws Exception {
+		while (!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+
+	int nextInt() throws Exception {
+		return Integer.parseInt(nextToken());
+	}
+
+	long nextLong() throws Exception {
+		return Long.parseLong(nextToken());
+	}
+
+	double nextDouble() throws Exception {
+		return Double.parseDouble(nextToken());
+	}
+
+	void close() throws Exception {
+		bw.flush();
+		bw.close();
+	}
+
+	void write(String content) throws Exception {
+		bw.write(content);
+	}
+
+}
+
+public class Main {
+
+	static IOController io;
+
+	//
+
+	static int N;
+	static int[] p;
+	static long[] s;
+	static int[] r;
+	static int[][] par;
+	static int[] dep;
+	static List<Integer>[] graph;
+	static List<int[]> edges;
+
+	static int f(int x) {return x==r[x] ? x : (r[x]=f(r[x]));}
+
+	public static void main(String[] args) throws Exception {
+
+		io = new IOController();
+
+		init();
+		solve();
+
+		io.close();
+
+	}
+
+	static void init() throws Exception {
+
+		N = io.nextInt();
+		p = new int[N+1];
+		s = new long[N+1];
+		r = new int[N+1];
+		par = new int[N+1][18];
+		graph = new List[N+1];
+		dep = new int[N+1];
+		for(int i=1;i<=N;i++) {
+			p[i] = io.nextInt();
+			r[i] = i;
+			graph[i] = new ArrayList<>();
+		}
+		edges = new ArrayList<>();
+		for(int i=1;i<N;i++) {
+			int a = p[io.nextInt()];
+			int b = p[io.nextInt()];
+			edges.add(new int[]{Math.min(a,b), Math.max(a,b)});
+			graph[a].add(b);
+			graph[b].add(a);
+		}
+
+	}
+
+	static void solve() throws Exception {
+
+		dfs(N,0,0);
+		for(int k=1;k<18;k++) for(int i=1;i<=N;i++) par[i][k] = par[par[i][k-1]][k-1];
+
+		Collections.sort(edges, (a,b) -> a[1]==b[1] ? a[0]-b[0] : a[1]-b[1]);
+		for(int[] edge : edges) {
+			int a = edge[0], b = edge[1];
+			int x = f(a), y = f(b);
+			s[y] = Math.max(s[y], s[x] + dist(x, y));
+			r[x] = y;
+		}
+		io.write(s[N] + "\n");
+
+	}
+
+	static void dfs(int n, int p, int d) {
+		par[n][0] = p;
+		dep[n] = d;
+		for(int i:graph[n]) if(i != p) dfs(i,n,d+1);
+	}
+
+	static int dist(int a, int b) {
+		int diff = Math.abs(dep[a]-dep[b]);
+		int res = 0;
+		for(int k=0;k<18;k++) if((diff & (1<<k)) != 0) {
+			if(dep[a] > dep[b]) a = par[a][k];
+			else b = par[b][k];
+			res += (1<<k);
+		}
+
+		for(int k=17;k>=0;k--) if(par[a][k] != par[b][k]) {
+			res += (1<<(k+1));
+			a = par[a][k];
+			b = par[b][k];
+		}
+		if(a != b) res += 2;
+		return res;
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/27539

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N개의 캣타워가 트리 형태로 주어진다.
캣타워들은 각각 높이가 1부터 N까지 겹치지 않게 구성되어 있다.

처음에, 고양이 한 마리가 높이 N인 캣타워에 있다.
캣타워에 장애물을 하나씩 놓을 수 있으며, 장애물의 위치에 따라 두 가지 경우로 나뉜다.
1. 장애물을 놓은 곳에 고양이가 없다면, 아무 일도 일어나지 않는다.
2. 장애물을 놓은 곳에 고양이가 있다면, 장애물이 없는 곳으로만 계속 이동하여 도달할 수 있는 가장 높은 곳으로 이동한다. 그러한 곳이 없다면 운동이 끝난다.

장애물을 잘 놓아서 고양이의 이동 거리를 최대로 해보자.

## 🔍 풀이 방법
- 분리 집합
- 희소 배열
---
s[u] = u에서 출발했을 때의 최대 이동 거리,
r[u] = u가 속한 컴포넌트에서의 최대 높이
라고 해보자.

낮은 곳부터 처리해야 함은 직관적으로 알 수 있다. -> 간선을 max(u,v)가 작은 순으로 정렬시키고 생각하자.

간선들을 정렬시키고 나면, 간선 (u, v) 에 대해 (u < v 라고 가정)
s[v] = max(s[v], s[r[u]] + dist(r[u], v)) 가 성립하게 된다.

여기서 dist는 트리 상에서 두 점 사이의 거리를 의미하며, 트리를 희소 배열로 전처리 해두면 한 번 당 O(logN)에 구할 수 있다.

## ⏳ 회고
### 귀여운 고양이
<img width="120" height="120" alt="image" src="https://github.com/user-attachments/assets/2565fae7-f8e7-45db-88c2-f2264f315109" />
