### PR TITLE
[20250828] BOJ / G5 / 탑 / 이인희

### DIFF
--- a/LiiNi-coder/202508/28 BOJ 탑.md
+++ b/LiiNi-coder/202508/28 BOJ 탑.md
@@ -1,0 +1,49 @@
+```java
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Stack;
+import java.util.StringTokenizer;
+
+public class Main{
+    private static BufferedReader Br;
+    private static int N;
+    private static int[] Arr;
+    private static final int MAX = 100_000_001;
+    private static BufferedWriter Bw;
+    private static StringBuilder Sb;
+
+    public static void main(String[] args) throws IOException {
+        Br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(Br.readLine());
+        Bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        Sb = new StringBuilder();
+        Arr = new int[N + 1];
+        StringTokenizer st = new StringTokenizer(Br.readLine());
+        for(int i = 0; i < N; i++){
+            Arr[i+1] = Integer.parseInt(st.nextToken());
+        }
+
+        Stack<int[]> stack = new Stack<>();
+        stack.add(new int[]{MAX, 0});
+        for (int i = 1; i <= N; i++) {
+            while (!stack.isEmpty() && stack.peek()[0] < Arr[i]) {
+                stack.pop();
+            }
+            // stack.peek()[1] == 0 이면, 수신할 탑 없음
+            p(stack.peek()[1]);
+            stack.add(new int[]{Arr[i], i});
+        }
+        Bw.write(Sb.toString() + "\n");
+        Bw.flush();
+        Bw.close();
+        Br.close();
+    }
+
+    private static void p(int i){
+        Sb.append(i + " ");
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2493
## 🧭 풀이 시간
80 분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
- 크기가 다른 탑들이 일직선상에 1칸씩 떨어져 나열되어있을때, 각 탑의 꼭대기에서 왼쪽으로 음파를 날려, 해당 음파가 도달하는 탑의 x좌표를 순서대로 쭈욱 출력하는 문제
## 🔍 풀이 방법
- 스택
## ⏳ 회고
- 정말 스택문제인지 꿈에도 모르고 삽질하다가 60분 지나고 그냥 알고리즘 분류를 봐서 스택인지 처음 안 문제. 이런 문제도 스택일수있구나...
- `이전의 이전꺼... 이렇게 계속 보는거`는 스택문제로 의심하자!