### PR TITLE
[20250825] BOJ / P4 / 가희의 수열놀이 (Large) / 권혁준

### DIFF
--- a/khj20006/202508/25 BOJ P4 가희의 수열놀이 (Large).md
+++ b/khj20006/202508/25 BOJ P4 가희의 수열놀이 (Large).md
@@ -1,0 +1,47 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+
+int Q, MOD;
+vector<int> pos[1000001]{};
+stack<int> st;
+set<int> s;
+
+int main(){
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin>>Q>>MOD;
+	if(MOD > Q) {
+		for(int o,a;Q--;) {
+			cin>>o;
+			if(o == 1) cin>>a;
+			if(o == 3) cout<<"-1\n";
+		}
+		return 0;
+	}
+
+	for(int i=0,o,a;i<Q;i++) {
+		cin>>o;
+		if(o == 1) {
+			cin>>a;
+			a %= MOD;
+			if(!pos[a].empty()) s.erase(pos[a].back());
+			s.insert(st.size());
+			pos[a].push_back(st.size());
+			st.push(a);
+		}
+		else if(o == 2) {
+			if(st.empty()) continue;
+			a = st.top(); st.pop();
+			s.erase(pos[a].back());
+			pos[a].pop_back();
+			if(!pos[a].empty()) s.insert(pos[a].back());
+		}
+		else {
+			if(s.size() != MOD) cout<<"-1\n";
+			else cout<<st.size()-(*s.begin())<<'\n';
+		}
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17163

## 🧭 풀이 시간
180분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
정수 MOD와 빈 수열 A가 주어지며, A에 할 수 있는 세 종류의 작업이 주어진다.
1. A의 맨 뒤에 num을 추가
2. A의 맨 뒤에 있는 원소 제거 (비어있다면 무시)
3. A의 맨 뒤에서 최소 몇 개의 수를 선택해야 이 수들을 MOD로 나눴을 때 나머지가 0부터 MOD-1까지 모두 나타나는지?

## 🔍 풀이 방법
- 스택
- TreeSet
---
어차피 MOD가 작업 횟수보다 크면 답은 항상 -1만 나온다. -> MOD <= Q인 경우만 고려함

0부터 MOD-1까지 스택을 MOD개 만들어놓고 각 스택에는 해당 수가 나온 A에서의 인덱스를 저장해둔다.
이 때 3번 작업에 대한 답은, 만약 0부터 MOD-1까지 안 나온 수가 있다면 -1이고 그렇지 않다면 0부터 MOD-1까지의 스택에서 가장 큰 인덱스 중 최솟값 v에 대해, (현재까지 나온 수의 개수) - v가 답이 된다.

이걸 빨리 구하려고, TreeSet으로 최신 인덱스들만 담아놓도록 구현했다.

## ⏳ 회고
최근 본 문제들 중에 제일 싫었던 문제임
채점 순서도 랜덤이라 몇 퍼에서 틀렸는지가 의미없고,
스택 쓰니까 메모리 초과인데 vector쓰면 맞음.
C++로 짜니까 맞는데 Java로 짜니까 틀림.