### PR TITLE
[20250819] BOJ / P1 / 수열과 쿼리 6 / 권혁준

### DIFF
--- a/khj20006/202508/19 BOJ P1 수열과 쿼리 6.md
+++ b/khj20006/202508/19 BOJ P1 수열과 쿼리 6.md
@@ -1,0 +1,161 @@
+```java
+import java.awt.image.AreaAveragingScaleFilter;
+import java.util.*;
+import java.io.*;
+
+class IOController {
+	BufferedReader br;
+	BufferedWriter bw;
+	StringTokenizer st;
+
+	public IOController() {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		st = new StringTokenizer("");
+	}
+
+	String nextLine() throws Exception {
+		String line = br.readLine();
+		st = new StringTokenizer(line);
+		return line;
+	}
+
+	String nextToken() throws Exception {
+		while (!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+
+	int nextInt() throws Exception {
+		return Integer.parseInt(nextToken());
+	}
+
+	long nextLong() throws Exception {
+		return Long.parseLong(nextToken());
+	}
+
+	double nextDouble() throws Exception {
+		return Double.parseDouble(nextToken());
+	}
+
+	void close() throws Exception {
+		bw.flush();
+		bw.close();
+	}
+
+	void write(String content) throws Exception {
+		bw.write(content);
+	}
+
+}
+
+public class Main {
+
+	static IOController io;
+
+	//
+
+	static int N, M;
+	static int sqrt;
+	static int[] a;
+	static int[][] queries;
+
+	public static void main(String[] args) throws Exception {
+
+		io = new IOController();
+
+		init();
+		solve();
+
+		io.close();
+
+	}
+
+	static void init() throws Exception {
+
+		N = io.nextInt();
+		a = new int[N];
+		for(int i=0;i<N;i++) a[i] = io.nextInt();
+		sqrt = (int)Math.sqrt(N);
+
+		M = io.nextInt();
+		queries = new int[M][];
+		for(int i=0;i<M;i++) queries[i] = new int[]{io.nextInt()-1,io.nextInt()-1,i};
+
+	}
+
+	static void solve() throws Exception {
+
+		Arrays.sort(queries, (a,b) -> {
+			int s = a[0] / sqrt, e = b[0] / sqrt;
+			if(s == e) return a[1]-b[1];
+			return s-e;
+		});
+
+		int[] cnt = new int[100001];
+		int[] ccnt = new int[100001];
+		ccnt[0] = 1;
+		int[] ans = new int[M];
+		int s = queries[0][0], e = queries[0][1], max = 0;
+		for(int i=s;i<=e;i++) {
+			ccnt[cnt[a[i]]]--;
+			if(ccnt[max] == 0) max--;
+			ccnt[++cnt[a[i]]]++;
+			if(cnt[a[i]] > max) max = cnt[a[i]];
+		}
+		ans[queries[0][2]] = max;
+
+		for(int i=1;i<M;i++) {
+			int ns = queries[i][0], ne = queries[i][1], idx = queries[i][2];
+			if(ns > e) {
+				for(int k=s;k<=e;k++) {
+					ccnt[cnt[a[k]]]--;
+					if(ccnt[max] == 0) max--;
+					ccnt[--cnt[a[k]]]++;
+					if(cnt[a[k]] > max) max = cnt[a[k]];
+				}
+				s = ns;
+				e = ns;
+				ccnt[cnt[a[s]]]--;
+				if(ccnt[max] == 0) max--;
+				ccnt[++cnt[a[s]]]++;
+				if(cnt[a[s]] > max) max = cnt[a[s]];
+			}
+			while(s < ns) {
+				ccnt[cnt[a[s]]]--;
+				if(ccnt[max] == 0) max--;
+				ccnt[--cnt[a[s]]]++;
+				if(cnt[a[s]] > max) max = cnt[a[s]];
+				s++;
+			}
+			while(ns < s) {
+				s--;
+				ccnt[cnt[a[s]]]--;
+				if(ccnt[max] == 0) max--;
+				ccnt[++cnt[a[s]]]++;
+				if(cnt[a[s]] > max) max = cnt[a[s]];
+			}
+			while(e < ne) {
+				e++;
+				ccnt[cnt[a[e]]]--;
+				if(ccnt[max] == 0) max--;
+				ccnt[++cnt[a[e]]]++;
+				if(cnt[a[e]] > max) max = cnt[a[e]];
+			}
+			while(ne < e) {
+				ccnt[cnt[a[e]]]--;
+				if(ccnt[max] == 0) max--;
+				ccnt[--cnt[a[e]]]++;
+				if(cnt[a[e]] > max) max = cnt[a[e]];
+				e--;
+			}
+			ans[idx] = max;
+			s = ns;
+			e = ne;
+		}
+
+		for(int v:ans) io.write(v + "\n");
+
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/13548

## 🧭 풀이 시간
35분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
길이가 N인 수열에 "구간 [l,r]에 가장 많이 등장하는 수의 등장 횟수를 구하기" 이 작업을 Q번 해보자.

## 🔍 풀이 방법
- mo's
---
수열의 총 길이를 sqrt(N)으로 쪼개서 쿼리의 시작점을 sqrt(N)로 나눈 몫을 기준으로 쿼리를 정렬한다.
정렬 후에 while문으로 매번 직접 l, r을 옮기면서 개수를 세어줬다.

## ⏳ 회고
개수의 개수를 세어주는게 너무 머리 아프다