### PR TITLE
[20250814] BOJ / D5 / 플러드 필 (Flood Fill) / 권혁준

### DIFF
--- a/khj20006/202508/14 BOJ D5 플러드 필 (Flood Fill).md
+++ b/khj20006/202508/14 BOJ D5 플러드 필 (Flood Fill).md
@@ -1,0 +1,72 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+using ll = long long;
+
+ll INF = 1e12;
+
+ll N, D;
+int r[100000]{}, c[100000]{};
+pair<ll,ll> a[100000]{};
+set<tuple<ll,ll,int>> s;
+
+int f(int x) {return x==r[x] ? x : r[x]=f(r[x]);}
+
+int main(){
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin>>N>>D;
+	iota(r, r+N, 0);
+	fill(c, c+N, 1);
+	for(int i=0;i<N;i++) {
+		ll x, y;
+		cin>>x>>y;
+		a[i] = {y+x, y-x};
+	}
+
+	sort(a, a+N);
+	priority_queue<tuple<ll,ll,ll,int>, vector<tuple<ll,ll,ll,int>>, greater<>> pq;
+	for(int j=0;j<N;j++) {
+		auto [x,y] = a[j];
+		while(!pq.empty() && get<0>(pq.top()) <= x) {
+			auto [_a, _b, _c, _d] = pq.top();
+			pq.pop();
+			s.erase({_b,_c,_d});
+		}
+		auto it = s.upper_bound({y, -INF, -1});
+		if(it != s.end() && get<0>(*it) <= y+D) {
+			int p = f(j), q = f(get<2>(*it));
+			if(p != q) {
+				c[p] += c[q];
+				r[q] = p;
+			}
+
+		}
+		if(it != s.begin()) {
+			it--;
+			if(get<0>(*it) >= y-D) {
+				int p = f(j), q = f(get<2>(*it));
+				if(p != q) {
+					c[p] += c[q];
+					r[q] = p;
+				}
+			}
+		}
+		
+		s.emplace(y,x,j);
+		pq.emplace(x+D+1,y,x,j);
+	}
+
+	int cnt = 0, mx = 0;
+	bitset<100000> v;
+	for(int i=0;i<N;i++) {
+		int x = f(i);
+		if(v[x]) continue;
+		v[x] = 1;
+		mx = max(mx, c[x]);
+		cnt++;
+	}
+	cout<<cnt<<' '<<mx;
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/6181

## 🧭 풀이 시간
180분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
2차원 좌표평면에 N개의 점이 주어진다.
두 점 사이의 맨해튼 거리가 D 이하면 두 점을 잇는 간선이 존재한다.
컴포넌트의 개수와 컴포넌트에 속한 점 수의 최댓값을 구해보자.

## 🔍 풀이 방법
- 분리 집합
- set
---
고개를 45도만 돌려서 문제를 보면, 각 점 (x,y)는 (y+x, y-x)가 된다.

그러면 어떤 점 (x, y)에 대해, 그 점을 중심으로 갖고 변의 길이가 2D인 정사각형 내에 속하는 점들을 찾으면 된다.

D가 고정된 값이니까, 일단 점들을 x축 기준으로 정렬시켜놓고 set에는 y좌표 기준으로 정렬되도록 세팅한다.
각 점을 방문할 때마다, set에서 양 옆으로 인접한 y좌표를 갖는 점들과 union한다.
그리고 이 점을 set에서 제거해야 하는 시기 (x좌표 차이가 D를 넘어갈 때)를 또다른 set에서 관리한다.

이런 식으로 모든 점들 사이의 연결 관계를 나타낼 수 있고, 마지막에 한 번 순회하며 답을 구했다.

## ⏳ 회고
너무고통스러웠다