### PR TITLE
[20250815] BOJ / G5 / 같은 나머지 / 김수연

### DIFF
--- a/suyeun84/202508/15 BOJ G5 같은 나머지.md
+++ b/suyeun84/202508/15 BOJ G5 같은 나머지.md
@@ -1,0 +1,40 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class boj1684 {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+
+	public static void main(String[] args) throws Exception {
+		nextLine();
+		int n = nextInt();
+        int[] arr = new int[n];
+        nextLine();
+        for (int i = 0; i < n; i++) arr[i] = nextInt();
+        Arrays.sort(arr);
+        int min = arr[0];
+        int i = 0;
+        for (i = 0; i < n; i++) if ((arr[i] -= min) != 0) break;
+        if (i == n) {
+            System.out.println(min);
+            return;
+        }
+        int gcd = arr[i++];
+        for (; i < n; i++) gcd = gcd(gcd, arr[i]-=min);
+        System.out.println(gcd);
+	}
+
+	static int gcd(int a, int b) {
+        int r = -1;
+        while (r!=0) {
+            r = a % b;
+            a = b;
+            b = r;
+        }
+        return a;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1684
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
n개의 정수로 된 수열이 있을 때, 모든 정수를 한 정수 D로 나눴을 때 나머지가 같아지는 경우가 있음
이때, 가장 큰 D 구하기
## 🔍 풀이 방법
유클리드 호제법 사용
입력값 중에서 가장 낮은 값을 찾고 해당 값을 입력받은 값에서 각각 빼준후에 해당 값들의 GCD를 찾아주었다.
## ⏳ 회고
틈틈이 풀어둬야겠다