### PR TITLE
[20250820] PGM / LV2 / 두 큐 합 같게 만들기 / 이인희

### DIFF
--- a/LiiNi-coder/202508/20 PGM 두 큐 합 같게 만들기.md
+++ b/LiiNi-coder/202508/20 PGM 두 큐 합 같게 만들기.md
@@ -1,0 +1,92 @@
+```java
+import java.util.*;
+
+class Solution {
+    static class BfsQElement {
+        int count;
+        ArrayDeque<Integer> q1;
+        ArrayDeque<Integer> q2;
+        long sum1;
+        long sum2;
+
+        BfsQElement(int count, ArrayDeque<Integer> q1, ArrayDeque<Integer> q2, long sum1, long sum2) {
+            this.count = count;
+            this.q1 = q1;
+            this.q2 = q2;
+            this.sum1 = sum1;
+            this.sum2 = sum2;
+        }
+    }
+
+    public int solution(int[] queue1, int[] queue2) {
+        long total = 0;
+        long sum1 = 0, sum2 = 0;
+
+        var q1 = new ArrayDeque<Integer>();
+        var q2 = new ArrayDeque<Integer>();
+
+        for (int i : queue1) {
+            q1.offer(i);
+            sum1 += i;
+            total += i;
+        }
+        for (int i : queue2) {
+            q2.offer(i);
+            sum2 += i;
+            total += i;
+        }
+        if (total % 2 != 0)
+          return -1;
+        long target = total / 2;
+        var bfsQ = new ArrayDeque<BfsQElement>();
+        bfsQ.offer(new BfsQElement(0, q1, q2, sum1, sum2));
+        
+        Set<String> visited = new HashSet<>();//방문상태
+        visited.add(sum1 + "," + sum2);
+
+        while (!bfsQ.isEmpty()) {
+            BfsQElement cur = bfsQ.poll();
+
+            if (cur.sum1 == target) {
+                return cur.count;
+            }
+
+            if (!cur.q1.isEmpty()) {
+                int val = cur.q1.peek();
+                var newQ1 = new ArrayDeque<>(cur.q1);
+                var newQ2 = new ArrayDeque<>(cur.q2);
+                newQ1.poll();
+                newQ2.offer(val);
+
+                long newSum1 = cur.sum1 - val;
+                long newSum2 = cur.sum2 + val;
+                String key = newSum1 + "," + newSum2;
+
+                if (!visited.contains(key)) {
+                    visited.add(key);
+                    bfsQ.offer(new BfsQElement(cur.count + 1, newQ1, newQ2, newSum1, newSum2));
+                }
+            }
+
+            if (!cur.q2.isEmpty()) {
+                int val = cur.q2.peek();
+                var newQ1 = new ArrayDeque<>(cur.q1);
+                var newQ2 = new ArrayDeque<>(cur.q2);
+                newQ2.poll();
+                newQ1.offer(val);
+
+                long newSum1 = cur.sum1 + val;
+                long newSum2 = cur.sum2 - val;
+                String key = newSum1 + "," + newSum2;
+
+                if (!visited.contains(key)) {
+                    visited.add(key);
+                    bfsQ.offer(new BfsQElement(cur.count + 1, newQ1, newQ2, newSum1, newSum2));
+                }
+            }
+        }
+
+        return -1;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/118667
## 🧭 풀이 시간
50 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 두 큐가 존재하고, 큐의 한쪽에서 pop한 것을 다룬 큐에 insert하는 행동을 a라 할때, a를 최소 몇번을 해야 두 큐의 합이 각각 같게 만드는지 구하는 문제

## 🔍 풀이 방법
- BFS를 진행하되, BFS의 Element로 두 큐의 상태를 넣었음

## ⏳ 회고
- 이 방식이 매 BFS시 큐를 아예 복사하는 것이라서 비효율적인것은 알지만, 제한된 시간내에 풀려하다 보니 급하게 푸느라, 이 방법대로 계속 해보려고 다른 풀이나 gpt힘을 빌려서 visited도 도입하는 등 풀어보려했습니다만 여전히 효율성체크에서 에러납니다...
- 이런 문제에서 처음에 생각을 할때, 비효율적이다 싶으면 좀더 생각하는 시간을 가지고 구현에 임하는 버릇을 들이자. 투포인터를 쓴다는 생각을 못해서 이 사단이 났따... 실제 코테에서 이러진 말자