### PR TITLE
[20250815] BOJ / G1 / 낚시왕 / 이준희

### DIFF
--- a/JHLEE325/202508/15 BOJ G1 낚시왕.md
+++ b/JHLEE325/202508/15 BOJ G1 낚시왕.md
@@ -1,0 +1,130 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static class Shark {
+        int r, c, s, d, z;
+        boolean alive;
+
+        Shark(int r, int c, int s, int d, int z) {
+            this.r = r; this.c = c; this.s = s; this.d = d; this.z = z;
+            this.alive = true;
+        }
+    }
+
+    static int R, C, M;
+    static Shark[] sharks;
+    static int[][] board;
+    static final int[] dr = {0, -1, 1, 0, 0};
+    static final int[] dc = {0, 0, 0, 1, -1};
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+        R = Integer.parseInt(st.nextToken());
+        C = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        sharks = new Shark[M];
+        board = new int[R + 1][C + 1];
+        for (int i = 1; i <= R; i++) Arrays.fill(board[i], -1);
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int r = Integer.parseInt(st.nextToken());
+            int c = Integer.parseInt(st.nextToken());
+            int s = Integer.parseInt(st.nextToken());
+            int d = Integer.parseInt(st.nextToken());
+            int z = Integer.parseInt(st.nextToken());
+            sharks[i] = new Shark(r, c, s, d, z);
+        }
+
+        for (int i = 0; i < M; i++) {
+            if (sharks[i].alive) board[sharks[i].r][sharks[i].c] = i;
+        }
+
+        int answer = 0;
+
+        for (int col = 1; col <= C; col++) {
+            for (int row = 1; row <= R; row++) {
+                int idx = board[row][col];
+                if (idx != -1 && sharks[idx].alive) {
+                    sharks[idx].alive = false;
+                    answer += sharks[idx].z;
+                    board[row][col] = -1;
+                    break;
+                }
+            }
+
+            moveAll();
+
+            resolveConflicts();
+        }
+
+        System.out.println(answer);
+    }
+
+    static void moveAll() {
+        for (int i = 1; i <= R; i++) Arrays.fill(board[i], -1);
+
+        for (int i = 0; i < M; i++) {
+            Shark s = sharks[i];
+            if (!s.alive) continue;
+
+            int nr = s.r, nc = s.c, nd = s.d, rem = s.s;
+            while (rem-- > 0) {
+                int tr = nr + dr[nd];
+                int tc = nc + dc[nd];
+
+                if (tr < 1 || tr > R || tc < 1 || tc > C) {
+                    if (nd == 1) nd = 2;
+                    else if (nd == 2) nd = 1;
+                    else if (nd == 3) nd = 4;
+                    else nd = 3;
+                    tr = nr + dr[nd];
+                    tc = nc + dc[nd];
+                }
+
+                nr = tr; nc = tc;
+            }
+
+            s.r = nr; s.c = nc; s.d = nd;
+
+            if (board[nr][nc] == -1) board[nr][nc] = i;
+            else {
+                board[nr][nc] = -2;
+            }
+        }
+    }
+
+    static void resolveConflicts() {
+        int[][] newBoard = new int[R + 1][C + 1];
+        for (int i = 1; i <= R; i++) Arrays.fill(newBoard[i], -1);
+
+        for (int i = 0; i < M; i++) {
+            Shark s = sharks[i];
+            if (!s.alive) continue;
+            int r = s.r, c = s.c;
+
+            int curIdx = newBoard[r][c];
+            if (curIdx == -1) {
+                newBoard[r][c] = i;
+            } else {
+                if (sharks[curIdx].z < s.z) {
+                    sharks[curIdx].alive = false;
+                    newBoard[r][c] = i;
+                } else {
+                    s.alive = false;
+                }
+            }
+        }
+
+        board = newBoard;
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17143

## 🧭 풀이 시간
100분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
속도, 방향, 크기가 존재하는 상어가 수조에 있고 낚시 왕이 있습니다.
각 시간마다
낚시왕이 한칸 오른쪽 열로 이동 후 가장 가까운 상어를 낚음
상어가 이동함, 이동이 끝난 후 칸이 겹치면 더 큰 상어가 작은 상어를 먹음
을 반복할 때, 낚시왕이 끝에 다다랐을 때 낚은 상어 무게의 총합을 구하는 문제입니다.

## 🔍 풀이 방법
문제에 제시된 프로세스를 구현했습니다.
낚시꾼을 이동시킨 후, 가장 가까운 행의 상어를 잡아서 flag를 바꾸어 잡힘 표시를 했습니다.
각 시행마다 이동 후 상어끼리의 충돌처리를 했습니다.

## ⏳ 회고
1학기때의 원자 어쩌구 문제가 생각나는 문제였습니다.
그래도 이 문제는 중간에 충돌처리 하는 부분은 없어서 수월했던 것 같습니다.
원래 그래프이동 문제를 풀 때 방향벡터를 이중배열로 사용하고 y와 x 를 사용했었는데
대부분 row, column 과 각 열과 행의 방향벡터를 주로 사용하는 것 같아서 따라해봤습니다.