### PR TITLE
[20250817] BOJ / G5 / 중력 큐 / 이강현

### DIFF
--- a/lkhyun/202508/17 BOJ G5 중력 큐.md
+++ b/lkhyun/202508/17 BOJ G5 중력 큐.md
@@ -1,0 +1,75 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static ArrayDeque<Integer> deq = new ArrayDeque<>();
+    static int state = 0; //0: 뒤 앞, 1: 앞이 하늘, 2: 앞 뒤, 3: 앞이 아래
+    static int ballCnt = 0;
+    static int wallCnt = 0;
+
+    public static void main(String[] args) throws IOException {
+        int Q = Integer.parseInt(br.readLine());
+        
+
+        for (int i = 0; i < Q; i++) {
+            st = new StringTokenizer(br.readLine());
+            String a = st.nextToken();
+
+            if(a.equals("push")){
+                String b = st.nextToken();
+                if(b.equals("b")){
+                    deq.offer(1);
+                    ballCnt++;
+                    ballFlush();
+                }else if(b.equals("w")){
+                    deq.offer(-1);
+                    wallCnt++;
+                }
+
+            }else if(a.equals("pop")){
+                if(!deq.isEmpty()){
+                    if(deq.poll() == 1){
+                        ballCnt--;
+                    }else{
+                        wallCnt--;
+                    }
+                }
+                ballFlush();
+            }else if(a.equals("rotate")){
+                String b = st.nextToken();
+                if(b.equals("l")){
+                    state = (state+1) % 4;
+                }else if(b.equals("r")){
+                    state = (state+3) % 4;
+                }
+                ballFlush();
+            }else if(a.equals("count")){
+                String b = st.nextToken();
+                if(b.equals("b")){
+                    bw.write(ballCnt+"\n");
+                }else if(b.equals("w")){
+                    bw.write(wallCnt+"\n");
+                }
+            }
+        }
+        bw.close();
+    }
+    static void ballFlush(){
+        if(state == 1){
+            while(!deq.isEmpty() && deq.peekLast() == 1){
+                deq.pollLast();
+                ballCnt--;
+            }
+        }else if(state == 3){
+            while(!deq.isEmpty() && deq.peek() == 1){
+                deq.poll();
+                ballCnt--;
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/28078
## 🧭 풀이 시간
10분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
큐가 있음.
큐에는 공과 가림막을 넣을 수 있음.
넣을때는 무조건 뒤에서부터 넣음.
근데 큐를 회전시킬 수 있음. 시계방향 반시계방향으로 90도씩
큐의 상태가 세로인 경우에 공들은 중력의 영향을 받아 아래로 떨어지게됨.
가림막은 중력의 영향을 안 받음.
이때, 다양한 명령에 대해 시뮬레이션 하면 됨.
## 🔍 풀이 방법
덱, 조건 분기 설정
걍 하라는대로 하면 됨.
큐 상태가 어떤 상태인지 보고 공들이 흘러내리는 것만 잘 생각
## ⏳ 회고
ez