### PR TITLE
[20250826] BOJ / G5 / 1, 2, 3 더하기 4 / 이인희

### DIFF
--- a/LiiNi-coder/202508/26 BOJ 1, 2, 3 더하기 4.md
+++ b/LiiNi-coder/202508/26 BOJ 1, 2, 3 더하기 4.md
@@ -1,0 +1,55 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main {
+	private static BufferedReader br;
+	private static int t;
+	private static int n;
+	private static int[][] dp;
+
+	public static void main(String[] args) throws IOException {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		t = Integer.parseInt(br.readLine());
+		int maxN = 10000;
+		dp = new int[4][maxN + 1];
+		dp[1][1] = 1; //1
+		dp[1][2] = 1; //1+1
+		dp[2][2] = 1; //2
+		dp[1][3] = 1; //1+1+1
+		dp[2][3] = 1; //2+1
+		dp[3][3] = 1; //3
+
+		for (int i = 1; i <= 3; i++) {
+			for (int j = 1; j <= maxN; j++) {
+				dp[0][j] += dp[i][j];
+			}
+		}
+
+		for (int i = 4; i <= maxN; i++) {
+			//맨 앞 항이 1 -> 1 + (나머지를 1,2,3으로 만듦)
+			dp[1][i] = dp[0][i - 1];
+
+			// 맨 앞 항이 2 -> 2 + (나머지를 2,3으로 만듦)
+			dp[2][i] = dp[2][i - 2] + dp[3][i - 2];
+			if (i == 2) dp[2][i] = 1;
+
+			// 맨 앞 항이 3 -> 3 + (나머지를 3으로 만듦)
+			dp[3][i] = dp[3][i - 3];
+			if (i == 3) dp[3][i] = 1;
+
+			dp[0][i] = dp[1][i] + dp[2][i] + dp[3][i];
+		}
+
+		StringBuilder sb = new StringBuilder();
+		for(int tt = 0; tt<t; tt++) {
+			n = Integer.parseInt(br.readLine());
+			sb.append(dp[0][n]).append("\n");
+		}
+		System.out.print(sb);
+        
+        br.close();
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/15989
## 🧭 풀이 시간
40 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 어떤 수를 1, 2, 3의 합으로 나타내는 방법. 단, 합을 이루고 잇는 수의 순서만 다른것은 같은것으로 친다
## 🔍 풀이 방법
- DP인데 이렇게 2차원 dp를 구현함
```
dp[0][n] 은 n이 결과인 것의 경우개수이고, dp[i:1...4][n]은 그 덧셈 경우의 수가 2+1+1과 같이 내림차순으로 항이 구성된다할때, 맨 앞 항의 숫자를 가질때의 경우의 수야. 예를 들어. dp[1][3]은 3을 완성하는 경우의 수중 맨 앞의 항이 1니까, 1+1+1 밖에없어서 1이야. 그리고 dp[2][3]은 2+1 이라 1이야. dp[3][3]은 3이라 1이야. 이 모두를 더한것이 dp[0][3] = 3인거지. 이렇게 해서 만약 n이 5일땐 맨 앞의 항이 3일땐 dp[0][2]이고, 앞의 항이 2일땐 dp[2][3] 로 하여서 dp[0][3]으로 하였을땐 2+3 과같은 내림차순을 만족하지 않는 경우를 미리 쳐내도록 하는거야. 마찬가지로 맨 앞의 항이 1일땐 dp[1][4] 를 두어서 계산하였어. 그래서 dp[0...4][5] 를 이렇게 계산해내는 거지.
```
- 그런데 이렇게 하니까 틀렸다.
## ⏳ 회고
- DP인건 알았지만 점화식을 어떻게 세울까에서 고민을 많이 하였음. 그런데도 틀렸다... DP 점화식을 세우는 연습을 많이 해야겠다