### PR TITLE
[20250823] BOJ / G1 / 좋은 부분 문자열의 개수 / 이종환

### DIFF
--- a/0224LJH/202508/23 BOJ 좋은 부분 문자열의 개수.md
+++ b/0224LJH/202508/23 BOJ 좋은 부분 문자열의 개수.md
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.*;
 
-
+ 
 public class Main {
 	
 	static int badLimit,len,ans;


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/13507

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
알파벳 소문자로 이루어진 문자열 s가 주어진다. 알파벳 중에서 일부는 좋고, 나머지는 나쁘다.

문자열 s = s1s2...s|s|(|s|는 문자열 s의 길이)의 부분 문자열 s[l...r] (1 ≤ l ≤ r ≤ |s|)는 slsl+1...sr 이다.

만약, s[l...r]을 이루고 있는 알파벳 sl, sl+1, ..., sr 중에서 나쁜 알파벳의 개수가 최대 k개라면, 그 부분 문자열을 좋다고 한다.

s의 서로 다른 좋은 부분 문자열의 개수를 찾는 프로그램을 작성하시오. s[x...y] ≠ s[p...q]인 경우에 두 부분 문자열 s[x...y]와 s[p...q]를 서로 다르다고 한다.

## 🔍 풀이 방법
전형적인 트라이 문제이다. 문자열의 시작위치를 다르게 해 각각의 경우에 대해서 하나의 단어로 간주하고 대입 후, dfs를 통해 계산하면 간단히 풀 수 있다.
## ⏳ 회고
