### PR TITLE
[20250828] BOJ / G4 / 이모티콘 / 이준희

### DIFF
--- a/JHLEE325/202508/28 BOJ G4 이모티콘.md
+++ b/JHLEE325/202508/28 BOJ G4 이모티콘.md
@@ -1,0 +1,61 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static class State {
+        int cur, clip;
+
+        State(int cur, int clip) {
+            this.cur = cur;
+            this.clip = clip;
+        }
+    }
+
+    static int s;
+    static int range = 2000;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        s = Integer.parseInt(br.readLine());
+        System.out.println(bfs());
+    }
+
+    static int bfs() {
+        int[][] dist = new int[range + 1][range + 1];
+        for (int i = 0; i <= range; i++) Arrays.fill(dist[i], -1);
+
+        ArrayDeque<State> q = new ArrayDeque<>();
+        q.add(new State(1, 0));
+        dist[1][0] = 0;
+
+        while (!q.isEmpty()) {
+            State now = q.poll();
+            int cur = now.cur;
+            int clip = now.clip;
+            int t = dist[cur][clip];
+
+            if (cur == s)
+                return t;
+
+            if (dist[cur][cur] == -1) {
+                dist[cur][cur] = t + 1;
+                q.add(new State(cur, cur));
+            }
+
+            if (clip > 0 && cur + clip <= range && dist[cur + clip][clip] == -1) {
+                dist[cur + clip][clip] = t + 1;
+                q.add(new State(cur + clip, clip));
+            }
+
+            if (cur > 0 && dist[cur - 1][clip] == -1) {
+                dist[cur - 1][clip] = t + 1;
+                q.add(new State(cur - 1, clip));
+            }
+        }
+        return -1;
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14226

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
이모티콘 입력 프로세스가
1. 화면의 이모티콘을 전체 복사해서 클립보드에 저장
2. 클립보드에 있는 이모티콘을 화면에 붙여넣기
3. 화면에 있는 이모티콘 1개 삭제
위 3가지가 있고 각각 1초가 걸릴 때

처음 1개의 이모티콘이 있는 상태에서 S개를 만들 수 있는 최소 시간을 구하는 문제입니다

## 🔍 풀이 방법
bfs를 이용하여 각 단계마다 3개 프로세스를 수행한 것을 다시 큐에 넣어서
다시 bfs를 하는 식으로 구현하였습니다.

S가 작기 때문에 처음에는 방문처리를 따로 하지 않는 방식으로 구현하였는데 메모리 초과가 났습니다.
그래서 방문배열을 사용해야 했는데, 각 단계마다 현재 화면의 이모티콘 개수와 클립보드에 저장되어있는 이모티콘 개수를 모두 관리해야하기 때문에 2차원 방문배열 [이모티콘 수, 클립보드] 를 사용하였습니다.

## ⏳ 회고
방문배열을 구성하는 방식이 특이해서 조금 걸렸던 것 같습니다
