### PR TITLE
[20250826] BOJ / G1 / 동전 뒤집기 / 김민진

### DIFF
--- a/zinnnn37/202508/26 BOJ G1 동전 뒤집기.md
+++ b/zinnnn37/202508/26 BOJ G1 동전 뒤집기.md
@@ -1,0 +1,69 @@
+```java
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+public class BJ_1285_동전_뒤집기 {
+
+    private static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+    private static int N;
+    private static int ans;
+    private static int[] coins;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+        ans = Integer.MAX_VALUE;
+
+        coins = new int[N];
+        for (int i = 0; i < N; i++) {
+            String s = br.readLine();
+            for (int j = 0; j < N; j++) {
+                if (s.charAt(j) == 'T') {
+                    coins[i] += (1 << j);
+                }
+            }
+        }
+    }
+
+    private static void sol() throws IOException {
+        // 행 뒤집기
+        for (int rowFillped = 0; rowFillped < (1 << N); rowFillped++) {
+            // 뒷면
+            int totalTails = 0;
+
+            for (int row = 0; row < N; row++) {
+                // 0일 때 뒤집지 않고(0), 1일 때 뒤집을 때(1) 0이 되어야 해서 XOR 연산
+                int tailsInCol = Integer.bitCount(coins[row] ^ rowFillped);
+                totalTails += Math.min(tailsInCol, N - tailsInCol);
+            }
+            ans = Math.min(ans, totalTails);
+        }
+
+        bw.write(ans + "");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static int countTails(boolean[][] arr) {
+        int cnt = 0;
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                if (arr[i][j]) {
+                    cnt++;
+                }
+            }
+        }
+        return cnt;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[동전 뒤집기](https://www.acmicpc.net/problem/1285)

## 🧭 풀이 시간
120분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
동전 뒷면이 가장 적게 나오도록 뒤집었을 때, 뒷면인 동전의 수 구하기

## 🔍 풀이 방법
비트마스킹으로 풀었습니다.
`coins`의 인덱스가 하나의 행을 의미하고, 비트 마스킹을 사용해서 뒤집히는 경우의 수를 계산했습니다.
처음에는 행과 열을 모두 일일이 고려하는 코드를 작성했는데, 시간이 너무 오래 걸려서 보니까 다른 사람들은 열만 고려하더라고요~..
코드에 주석이랑 변수 좀 잘못 적힌 게 많은데 그건 무시하시고,,....,.

```java
        // 뒤집는 경우의 수(열)
        for (int colFlipped = 0; colFlipped < (1 << N); colFlipped++) {
            // 뒷면
            int totalTails = 0;

            for (int row = 0; row < N; row++) {
                // 0일 때 뒤집지 않고(0), 1일 때 뒤집을 때(1) 0이 되어야 해서 XOR 연산
                // 여기서 열 뒤집기
                int tailsInRow = Integer.bitCount(coins[row] ^ colFlipped);

                // 행은 직접적으로 뒤집지 않고 뒷면의 개수를 비교해서 확인
                totalTails += Math.min(tailsInRow, N - tailsInRow);
            }
            ans = Math.min(ans, totalTails);
        }
```

열은 완탐하고 행은 그리디로 찾는 방법입니다.. 어려워

## ⏳ 회고
🙂🙃🙂🙃