### PR TITLE
[20250827] PGM / LV2 / 연속된 부분 수열의 합 / 김수연

### DIFF
--- a/suyeun84/202508/27 PGM LV2 연속된 부분 수열의 합.md
+++ b/suyeun84/202508/27 PGM LV2 연속된 부분 수열의 합.md
@@ -1,0 +1,33 @@
+```java
+import java.util.*;
+class Solution {
+    public int[] solution(int[] sequence, int k) {
+        List<int[]> list = new ArrayList<>();
+        int start = 0, end = 0, sum = sequence[0];
+        while (start < sequence.length && end < sequence.length) {
+            if (sum == k) {
+                list.add(new int[] {start, end});
+            }
+            if (sum <= k) {
+                end++;
+                if (end < sequence.length)
+                    sum += sequence[end];
+            } else {
+                if (start < sequence.length)
+                    sum -= sequence[start];
+                start++;
+            }
+        }
+        Collections.sort(list, new Comparator<int[]>() {
+            @Override
+            public int compare(int[] o1, int[] o2) {
+                int len1 = o1[1] - o1[0];
+                int len2 = o2[1] - o2[0];
+                return len1 - len2;
+            }
+        });
+        int[] answer = {list.get(0)[0], list.get(0)[1]};
+        return answer;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/178870
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
기존 수열에서 임의의 두 인덱스의 원소와 그 사이의 원소를 모두 포함하는 부분 수열이며 합이 k인 부분 수열 중,
길이가 가장 짧은 수열의 시작과 마지막 인덱스 구하
## 🔍 풀이 방법
이분 탐색 사용
k랑 같으면 list에 추가하고,
작거나 같으면 end 인덱스를 하나 높이고,
크면 start 인덱스를 하나 높임
이후, 길이가 짧은 순서로 정렬해서 답 구함
## ⏳ 회고
으릅다..