### PR TITLE
[20250816] BOJ / G5 / 암호 만들기 / 이인희

### DIFF
--- a/LiiNi-coder/202508/16 BOJ 암호 만들기.md
+++ b/LiiNi-coder/202508/16 BOJ 암호 만들기.md
@@ -1,0 +1,69 @@
+```java
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+//TIP 코드를 <b>실행</b>하려면 <shortcut actionId="Run"/>을(를) 누르거나
+// 에디터 여백에 있는 <icon src="AllIcons.Actions.Execute"/> 아이콘을 클릭하세요.
+public class Main {
+    private static BufferedReader br;
+    private static int L;
+    private static int C;
+    private static char[] Arr;
+    private static char[] Combination;
+    private static StringBuilder answer;
+    private static HashSet<Character> mos = new HashSet<>(Set.of('a', 'e', 'i', 'o', 'u'));
+    public static void main(String[] args) throws IOException {
+       br = new BufferedReader(new InputStreamReader(System.in));
+       String[] temp = br.readLine().split(" ");
+       L = Integer.parseInt(temp[0]);
+       C = Integer.parseInt(temp[1]);
+       Arr = new char[C];
+       Combination = new char[L];
+       StringTokenizer st = new StringTokenizer(br.readLine());
+       for(int i = 0; i < C; i++) {
+           Arr[i] = st.nextToken().charAt(0);
+       }
+       Arrays.sort(Arr);
+       answer = new StringBuilder();
+       dfs(0, 0);
+       System.out.println(answer.toString());
+       br.close();
+   }
+
+    private static void dfs(int startIndex, int depth) {
+        if(depth == L){
+            if(isFullfill()){
+                answer.append(new String(Combination)).append("\n");
+            }
+            return;
+        }
+        for(int i = startIndex; i < C; i++){
+            Combination[depth] = Arr[i];
+            dfs(i + 1, depth + 1);
+        }
+    }
+
+    private static boolean isFullfill() {
+        int countJa = 0;
+        int countMo = 0;
+        for(char c : Combination){
+            if(mos.contains(c)){
+                countMo++;
+            }else{
+                countJa++;
+            }
+        }
+        if(countJa < 2 || countMo < 1){
+            return false;
+        }
+        return true;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1759
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 특정 알파벳들이 주어지고, 이들중 C개를 가져와 문자열을 만들때, 자음이 2개 이상, 모음이 1개 이상인 것들의 문자열들을 사전순으로 모두 출력
## 🔍 풀이 방법
- DFS하면서 백트래킹
## ⏳ 회고
- 자음, 모음 각각마다 부분집합하여 꺼내 쓸 생각을 했는데 너무 오래걸릴것같고 시간낭비일것 같아, 그냥 바로 dfs로 조합구해서 그때마다 맞는지 판단하는 것으로 함