### PR TITLE
[20250823] BOJ / G1 / 가계부 (Hard) / 김민진

### DIFF
--- a/zinnnn37/202508/23 BOJ 12837 가계부 (Hard).md
+++ b/zinnnn37/202508/23 BOJ 12837 가계부 (Hard).md
@@ -1,0 +1,86 @@
+```java
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class BJ_12837_가계부_Hard {
+
+	private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+	private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	private static final StringBuilder   sb = new StringBuilder();
+	private static       StringTokenizer st;
+
+	private static int N;
+	private static int Q;
+
+	private static long[] tree;
+
+	public static void main(String[] args) throws IOException {
+		init();
+		sol();
+	}
+
+	private static void init() throws IOException {
+		st = new StringTokenizer(br.readLine());
+
+		N = Integer.parseInt(st.nextToken());
+		Q = Integer.parseInt(st.nextToken());
+
+		tree = new long[N * 4];
+	}
+
+	private static void sol() throws IOException {
+		while (Q-- > 0) {
+			st = new StringTokenizer(br.readLine());
+
+			int cmd = Integer.parseInt(st.nextToken());
+			int a   = Integer.parseInt(st.nextToken());
+			int b   = Integer.parseInt(st.nextToken());
+
+			if (cmd == 1) {
+				update(1, 1, N, a, b);
+			} else {
+				bw.write(partialSum(1, 1, N, a, b) + "\n");
+			}
+		}
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+
+	private static void update(int node, int start, int end, int idx, long diff) {
+		// OOB
+		if (idx < start || end < idx) {
+			return;
+		}
+		// update
+		tree[node] += diff;
+
+		// leaf node
+		if (start == end) {
+			return;
+		}
+
+		int mid = (start + end) / 2;
+		update(node * 2, start, mid, idx, diff);
+		update(node * 2 + 1, mid + 1, end, idx, diff);
+	}
+
+	private static long partialSum(int node, int start, int end, int left, int right) {
+		// OOB
+		if (end < left || right < start) {
+			return 0;
+		}
+
+		// in range
+		if (left <= start && end <= right) {
+			return tree[node];
+		}
+
+		int mid = (start + end) / 2;
+
+		return partialSum(node * 2, start, mid, left, right)
+		       + partialSum(node * 2 + 1, mid + 1, end, left, right);
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[가계부 (Hard)](https://www.acmicpc.net/problem/12837)

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
세그먼트 트리를 사용해서 `diff` 값을 적용하고 부분 합을 구하면 되는 문제입니다.
초기화 할 필요도 없음

## 🔍 풀이 방법
세그트리 사용해서 풀면 됩니다

## ⏳ 회고
부분합 구하는 함수 조건문 잘 확인하기
확인하고자 하는 범위가 지금 확인하는 범위랑 같거나 더 커야함
`if (left <= start && end <= right)`
