### PR TITLE
[20250823] BOJ / G4 / 단어 수학 / 이준희

### DIFF
--- a/JHLEE325/202508/23 BOJ G4 단어 수학.md
+++ b/JHLEE325/202508/23 BOJ G4 단어 수학.md
@@ -1,0 +1,37 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+
+        int[] weight = new int[26];
+
+        for (int i = 0; i < N; i++) {
+            String word = br.readLine();
+            int len = word.length();
+            for (int j = 0; j < len; j++) {
+                char c = word.charAt(j);
+                weight[c - 'A'] += Math.pow(10, len - j - 1);
+            }
+        }
+
+        PriorityQueue<Integer> pq = new PriorityQueue<>(Collections.reverseOrder());
+        for (int w : weight) {
+            if (w > 0) pq.add(w);
+        }
+
+        int num = 9;
+        int sum = 0;
+        while (!pq.isEmpty()) {
+            int val = pq.poll();
+            sum += val * num--;
+        }
+
+        System.out.println(sum);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1339

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
ABA
BCD
처럼 수가 단어로 주어졌을 때 
단어 수를 더했을 때 나올 수 있는 값의 최대값을 구하는 문제입니다.

## 🔍 풀이 방법
문자를 받은 후 알파벳 배열에 자릿수를 계산한 후
ex) ABA, BCD 기준 A : 101 / B 110 / C 10 / D 1 처럼 계산
그 자릿수를 우선순위큐 reverse 를 사용하여 큰 것부터 꺼내면서
9,8,7... 을 곱해서 더했습니다.

## ⏳ 회고
우선순위 큐 reverse를 사용하는 문제를 최근에 봤던 것 같은데 그 기억으로 쉽게 풀 수 있었습니다.
