### PR TITLE
[20250829] BOJ / G1 / 공평하게 팀 나누기 / 이준희

### DIFF
--- a/JHLEE325/202508/29 BOJ G1 공평하게 팀 나누기.md
+++ b/JHLEE325/202508/29 BOJ G1 공평하게 팀 나누기.md
@@ -1,0 +1,54 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+        int[] arr = new int[n];
+        int weight_sum = 0;
+
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(br.readLine());
+            weight_sum += arr[i];
+        }
+
+        int member = n / 2;
+
+        boolean[][] weight = new boolean[member + 1][weight_sum + 1];
+
+        weight[0][0] = true;
+
+        for (int w : arr) {
+            for (int i = member; i >= 1; i--) {
+                for (int ws = weight_sum; ws >= 0; ws--) {
+                    if (weight[i - 1][ws])
+                        weight[i][ws + w] = true;
+                }
+            }
+        }
+
+        int big = 0, small = 0;
+        int difference = 987654321;
+
+        for (int i = 0; i <= weight_sum; i++) {
+            if (weight[member][i]) {
+                int difftemp = Math.abs(weight_sum - (i * 2));
+                if (difftemp < difference) {
+                    difference = difftemp;
+                    big = Math.max(weight_sum - i, i);
+                    small = Math.min(weight_sum - i, i);
+                }
+            }
+        }
+
+        System.out.println(small + " " + big);
+
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/4384

## 🧭 풀이 시간
70분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
학생의 수와 각 학생의 몸무게가 주어졌을 때
두 팀의 인원수 차이가 1 이하이면서, 두 팀간의 몸무게합의 차이가 최소화되도록 하는 경우의 두 팀의 무게를 작은 순으로 출력하는 문제입니다.

## 🔍 풀이 방법
boolean dp를 이용하여 풀었습니다.
해당 인원수로 만들 수 있는 무게를 체크한 후
팀 인원수는 무조건 n/2이기 때문에
dp[n/2][weight] 인 weight를 모두 체크하여 몸무게 차이를 계산했습니다.

## ⏳ 회고
처음에 dp문제라는 것은 알고 접근하려고 했는데 어떤 식으로 접근해야할 지 감이 안잡혀서 힌트를 얻어서 풀었습니다.
dp는 담아가면서 합을 계산하는 것만 풀어봐서 이런 유형은 처음이었는데 숙지해놔야 할 것 같습니다.
