### PR TITLE
[20250827] BOJ / G3 / 마라톤 2 / 이종환

### DIFF
--- a/0224LJH/202508/27 BOJ 마라톤 2.md
+++ b/0224LJH/202508/27 BOJ 마라톤 2.md
@@ -1,0 +1,84 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.StringTokenizer;
+
+
+public class Main {
+	
+	static int checkCnt, skipMaxCnt,ans;
+	static int[][] dp; //dp[i][j] skip j번하고 i번째 체크포인트에 도달했을 때의 최댓값
+	static int[] y;
+	static int[] x;
+	
+	public static void main(String[] args) throws IOException {
+		init();
+		process();
+		print();
+	}
+	
+	public static void init() throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		checkCnt = Integer.parseInt(st.nextToken());
+		skipMaxCnt = Integer.parseInt(st.nextToken());
+		dp = new int[checkCnt][skipMaxCnt+1];
+		y = new int[checkCnt];
+		x = new int[checkCnt];
+		
+		for (int i = 0; i < checkCnt; i++) {
+			st = new StringTokenizer(br.readLine());
+			y[i] = Integer.parseInt(st.nextToken());
+			x[i] = Integer.parseInt(st.nextToken());
+			
+			Arrays.fill( dp[i], Integer.MAX_VALUE/2);
+		}
+		
+		
+		dp[0][0] = 0;
+		ans = Integer.MAX_VALUE/2;
+	}
+	
+	public static void process() throws IOException {
+		for (int i = 0; i < checkCnt; i++) {
+			int curY = y[i];
+			int curX = x[i];
+			for (int j = 0; j <=skipMaxCnt; j++) { // 이전에 스킵했던 횟수
+				for (int k = 0; k <= skipMaxCnt; k++) { // 이번에 스킵하려는 횟수
+					int nIdx = i+1+k;
+					int nSkipCnt = j + k;
+					
+					if (nIdx >= checkCnt || nSkipCnt > skipMaxCnt) break;
+					
+					int nY = y[nIdx];
+					int nX = x[nIdx];
+					int plus = Math.abs(curX- nX) + Math.abs(curY - nY);
+					
+					dp[nIdx][nSkipCnt] = Math.min(dp[nIdx][nSkipCnt], dp[i][j] + plus);
+				}
+
+				
+
+			}
+		}
+		
+		for (int i = 0; i <= skipMaxCnt; i++) {
+			
+			ans = Math.min(dp[checkCnt-1][i], ans);
+		}
+
+	}
+
+	
+
+	public static void print() {
+		System.out.println(ans);
+	}
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/10653

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
첫 번째 줄에 체크포인트의 수 N과 건너뛸 체크포인트의 수 K가 주어진다.

이후 N개의 줄에 정수가 두개씩 주어진다. i번째 줄의 첫 번째 정수는 체크포인트 i의 x 좌표, 두 번째 정수는 y 좌표이다. (-1000 <= x <= 1000, -1000 <= y <= 1000)

체크 포인트의 좌표는 겹칠 수도 있다 - 젖소 박승원이 한 체크포인트를 건너뛸 때는 그 번호의 체크포인트만 건너뛰며, 그 점에 있는 모든 체크포인트를 건너뛰지 않는다.

체크포인트 K 개를 건너뛰고 달릴 수 있는 최소 거리를 출력하라.

## 🔍 풀이 방법
전형적인 dp 문제이다. dp[i][j] 에 j번 스킵을 하였을 때 i번째 노드에 도달 시 필요한 최소 거리를 기록하면 된다.


## ⏳ 회고
이제 dp문제는 그래도 괜찮은?것같다.