### PR TITLE
[20250820] BOJ / D5 / 수열과 쿼리 39 / 권혁준

### DIFF
--- a/khj20006/202508/20 BOJ D5 수열과 쿼리 39.md
+++ b/khj20006/202508/20 BOJ D5 수열과 쿼리 39.md
@@ -1,0 +1,207 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+    BufferedReader br;
+    BufferedWriter bw;
+    StringTokenizer st;
+
+    public IOController() {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        st = new StringTokenizer("");
+    }
+
+    String nextLine() throws Exception {
+        String line = br.readLine();
+        st = new StringTokenizer(line);
+        return line;
+    }
+
+    String nextToken() throws Exception {
+        while (!st.hasMoreTokens()) nextLine();
+        return st.nextToken();
+    }
+
+    int nextInt() throws Exception {
+        return Integer.parseInt(nextToken());
+    }
+
+    long nextLong() throws Exception {
+        return Long.parseLong(nextToken());
+    }
+
+    double nextDouble() throws Exception {
+        return Double.parseDouble(nextToken());
+    }
+
+    void close() throws Exception {
+        bw.flush();
+        bw.close();
+    }
+
+    void write(String content) throws Exception {
+        bw.write(content);
+    }
+
+}
+
+class Node {
+    int len, left, right, total;
+    long lval, rval;
+    Node(int len, int left, int right, int total, long lval, long rval) {
+        this.len = len;
+        this.left = left;
+        this.right = right;
+        this.total = total;
+        this.lval = lval;
+        this.rval = rval;
+    }
+    Node(int len){this.len = len;}
+}
+
+class SegTree {
+    Node[] tree;
+    long[] arr, lazy;
+    int size;
+    SegTree(long[] a) {
+        size = a.length-1;
+        arr = new long[size+1];
+        for(int i=1;i<=size;i++) arr[i] = a[i];
+        tree = new Node[size*4];
+        lazy = new long[size*4];
+        init(1,size,1);
+    }
+
+    Node merge(Node a, Node b) {
+        if(a.len == 0) return new Node(b.len, b.left, b.right, b.total, b.lval, b.rval);
+        if(b.len == 0) return new Node(a.len, a.left, a.right, a.total, a.lval, a.rval);
+
+        Node c = new Node(a.len + b.len);
+        c.lval = a.lval;
+        c.left = a.left;
+        if(a.left == a.len && a.lval == b.lval) {
+            c.left = a.left + b.left;
+        }
+
+        c.rval = b.rval;
+        c.right = b.right;
+        if(b.right == b.len && b.rval == a.rval) {
+            c.right = a.right + b.right;
+        }
+
+        c.total = Math.max(a.total, b.total);
+        if(a.rval == b.lval) c.total = Math.max(c.total, a.right + b.left);
+
+        return c;
+    }
+
+    void init(int s, int e, int n) {
+        if(s == e) {
+            tree[n] = new Node(1,1,1,1,arr[s],arr[s]);
+            return;
+        }
+        int m = (s+e)>>1;
+        init(s,m,n*2);
+        init(m+1,e,n*2+1);
+        tree[n] = merge(tree[n*2], tree[n*2+1]);
+    }
+
+    void prop(int s, int e, int n) {
+        if(lazy[n] != 0) {
+            tree[n].lval += lazy[n];
+            tree[n].rval += lazy[n];
+            if(s != e) {
+                lazy[n*2] += lazy[n];
+                lazy[n*2+1] += lazy[n];
+            }
+            else arr[s] += lazy[n];
+            lazy[n] = 0;
+        }
+    }
+
+    void rangeUpdate(int s, int e, int l, int r, long v, int n) {
+        prop(s,e,n);
+        if(l>r || l>e || r<s) return;
+        if(l<=s && e<=r) {
+            tree[n].lval += v;
+            tree[n].rval += v;
+            if(s != e) {
+                lazy[n*2] += v;
+                lazy[n*2+1] += v;
+            }
+            else arr[s] += v;
+            return;
+        }
+        int m = (s+e)>>1;
+        rangeUpdate(s,m,l,r,v,n*2);
+        rangeUpdate(m+1,e,l,r,v,n*2+1);
+        tree[n] = merge(tree[n*2], tree[n*2+1]);
+    }
+
+    Node find(int s, int e, int l, int r, int n) {
+        prop(s,e,n);
+        if(l>r || l>e || r<s) return new Node(0,0,0,0,0,0);
+        if(l<=s && e<=r) return tree[n];
+        int m = (s+e)>>1;
+        return merge(find(s,m,l,r,n*2), find(m+1,e,l,r,n*2+1));
+    }
+}
+
+public class Main {
+
+    static IOController io;
+
+    //
+
+    static int N, M;
+    static long[] a;
+    static SegTree seg;
+
+    public static void main(String[] args) throws Exception {
+
+        io = new IOController();
+
+        init();
+        solve();
+
+        io.close();
+
+    }
+
+    static void init() throws Exception {
+
+        N = io.nextInt();
+        a = new long[N+1];
+        long[] b = new long[N+1];
+        for(int i=1;i<=N;i++) {
+            a[i] = io.nextInt();
+            b[i] = a[i] - a[i-1];
+        }
+        seg = new SegTree(b);
+
+    }
+
+    static void solve() throws Exception {
+
+        for(M = io.nextInt();M-->0;) {
+            int op = io.nextInt();
+            int i = io.nextInt();
+            int j = io.nextInt();
+            if(op == 1) {
+                long x = io.nextLong();
+                long y = io.nextLong();
+                seg.rangeUpdate(1,N,i,i,x,1);
+                seg.rangeUpdate(1,N,i+1,j,y,1);
+                if(j != N) seg.rangeUpdate(1,N,j+1,j+1,-(x+y*((long)j-i)),1);
+            }
+            else {
+                io.write((seg.find(1,N,i+1,j,1).total+1) + "\n");
+            }
+        }
+
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/19651

## 🧭 풀이 시간
240분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
길이 N인 수열 A가 있다.
두 가지 쿼리를 처리해보자.
1. 구간 [i,j]에 초항이 x, 공차가 y인 등차수열 더하기
2. 구간 [i,j]에서의 연속 부분 수열 중 등차수열의 최대 길이

## 🔍 풀이 방법
- 느리게 갱신되는 세그먼트 트리
---
B[i] = A[i] - A[i-1]로 정의하고 이 B 배열로 세그먼트 트리를 구성하면, 1번 쿼리가 단순히 구간 덧셈 쿼리로 변한다.
구체적으로 쿼리 (1, i, j, x, y)가 다음과 같이 변함.
- B[i]에 x 더하기
- B[i+1]부터 B[j]까지 y 더하기
- B[j+1]에 x + (j-i)*y 빼기

위 작업들을 모두 세그먼트 트리에서 레이지 배열로 처리하고, 2번 쿼리는 구조체를 정의해서 세그먼트 트리의 노드로 넣어 처리했다.

구조체 Node에 포함되는 값은
1. 구간 길이
2. 이 구간에서의 가장 왼쪽 원소
3. 이 구간에서의 가장 오른쪽 원소
4. 이 구간에서 가장 왼쪽 원소를 포함하는 최대 등차수열 길이
5. 이 구간에서 가장 오른쪽 원소를 포함하는 최대 등차수열 길이
6. 이 구간에서의 최대 등차수열 길이

이렇게 정의하고 세그먼트 트리에서 하위 두 노드를 합치는 함수를 만들어줬다.

## ⏳ 회고
레이지 배열 안 쓰는 업데이트 함수를 지우니까 맞음. 뭐지????