### PR TITLE
[20250827] BOJ / G1 / 구간 합 구하기 / 이준희

### DIFF
--- a/JHLEE325/202508/27 BOJ G1 구간 합 구하기.md
+++ b/JHLEE325/202508/27 BOJ G1 구간 합 구하기.md
@@ -1,0 +1,85 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        StringBuilder sb = new StringBuilder();
+
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+
+        long[] arr = new long[n];
+        long[] tree = new long[4*n];
+
+        for(int i=0;i<n;i++){
+            arr[i] = Long.parseLong(br.readLine());
+        }
+
+        init(arr,tree,1,0,n-1);
+
+        for(int i=0;i<m+k;i++){
+            st = new StringTokenizer(br.readLine());
+            int op = Integer.parseInt(st.nextToken());
+
+            if(op==1){
+                int a = Integer.parseInt(st.nextToken());
+                long b = Long.parseLong(st.nextToken());
+                update(arr, tree, 1, 0, n-1, a-1,b);
+            }
+            else{
+                int a = Integer.parseInt(st.nextToken());
+                int b = Integer.parseInt(st.nextToken());
+
+                long sum = query(tree,1,0,n-1,a-1,b-1);
+
+                sb.append(sum+"\n");
+            }
+        }
+
+        System.out.println(sb.toString());
+    }
+
+    static void init(long[] arr, long[] tree, int node, int start, int end){
+        if(start == end){
+            tree[node]=arr[start];
+        }
+        else{
+            init(arr,tree,node*2,start,(start+end)/2);
+            init(arr,tree,node*2+1,(start+end)/2+1,end);
+            tree[node]=tree[node*2]+tree[node*2+1];
+        }
+    }
+
+    static long query(long[] tree, int node, int start, int end, int left, int right) {
+        if (left > end || right < start) {
+            return 0;
+        }
+        if (left <= start && end <= right) {
+            return tree[node];
+        }
+        long lsum = query(tree, node*2, start, (start+end)/2, left, right);
+        long rsum = query(tree, node*2+1, (start+end)/2+1, end, left, right);
+        return lsum+rsum;
+    }
+
+    static void update(long[] arr, long[] tree, int node, int start, int end, int index, long val) {
+        if (index < start || index > end) {
+            return;
+        }
+        if (start == end) {
+            arr[index] = val;
+            tree[node] = val;
+            return;
+        }
+        update(arr, tree,node*2, start, (start+end)/2, index, val);
+        update(arr, tree,node*2+1, (start+end)/2+1, end, index, val);
+        tree[node] = tree[node*2] + tree[node*2+1];
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2042

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
배열이 주어졌을 때
특정 부분의 원소를 바꿔가며 구간합을 구하는 문제입니다.

## 🔍 풀이 방법
세그먼트 트리를 구현하여 풀었습니다.
어제 풀었던 문제에서 각 노드가 최대, 최소값을 저장하였다면
이 문제에서는 노드마다 자식노드들의 합을 계산하여 저장했습니다.

## ⏳ 회고
세그먼트 트리 2일차였습니다.
어제는 update는 사용하지 않는 문제였지만 이번 문제는 update를 해야하는 문제였습니다.
슬슬 외워가고 있는 것 같습니다.
