### PR TITLE
[20250822] BOJ / P5 / (Relatively) Prime / 권혁준

### DIFF
--- a/khj20006/202508/22 BOJ P5 (Relatively) Prime.md
+++ b/khj20006/202508/22 BOJ P5 (Relatively) Prime.md
@@ -1,0 +1,111 @@
+```java
+import java.awt.image.AreaAveragingScaleFilter;
+import java.util.*;
+import java.io.*;
+
+class IOController {
+	BufferedReader br;
+	BufferedWriter bw;
+	StringTokenizer st;
+
+	public IOController() {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		st = new StringTokenizer("");
+	}
+
+	String nextLine() throws Exception {
+		String line = br.readLine();
+		st = new StringTokenizer(line);
+		return line;
+	}
+
+	String nextToken() throws Exception {
+		while (!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+
+	int nextInt() throws Exception {
+		return Integer.parseInt(nextToken());
+	}
+
+	long nextLong() throws Exception {
+		return Long.parseLong(nextToken());
+	}
+
+	double nextDouble() throws Exception {
+		return Double.parseDouble(nextToken());
+	}
+
+	void close() throws Exception {
+		bw.flush();
+		bw.close();
+	}
+
+	void write(String content) throws Exception {
+		bw.write(content);
+	}
+
+}
+
+public class Main {
+
+	static IOController io;
+
+	//
+
+	static final long MOD = 998244353;
+	static long P, N, M;
+
+	public static void main(String[] args) throws Exception {
+
+		io = new IOController();
+
+		for(int T=io.nextInt(); T-->0; ) {
+			init();
+			solve();
+		}
+
+		io.close();
+
+	}
+
+	static void init() throws Exception {
+
+		P = io.nextLong();
+		N = io.nextLong();
+		M = io.nextLong();
+
+	}
+
+	static void solve() throws Exception {
+
+		if(N < M) {
+			long t = N;
+			N = M;
+			M = t;
+		}
+
+		long pm = power(P, M);
+		long ans = pm * ((power(pm, N/M) + MOD - 1) % MOD) % MOD;
+		ans = (ans * (power((pm+MOD-1)%MOD, MOD-2))) % MOD;
+		if(N%M != 0) ans = (ans + power(P, N)) % MOD;
+
+		if(pm == 1) {
+			ans = N/M;
+			if(N%M != 0) ans = (ans + power(P, N)) % MOD;
+		}
+		io.write(ans + "\n");
+
+	}
+
+	static long power(long a, long x) {
+		if(x == 0) return 1;
+		if(x == 1) return a%MOD;
+		long h = power(a, x>>1) % MOD;
+		if(x%2 == 0) return h*h%MOD;
+		return h*h%MOD*a%MOD;
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/34151

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
소수 p와 정수 n, m가 주어지면, gcd(a,b) = p를 만족하는 a, b에 대해 gcd(a^n, b^m)으로 가능한 서로 다른 값들의 합을 구해보자.

## 🔍 풀이 방법
- 수학
---
일단 n >= m이라고 가정한다.
gcd(a,b) = p라는 것은, gcd(x,y) = 1인 어떤 x, y에 대해 a = xp, b = yp 꼴이라는 의미다.

그래서 gcd(a^n, b^m) = gcd((xp)^n, (yp)^m)이고, 이 값은 일단 p^m을 갖고 간다.

gcd(x,y) = 1이어야 하기 떄문에, 위 값으로 가능한 다른 값은 y = p^k 꼴인 경우 뿐이다.

따라서 최종 답은 p^m + p^2m + ... + p^n 꼴로 나오게 된다.
등비수열의 합 공식을 이용해서 답을 구해줬다.
거듭제곱을 빠르게 구해야 하므로 분할 정복을 사용했고, 등비수열 합 공식에서 나눗셈에 대한 모듈로 처리를 위해 페르마의 소정리를 이용했다.

## ⏳ 회고
좋은아침