### PR TITLE
[20250819] BOJ / G4 / 도서관 / 김수연

### DIFF
--- a/suyeun84/202508/19 BOJ G4 도서관.md
+++ b/suyeun84/202508/19 BOJ G4 도서관.md
@@ -1,0 +1,44 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class boj1461 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+    static int nextInt() {return Integer.parseInt(st.nextToken());}
+
+    public static void main(String[] args) throws Exception {
+        nextLine();
+        int N = nextInt();
+        int M = nextInt();
+        int answer = 0;
+        PriorityQueue<Integer> pos = new PriorityQueue<>(Collections.reverseOrder());
+        PriorityQueue<Integer> neg = new PriorityQueue<>(Collections.reverseOrder());
+        nextLine();
+        for (int i = 0; i < N; i++) {
+            int num = nextInt();
+            if (num < 0) neg.add(Math.abs(num));
+            else pos.add(num);
+        }
+        int last = 0;
+        if (pos.isEmpty()) last = neg.peek();
+        else if (neg.isEmpty()) last = pos.peek();
+        else {
+            last = Math.max(neg.peek(), pos.peek());
+        }
+
+        while (!pos.isEmpty()) {
+            answer += pos.peek() * 2;
+            for (int i = 0; i < M; i++) pos.poll();
+        }
+
+        while(!neg.isEmpty()) {
+            answer += neg.peek() * 2;
+            for (int i = 0; i < M; i++) neg.poll();
+        }
+
+        System.out.println(answer - last);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1461
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
세준이와 책이 전부 0에 있을 때,
책들을 최소 걸음 수로 전부 제자리에 가져다 놓는 걸음 수 구하기
## 🔍 풀이 방법
priorityQueue 사용
우선순위 큐를 양수, 음수 2개로 만들어서 M개마다의 최댓값을 구해서 answer에 더해줌
## ⏳ 회고
제일 마지막꺼는 갔다가 안돌아와도 되지만, 다른거는 갔다가 다시 0으로 돌아와야 해서 2를 곱해줘야 함