### PR TITLE
[20250822] BOJ / P3 / 화려한 마을 / 이종환

### DIFF
--- a/0224LJH/202508/22 BOJ 화려한 마을
+++ b/0224LJH/202508/22 BOJ 화려한 마을
@@ -1,0 +1,166 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.StringTokenizer;
+
+
+public class Main {
+	
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringBuilder sb = new StringBuilder();
+	static StringTokenizer st;
+	
+	static int houseCnt, nodeCnt, colorCnt, taskCnt;
+	
+	// 각각의 노드가 지금 구간에서 어떤 색을 몇 개 가지고 있는 지 인지해야함.
+	// 100,000 * 4 * 30 = 12,000,000 개의 Integer -> 이게 맞나?
+	
+	static class SegmentTree{
+		
+		int[] lazy;
+		int check;
+		int[] nodes; // 어느 색상을 가지는지 비트마스킹으로 표현. 이래서 색상이 최대가 30이었구나
+		
+		public SegmentTree() {
+			nodeCnt = houseCnt*4;
+			nodes = new int[nodeCnt];
+			lazy = new int[nodeCnt];
+			Arrays.fill(nodes, (1 << 1));
+		}
+		
+
+		
+		private void updateLazy(int nodeIdx, int from, int to) {
+			if (lazy[nodeIdx] ==0) return;
+			
+			nodes[nodeIdx] =  ( 1 << lazy[nodeIdx]);
+			
+			if ( from != to) {
+				lazy[nodeIdx*2] = lazy[nodeIdx];
+				lazy[nodeIdx*2+1] = lazy[nodeIdx];
+			}
+			lazy[nodeIdx] = 0;
+			
+			return;
+		}
+		
+		public void updateRnage(int from, int to , int target) {
+			updateRange(1,1,houseCnt, from,to,target);
+		}
+		
+		private void updateRange (int idx, int start, int end, int from ,int to, int target) {
+			updateLazy(idx, start, end);
+			
+			if ( start > to || end < from) return; // 아예 안걸림 
+			
+			
+			// 완전히 걸림
+			if ( start >= from && end <= to) {
+				
+				nodes[idx] = (1 << target);
+				
+				if (start!=end) {
+					lazy[idx*2] = target;
+					lazy[idx*2+1] = target;
+				}
+				return;
+			}
+			
+			//걸치는 경우
+			
+			int mid = (start+end)/2;
+			
+			// 하위 노드를 업데이트 후
+			updateRange(idx*2,start,mid,from,to,target);
+			updateRange(idx*2+1,mid+1,end,from,to,target);
+			
+
+			nodes[idx] =( nodes[idx*2] | nodes[idx*2+1]);
+		}
+		
+		public int query (int from, int to) {
+			check = 0 ;
+			query(1, 1, houseCnt, from,to);
+			
+			int ans = 0;
+			
+			for (int i = 0; i < 30; i++) {
+				if ( (check & (1 << i)) != 0) ans++;
+			}
+			return  ans;
+		}
+		
+		private void query(int idx, int start, int end, int from ,int to) {
+			updateLazy(idx, start, end);
+			
+			if (start > to || end < from) return;
+			
+			
+			if ( start >= from && end <= to) {
+				check |= nodes[idx];
+				return;
+			}
+			
+			// 적당히 겹치는 경우
+			int mid = (start+end)/2;
+			query(idx*2, start,mid,from,to);
+			query(idx*2+1, mid+1,end,from,to);
+		}
+		
+	}
+	
+
+	
+
+	public static void main(String[] args) throws IOException {
+		init();
+		process();
+		print();
+	}
+	
+	public static void init() throws IOException {
+		st = new StringTokenizer(br.readLine());
+		
+		houseCnt = Integer.parseInt(st.nextToken());
+		colorCnt = Integer.parseInt(st.nextToken());
+		taskCnt = Integer.parseInt(st.nextToken());
+		
+	}
+	
+	public static void process() throws IOException {
+		SegmentTree tree = new SegmentTree();
+		
+		for (int i = 0; i < taskCnt; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			String order = st.nextToken();
+			int from = Integer.parseInt(st.nextToken());
+			int to = Integer.parseInt(st.nextToken());
+			
+			if (from > to) {
+				int temp = from;
+				from = to;
+				to = temp;
+			}
+			
+			if (order.equals("C")){
+				int target = Integer.parseInt(st.nextToken());
+				tree.updateRnage(from, to, target);
+			} else {
+				sb.append(tree.query(from, to)).append("\n");
+			}
+		}
+
+	}
+
+	
+
+	public static void print() {
+		System.out.print(sb.toString());
+	}
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/12895


## 🧭 풀이 시간
120분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
특정 구간의 집들의 색들을 새롭게 칠하거나, 특정 구간의 집들에 존재하는 색의 수를 알고 싶어졌다.

작업은 다음과 같은 두가지로 이루어 진다.

“C x y z” : x번과 y번, 그리고 그 사이에 있는 모든 집을 z번 색으로 색칠한다.
“Q x y” : x번과 y번, 그리고 그 사이에 있는 모든 집에 존재하는 색의 가짓수를 출력한다.
민호가 사용할 색의 종류는 (1번, 2번, … T번) 이라 하고 처음 모든 집은 1번으로 색칠되어 있다고 생각한다.

작업이 “Q x y”일 때의 경우 x번과 y번, 그리고 그 사이에 있는 모든 집에 존재하는 색의 가짓수를 출력한다.


## 🔍 풀이 방법

레이지 세그먼트 트리를 연습하기 위해서 푼 문제이기에 당연히 그것부터 도입했다. 그렇게 천천히 도입해서 1시반 30정도 걸렸을 때 풀긴 풀었는데, 시간 초과가 간신히 안된 상태였다.
그렇기에 다른 사람들의 코드를 보니 현재 노드에서 몇가지 색상을 가지고 있냐를 Set이 아니라 비트마스킹으로 표현하고 있었다.

이를 도입하니 정상적인 풀이 시간이 나와 해결하였다.

## ⏳ 회고
입력값의 제한을 잘 보자. 색상의 제한이 30이길래 왜그런가 했는데 int로 비트마스킹 하라는 뜻이었다..
