### PR TITLE
[20250826] BOJ / G1 / 난민 / 한종욱

### DIFF
--- a/Ukj0ng/202508/26 BOJ G1 난민.md
+++ b/Ukj0ng/202508/26 BOJ G1 난민.md
@@ -1,0 +1,66 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static PriorityQueue<int[]> upperQueue;
+    private static PriorityQueue<int[]> lowerQueue;
+    private static int N, median;
+    private static long sum;
+    public static void main(String[] args) throws IOException {
+        init();
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+        long upperVal = 0;
+        long lowerVal = 0;
+        median = 0;
+        sum = 0;
+        long xSum = 0;
+
+        upperQueue = new PriorityQueue<>((o1, o2) -> Integer.compare(o1[1], o2[1]));
+        lowerQueue = new PriorityQueue<>((o1, o2) -> Integer.compare(o2[1], o1[1]));
+
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int x = Integer.parseInt(st.nextToken());
+            int y = Integer.parseInt(st.nextToken());
+
+            lowerQueue.add(new int[]{x, y});
+            lowerVal += y;
+            xSum += Math.abs(x);
+
+            if (upperQueue.size() + 1 == lowerQueue.size()) {
+                if (!upperQueue.isEmpty() && upperQueue.peek()[1] < lowerQueue.peek()[1]) {
+                    upperVal += (lowerQueue.peek()[1] - upperQueue.peek()[1]);
+                    lowerVal += (upperQueue.peek()[1] - lowerQueue.peek()[1]);
+                    swap();
+                }
+            } else if (upperQueue.size() + 2 == lowerQueue.size()) {
+                upperVal += lowerQueue.peek()[1];
+                lowerVal -=  lowerQueue.peek()[1];
+                upperQueue.add(lowerQueue.poll());
+            }
+
+            median = lowerQueue.peek()[1];
+            long ySum = ((long)median * lowerQueue.size() - lowerVal + upperVal - (long)median * upperQueue.size());
+            long totalSum = xSum + ySum;
+            bw.write(median + " " + totalSum + "\n");
+        }
+    }
+
+    private static void swap() {
+        int[] temp = lowerQueue.poll();
+        lowerQueue.add(upperQueue.poll());
+        upperQueue.add(temp);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/23090

## 🧭 풀이 시간
210분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
설명 적기 힘들다. 문제 읽자.

## 🔍 풀이 방법
이 문제는 두 가지 과정을 거쳐야 한다. 

1. 강 위에 있는 점 중 각 점들과의 거리의 합이 최소값이 되는 점을 찾기
2. 해당 점을 기준으로 각 점들과의 총 거리 구하기

처음엔 y값의 값들을 평균으로 최소값을 구했다. 근데 맨해튼 거리에선 그게 아니라 중앙값이 최소라고 한다. 
수학적인 설명은 읽어봤지만, 간단하게 설명하면 1차원 위에 [1, 3, 5, 7, 9]의 점들이 있다고 하자. 어떤 위치 x에서 거리 합은 $∣1−x∣+∣3−x∣+∣5−x∣+∣7−x∣+∣9−x∣$ 이다. x가 오른쪽으로 이동하면 왼쪽 점의 개수만큼 거리가 증가하고 오른쪽 점의 개수만큼 거리가 감소한다. 반대로 x가 왼쪽으로 이동하면 오른쪽 점의 개수만큼 거리가 증가하고 왼쪽 점의 개수만큼 거리가 감소한다. 
따라서, 왼쪽 점 개수 = 오른쪽 점 개수가 되어야 각 거리 합이 최소가 된다. 

그래서 중앙값을 구해야 하고, 이 중앙값은 maxHeap, minHeap으로 쉽게 구할 수 있다. 

다음은 각 점들과의 총 거리를 구하는 방식이다. 
내가 처음 시도한 방식은 중앙값이 변활 때 기존 점들의 거리 변화량을 계산해 구하려고 했다. 하지만, 내 풀이 방식 상 새로운 점이 들어왔을 때, 이동한 점이 기존 점인지 새로운 점인지에 따라 계산이 달라지고, `swap()`까지 일어나면 그 점들을 계속 추적해야 해 복잡했다. 

따라서, x값은 누적으로 구하고 `upperQueue`와 `lowerQueue`의 합을 계산해 `upperVal`와 `lowerVal`를 따로 구한다. `long ySum = (median * lowerQueue.size() - lowerVal + upperVal - median * upperQueue.size())`로 y거리 합을 계산한다. 

## ⏳ 회고
간단한 게 풀려고 시도해야 한다. 그리고 기존 점들의 거리 변화량에 따라 값을 구하려고 했지만, 뭔가 실질적으로 변화하는 값을 정의하기가 어려웠다. 문제를 풀 때, 내가 계산하고자 하는 값을 구체적으로 설명할 수 있는 풀이를 해야겠다. **그리고 꼭 int의 오버플로우를 확인하자. 꼭**