### PR TITLE
[20250816] BOJ / G4 / 줄세우기 / 이준희

### DIFF
--- a/JHLEE325/202508/16 BOJ G4 줄세우기.md
+++ b/JHLEE325/202508/16 BOJ G4 줄세우기.md
@@ -1,0 +1,32 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        int[] arr = new int[n];
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(br.readLine());
+        }
+
+        int[] dp = new int[n];
+        Arrays.fill(dp, 1);
+
+        int lis = 1;
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < i; j++) {
+                if (arr[j] < arr[i]) {
+                    dp[i] = Math.max(dp[i], dp[j] + 1);
+                }
+            }
+            lis = Math.max(lis, dp[i]);
+        }
+
+        System.out.println(n - lis);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2631

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
아이들의 번호와 순서가 주어질 때
아이들을 번호순으로 정렬하기 위해 옮겨져야 하는 아이들의 최소 수를 구하는 문제입니다.

## 🔍 풀이 방법
번호 순으로 오름차순 시켜야되기 때문에
가장 긴 증가하는 부분수열을 구한 후
나머지 애들을 맞는 자리로 끼워 맞추면 되기 때문에 LIS 로 풀었습니다.

## ⏳ 회고
아이디어 떠올리는게 전부인 문제였습니다.
