### PR TITLE
[20250822] BOJ / P4 / 세금 / 이강현

### DIFF
--- a/lkhyun/202508/22 BOJ P4 세금.md
+++ b/lkhyun/202508/22 BOJ P4 세금.md
@@ -1,0 +1,108 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+
+    static class Edge{
+        int to;
+        int cnt;
+        int cost;
+
+        Edge(int to, int cnt, int cost){
+            this.to = to;
+            this.cnt = cnt;
+            this.cost = cost;
+        }
+    }
+    static int N,M,K;
+    static int S,D;
+    static List<Edge>[] adjLists;
+    static int[][] dist;
+
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+        adjLists = new List[N+1];
+        dist = new int[N+1][N+1];
+        
+        for (int i = 1; i <= N; i++) {
+            adjLists[i] = new ArrayList<>();
+            Arrays.fill(dist[i], Integer.MAX_VALUE);
+        }
+
+        st = new StringTokenizer(br.readLine());
+        S = Integer.parseInt(st.nextToken());
+        D = Integer.parseInt(st.nextToken());
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+            int cost = Integer.parseInt(st.nextToken());
+            adjLists[from].add(new Edge(to, 0, cost));
+            adjLists[to].add(new Edge(from, 0, cost));
+        }
+
+        dijkstra(S);
+        
+        int optIdx = 0;
+        int ans = Integer.MAX_VALUE;
+        for (int i = 1; i <= N; i++) {
+            if(dist[D][i] < ans){
+                ans = dist[D][i];
+                optIdx = i;
+            }
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append(ans).append("\n");
+
+        int tax = 0;
+        for (int i = 0; i < K; i++) {
+            tax += Integer.parseInt(br.readLine());
+            ans = Integer.MAX_VALUE;
+            for (int j = 1; j <= N; j++) {
+                if(dist[D][j] == Integer.MAX_VALUE) continue;
+                int cur = dist[D][j] + (tax*j);
+                if(cur < ans){
+                    ans = cur;
+                    optIdx = j;
+                }
+            }
+            sb.append(ans).append("\n");
+        }
+        bw.write(sb.toString());
+        bw.close();
+    }
+    
+    public static void dijkstra(int start){
+        PriorityQueue<Edge> pq = new PriorityQueue<>((a,b) -> a.cost - b.cost);
+        
+        dist[start][0] = 0;
+        pq.add(new Edge(start,0,0));
+
+        while(!pq.isEmpty()){
+            Edge cur = pq.poll();
+
+            if(dist[cur.to][cur.cnt] < cur.cost) continue;
+
+            for(Edge next : adjLists[cur.to]){
+                int newCost = cur.cost + next.cost;
+                int nextCnt = cur.cnt + 1;
+                
+                if(nextCnt <= N && dist[next.to][nextCnt] > newCost){
+                    dist[next.to][nextCnt] = newCost;
+                    pq.offer(new Edge(next.to, nextCnt, newCost));
+                }
+            }
+        }
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/13907
## 🧭 풀이 시간
120분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
출발지와 도착지 주어짐.
K번 만큼의 세금 인상이 있음. 세금을 인상하면 모든 도로의 통행료가 증가함.
매 세금 인상마다 최소 비용을 출력.
## 🔍 풀이 방법
다익스트라
다익스트라 한번 쓰고 거쳐온 간선수를 최소비용과 함께 저장.
이후 세금 인상 시키면서 최소비용 출력.
## ⏳ 회고
로직은 금방 생각해서 구현했는데 시간 초과가 자꾸 떴음.
핵심은 두가지
1. 정점의 수가 N일때 단순 경로의 최대 간선 수는 N-1이다.(그래서 그 이후는 잘라내도 됨.)
2. Map의 keySet() 메소드는 iterator를 호출해서 ㅈㄴ 느리다. 범위가 정해지면 무조건 배열 써라. 간선의 수가 30000개라서 맵으로 구현했다가 N 이하로 잘라도 되는것을 알고 다익스트라 조건만 추가했는데, 그냥 맵 자체가 느려서 배열로만 통과됐다.
진짜 ㅈㄴ 열받는다