### PR TITLE
[20250821] BOJ / G4 / 별 찍기 - 18 / 김민진

### DIFF
--- a/zinnnn37/202508/21 BOJ G4 별 찍기 - 18.md
+++ b/zinnnn37/202508/21 BOJ G4 별 찍기 - 18.md
@@ -1,0 +1,88 @@
+```java
+import java.io.*;
+
+public class BJ_10933_별_찍기_18 {
+
+	private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+	private static int N;
+	private static int height;
+	private static int width;
+
+	private static char[][] mat;
+
+	public static void main(String[] args) throws IOException {
+		init();
+		sol();
+	}
+
+	private static void init() throws IOException {
+		N      = Integer.parseInt(br.readLine());
+		height = (int) (Math.pow(2, N) - 1);
+		width  = height * 2 - 1;
+
+		mat = new char[height][width];
+	}
+
+	private static void sol() throws IOException {
+		rec(N, 0, 0);
+		printMat();
+	}
+
+	private static void rec(int n, int x, int y) {
+		if (n == 1) {
+			mat[x][y] = '*';
+			return;
+		}
+
+		int h = (int) (Math.pow(2, n) - 1);
+		int w = h * 2 - 1;
+
+		if (n % 2 == 1) {
+			for (int i = 0; i <= w / 2; i++) {
+				mat[x + h - i - 1][y + i]             = '*';
+				mat[x + h - i - 1][y + h * 2 - i - 2] = '*';
+				mat[x + h - 1][y + i]                 = '*';
+				mat[x + h - 1][y + h * 2 - i - 2]     = '*';
+			}
+			rec(n - 1, x + h / 2, y + w / 4 + 1);
+		} else {
+			for (int i = 0; i <= w / 2; i++) {
+				mat[x][y + i]                 = '*';
+				mat[x][y + h * 2 - i - 2]     = '*';
+				mat[x + i][y + i]             = '*';
+				mat[x + i][y + h * 2 - i - 2] = '*';
+			}
+			rec(n - 1, x + 1, y + w / 4 + 1);
+		}
+	}
+
+	private static void printMat() throws IOException {
+		for (char[] chars : mat) {
+			// 각 줄에서 마지막 '*'의 위치 찾기
+			int lastStar = -1;
+			for (int i = chars.length - 1; i >= 0; i--) {
+				if (chars[i] == '*') {
+					lastStar = i;
+					break;
+				}
+			}
+
+			// 마지막 별까지만 출력
+			for (int i = 0; i <= lastStar; i++) {
+				if (chars[i] == '*') {
+					bw.write('*');
+				} else {
+					bw.write(' ');
+				}
+			}
+			bw.write("\n");
+		}
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[10993 별 찍기 - 18](https://www.acmicpc.net/problem/10993)

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
재귀 사용해서 별 찍으면 되는 문제입니다.

## 🔍 풀이 방법
직선은 양 끝점에서 1씩 가운데로 움직이도록, <br/>
대각선은 거기에 x축 방향으로 ±1 하도록 반복문을 구성하여 한 번에 `*`을 찍었습니다.<br/>

시작 점은 삼각형이 꽉 차는 사각형의 좌상단 모서리로 잡았습니다.<br/>
짝수의 경우 역삼각형이기 때문에 시작 좌표의 `x`값은 늘 `x+1`이 되고<br/>
홀수의 경우 높이의 절반이 되기 때문에 `x + h / 2` 입니다.<br/>
좌표의 `y` 값은 항상 너비를 4로 나눈 값이 되어 `y + w / 4 + 1`이 됩니다.<br/>

이를 깊이가 1(가장 작은 삼각?형)이 될 때까지 반복합니다.

## ⏳ 회고
규칙 찾는 건 그다지 어렵지 않았는데 오른쪽 공백을 출력하면 안 된다는 사실을 늦게 알아서 시간이 좀 걸렸습니다.<br/>
재귀를 하는 과정에서 공백을 함께 넣어 오른쪽 공백을 아예 넣지 않는 것이 베스트겠지만<br/>
이미 로직이 다 나온 상태라 그냥 출력할 때 오른쪽 공백 제외하고 출력하도록 했습니다..<br/>
