### PR TITLE
[20250821] BOJ / G1 / 2048(Easy)  / 이종환

### DIFF
--- a/0224LJH/202508/21 BOJ  2048 (Easy).md
+++ b/0224LJH/202508/21 BOJ  2048 (Easy).md
@@ -1,0 +1,134 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+
+public class Main {
+   
+   static final int END = 5;
+   static final int UP = 0;
+   static final int RIGHT = 1;
+   static final int DOWN = 2;
+   static final int LEFT = 3;
+   
+   static int[][] arr;
+   static int[] dy = {-1,0,1,0};
+   static int[] dx = {0,1,0,-1};
+   static int size,ans;
+   
+   
+
+   public static void main(String[] args) throws IOException {
+      init();
+      process();
+      print();
+   }
+   
+   public static void init() throws IOException {
+      BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+      size = Integer.parseInt(br.readLine());
+      arr = new int[size][size];
+      ans = 0;
+      
+      for (int i = 0; i < size; i++) {
+         StringTokenizer st = new StringTokenizer(br.readLine());
+         for (int j = 0; j < size; j++) {
+            arr[i][j] = Integer.parseInt(st.nextToken());
+         }
+      }
+
+      
+   }
+   
+   public static void process() {
+	   dfs(arr, 0);
+   }
+   
+   public static void dfs(int[][] board, int cnt) {
+      if (cnt == END) {
+         for (int i = 0 ; i < size; i++) {
+            for (int j = 0; j < size; j++) {
+            	System.out.print(board[i][j]+ " ");
+            	ans = Math.max(board[i][j],ans);
+            }
+            System.out.println();
+         }
+         System.out.println();
+         return;
+      }
+      
+      
+      //dir으로 이동하면 dir부터 큐에 넣은 후, 하나씩 꺼내면 됨. 이걸 유지
+      
+      for (int dir = 0 ; dir < 4; dir++) {
+         Queue<Integer>[] qs = new Queue[size];
+         int[][] temp = new int[size][size];
+         boolean keepTrying = false;
+         
+         
+         for (int i = 0 ; i < size; i++) {
+            qs[i] = new LinkedList<Integer>(); 
+            for (int j = 0; j < size; j++) {
+               int num = 0;
+               
+               if (dir == UP) num = board[j][i]; // 위에서부터 아래 순으로 담김
+               else if (dir == DOWN) num = board[size-1-j][i]; // 아래에서부터 위로
+               else if (dir == LEFT) num = board[i][j];
+               else if (dir == RIGHT) num = board[i][size-1-j];
+               
+               if (num != 0 ) qs[i].add(num);
+            }
+         }
+         
+         for (int i = 0 ; i < size; i++) {
+            Queue q = qs[i];
+            int idx = 0;
+            
+            while (!q.isEmpty()) {
+               int target = -1; // 지금 보고있는 칸.
+               
+               if (dir == UP) target = temp[idx][i]; // 위에서부터 아래 순으로 담김
+               else if (dir == DOWN) target = temp[size-1-idx][i]; // 아래에서부터 위로
+               else if (dir == LEFT) target = temp[i][idx];
+               else if (dir == RIGHT) target = temp[i][size-1-idx];
+               
+               
+               int num = (int) q.poll();
+               
+               
+               
+               if (target != 0 && target != num) idx++;
+               
+               if (target == num) keepTrying = true;
+
+               if (dir == UP) temp[idx][i] += num;
+               else if (dir == DOWN) temp[size-1-idx][i] += num;
+               else if (dir == LEFT) temp[i][idx] += num;
+               else if (dir == RIGHT) temp[i][size-1-idx] += num;
+                  
+               if (target == num) idx++; // 합쳐진것. 이제 이 칸에 볼일없음               
+               
+            }
+            
+            
+            
+            
+         }
+         
+         dfs(temp,cnt+1);
+         
+      }
+      
+   }
+   
+
+   
+
+   public static void print() {
+      System.out.println(ans);
+   }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/12100

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
이 문제에서 다루는 2048 게임은 보드의 크기가 N×N 이다. 보드의 크기와 보드판의 블록 상태가 주어졌을 때, 최대 5번 이동해서 만들 수 있는 가장 큰 블록의 값을 구하는 프로그램을 작성하시오.

## 🔍 풀이 방법
결국 순수 구현인데, 이걸 어떻게 표현할까 많이 고민했다. 그런데 방향에 따라서 대입하거나 꺼내오는 값이 바뀌는 파트가 별로 없어서 그냥 무식하게 if문으로 나눴다. 

숫자가 합쳐지는 것의 경우 줄마다 큐를 생성한 후, 각 줄에서 0이아닌 수를 다 큐에 넣고, 다시 꺼내는 방식으로 구현하였다. 이를 통해 이제 합쳐져서 생긴 수에 또 다른 수를 또 합쳐버리는 실수를 방지하였다.

## ⏳ 회고

으 헷갈려
