### PR TITLE
[20250826] BOJ / P5 / 문제 수 줄이기 / 권혁준

### DIFF
--- a/khj20006/202508/26 BOJ P5 문제 수 줄이기.md
+++ b/khj20006/202508/26 BOJ P5 문제 수 줄이기.md
@@ -1,0 +1,94 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+	BufferedReader br;
+	BufferedWriter bw;
+	StringTokenizer st;
+
+	public IOController() {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		st = new StringTokenizer("");
+	}
+
+	String nextLine() throws Exception {
+		String line = br.readLine();
+		st = new StringTokenizer(line);
+		return line;
+	}
+
+	String nextToken() throws Exception {
+		while (!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+
+	int nextInt() throws Exception {
+		return Integer.parseInt(nextToken());
+	}
+
+	long nextLong() throws Exception {
+		return Long.parseLong(nextToken());
+	}
+
+	double nextDouble() throws Exception {
+		return Double.parseDouble(nextToken());
+	}
+
+	void close() throws Exception {
+		bw.flush();
+		bw.close();
+	}
+
+	void write(String content) throws Exception {
+		bw.write(content);
+	}
+
+}
+
+public class Main {
+
+	static IOController io;
+
+	//
+
+	static int N;
+	static int[] a;
+	static long[][] dp;
+
+	public static void main(String[] args) throws Exception {
+
+		io = new IOController();
+
+		N = io.nextInt();
+		a = new int[N+1];
+		for(int i=1;i<=N;i++) a[i] = io.nextInt();
+
+		dp = new long[N+1][4];
+		dp[1][0] = a[1];
+		for(int j=1;j<4;j++) dp[1][j] = -(long)1e18;
+
+		for(int i=2;i<=N;i++) {
+			long xor = 0;
+			for(int j=0;j<4;j++) {
+				if(i-j-1 < 0) {
+					dp[i][j] = -(long)1e18;
+					continue;
+				}
+				xor ^= a[i-j];
+				long max = -(long)1e18;
+				for(int k=0;k<4;k++) if(k != j) max = Math.max(max, dp[i-j-1][k]);
+				dp[i][j] = max + xor;
+			}
+		}
+		long max = 0;
+		for(int j=0;j<4;j++) max = Math.max(max, dp[N][j]);
+		io.write(max + "\n");
+
+		io.close();
+
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/29200

## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N개의 문제가 있고, 각 문제의 레벨은 A[i]
문제들을 한 개 이상의 연속된 구간으로 분할
-> 각 구간을 하나의 새로운 문제로 대체. 새 레벨은 기존 문제들 레벨을 XOR한 값
(인접한 두 구간의 문제 수가 달라야 함)

새 문제들의 레벨 합을 최대로 해보자.

## 🔍 풀이 방법
- DP
---
두 수를 XOR한 값은 반드시 두 수의 합 이하가 된다.
-> 구간의 길이가 길면 손해임.

그래서 구간 길이를 최대 4로 두고 2차원 DP(N*4)를 돌려줬다.

## ⏳ 회고
구간 길이를 최대 2로 둬도 될 줄 알고 냈는데 틀리길래 하나씩 늘려보다가 4로 하니까 맞았다.
왜 맞는지 고민해봐야할듯