### PR TITLE
[20250827] BOJ / P5 / 도로포장 / 이강현

### DIFF
--- a/lkhyun/202508/27 BOJ P5 도로포장.md
+++ b/lkhyun/202508/27 BOJ P5 도로포장.md
@@ -1,0 +1,88 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main{
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static StringBuilder sb = new StringBuilder();
+    static int N,M,K;
+    static class Edge{
+        int to,cost;
+
+        Edge(int to, int cost){
+            this.to = to;
+            this.cost = cost;
+        }
+    }
+    static class State{
+        int to,k;
+        long cost;
+        State(int to, int k, long cost){
+            this.to = to;
+            this.k = k;
+            this.cost = cost;
+        }
+    }
+    static List<Edge>[] adjList;
+    
+    public static void main(String[] args) throws Exception {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        adjList = new ArrayList[N+1];
+
+        for (int i = 1; i <= N; i++) {
+            adjList[i] = new ArrayList<>();
+        }
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+            int cost = Integer.parseInt(st.nextToken());
+            adjList[from].add(new Edge(to, cost));
+            adjList[to].add(new Edge(from, cost));
+        }
+        long[][] dist = dijkstra();
+        long ans = Long.MAX_VALUE;
+        for (int i = 0; i <= K; i++) {
+            ans = Math.min(ans, dist[N][i]);
+        }
+        bw.write(ans+"");
+        bw.close();
+    }
+    public static long[][] dijkstra(){
+        PriorityQueue<State> pq = new PriorityQueue<>((a,b) -> Long.compare(a.cost,b.cost));
+        long[][] dist = new long[N+1][K+1];
+        for (int i = 1; i <= N; i++) {
+            Arrays.fill(dist[i],Long.MAX_VALUE);
+        }
+        pq.offer(new State(1,0,0));
+        dist[1][0] = 0;
+
+        while(!pq.isEmpty()){
+            State cur = pq.poll();
+
+            if(dist[cur.to][cur.k] < cur.cost) continue;
+            
+            for(Edge e : adjList[cur.to]){
+                long notUsedCost = cur.cost + e.cost;
+                long usedCost = cur.cost;
+
+                if(notUsedCost < dist[e.to][cur.k]){
+                    dist[e.to][cur.k] = notUsedCost;
+                    pq.offer(new State(e.to, cur.k, notUsedCost));
+                }
+
+                if(cur.k < K && usedCost < dist[e.to][cur.k + 1]){
+                    dist[e.to][cur.k + 1] = usedCost;
+                    pq.offer(new State(e.to, cur.k + 1, usedCost));
+                }
+            }
+        }
+        return dist;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1162
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
1에서 N까지 가는데 도로 포장을 하면 비용이 0이됨.
K개만큼 도로 포장 가능. 최소 비용 출력
## 🔍 풀이 방법
다익스트라
dist[목적지][사용한 도로포장 개수]로 정의하고 다익스트라 적용
## ⏳ 회고
그냥 dist 하나 정보 추가된건데 플레5는 좀 아닌거 같긴해. 