### PR TITLE
[20250818] BOJ / P5 / AND, OR, XOR 2 / 권혁준

### DIFF
--- a/khj20006/202508/18 BOJ P5 AND, OR, XOR 2.md
+++ b/khj20006/202508/18 BOJ P5 AND, OR, XOR 2.md
@@ -1,0 +1,146 @@
+```java
+import java.awt.image.AreaAveragingScaleFilter;
+import java.util.*;
+import java.io.*;
+
+class IOController {
+	BufferedReader br;
+	BufferedWriter bw;
+	StringTokenizer st;
+
+	public IOController() {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		st = new StringTokenizer("");
+	}
+
+	String nextLine() throws Exception {
+		String line = br.readLine();
+		st = new StringTokenizer(line);
+		return line;
+	}
+
+	String nextToken() throws Exception {
+		while (!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+
+	int nextInt() throws Exception {
+		return Integer.parseInt(nextToken());
+	}
+
+	long nextLong() throws Exception {
+		return Long.parseLong(nextToken());
+	}
+
+	double nextDouble() throws Exception {
+		return Double.parseDouble(nextToken());
+	}
+
+	void close() throws Exception {
+		bw.flush();
+		bw.close();
+	}
+
+	void write(String content) throws Exception {
+		bw.write(content);
+	}
+
+}
+
+public class Main {
+
+	static IOController io;
+
+	//
+
+	static final long MOD = 998244353;
+
+	static int N;
+	static int[] a;
+
+	public static void main(String[] args) throws Exception {
+
+		io = new IOController();
+
+		init();
+		solve();
+
+		io.close();
+
+	}
+
+	static void init() throws Exception {
+
+		N = io.nextInt();
+		a = new int[N+1];
+		for(int i=1;i<=N;i++) a[i] = io.nextInt();
+
+	}
+
+	static void solve() throws Exception {
+
+		io.write(and() + " " + or() + " " + xor());
+
+	}
+
+	static long and() {
+		long res = 0;
+		for(int k=0;k<30;k++) {
+			for(int i=1;i<=N;) if((a[i] & (1<<k)) != 0) {
+				int j = i;
+				while(j<=N && (a[j] & (1<<k)) != 0) j++;
+				long cnt = j-i;
+				res = (res + ((cnt*(cnt+1)/2)%MOD) * (1<<k)%MOD) % MOD;
+				i = j;
+			}
+			else i++;
+		}
+		return res;
+	}
+
+	static long or() {
+		long res = 0;
+		for(int k=0;k<30;k++) {
+			long coef = (long)N*(N+1)/2;
+			for(int i=1;i<=N;) if((a[i] & (1<<k)) == 0) {
+				int j = i;
+				while(j<=N && (a[j] & (1<<k)) == 0) j++;
+				long cnt = j-i;
+				coef -= cnt*(cnt+1)/2;
+				i = j;
+			}
+			else i++;
+			res = (res + coef%MOD * (1<<k)%MOD) % MOD;
+		}
+		return res;
+	}
+
+	static long xor() {
+		long res = 0;
+		for(int k=0;k<30;k++) {
+			int[] c = new int[N+1];
+			long odd = 0, even = 0;
+			for(int i=1;i<=N;i++) {
+				c[i] += c[i-1];
+				if((a[i] & (1<<k)) != 0) c[i]++;
+				if(c[i]%2 == 0) {
+					if(c[i] > 0) even++;
+				}
+				else odd++;
+			}
+			for(int i=1;i<=N;i++) {
+				if(c[i-1]%2 == 0) res += odd*(1<<k);
+				else res += even*(1<<k);
+				res %= MOD;
+				if(c[i]%2 == 0) {
+					if(c[i] > 0) even--;
+				}
+				else odd--;
+			}
+		}
+		return res;
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/31422

## 🧭 풀이 시간
70분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
길이 $N$인 수열 $A_1, A_2, \cdots, A_N$이 있다.
다음 세 값을 각각 $998\,244\,353$으로 나눈 나머지를 구해보자.
<img width="1304" height="141" alt="image" src="https://github.com/user-attachments/assets/a82e4634-7dca-479c-8eea-0eebfa864e27" />

## 🔍 풀이 방법
- 누적 합
- 비트마스킹
---
비트 연산(AND, OR, XOR)은 각 비트별로 따로따로 생각해줘도 된다.
그러면 각 원소가 해당 비트를 포함하는지 여부에 따라 수열의 원소는 0,1 꼴로 바뀌게 된다.

AND와 OR은 각각 해당 구간에 1만 포함 / 0만 포함하는 경우만 세어주면 된다.
XOR은 수열의 원소를 0,1로 바꾼 꼴에서 누적 합을 구한 뒤 잘 세어주면 된다.

## ⏳ 회고
왜 틀렸는지도 모르겠고 왜 맞았는지도 모르겠다