### PR TITLE
[20250829] BOJ / G1 / 공평하게 팀 나누기 / 한종욱

### DIFF
--- a/Ukj0ng/202508/29 BOJ G1 공평하게 팀 나누기.md
+++ b/Ukj0ng/202508/29 BOJ G1 공평하게 팀 나누기.md
@@ -1,0 +1,73 @@
+```
+import java.io.*;
+import java.util.HashSet;
+import java.util.Set;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static Set<Integer>[] dp;
+    private static int[] weight;
+    private static int N, sum, max;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        DP();
+
+        int answer = 0;
+
+        for (int val : dp[dp.length-1]) {
+            answer = Math.max(val, answer);
+        }
+
+        if (N%2 == 1) {
+            for (int val : dp[dp.length-2]) {
+                answer = Math.max(val, answer);
+            }
+        }
+
+        bw.write(answer + " " + (sum - answer) + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+        sum = 0;
+        max = 0;
+
+        int length = N/2;
+        if (N%2 == 1) length++;
+        weight = new int[N];
+        dp = new Set[length + 1];
+        for (int i = 0; i < dp.length; i++) {
+            dp[i] = new HashSet<>();
+        }
+
+        dp[0].add(0);
+
+        for (int i = 0; i < N; i++) {
+            weight[i] = Integer.parseInt(br.readLine());
+            sum += weight[i];
+        }
+
+        max = sum / 2;
+    }
+
+    private static void DP() {
+        for (int i = 0; i < N; i++) {
+            for (int j = dp.length-1; j > 0; j--) {
+                if (!dp[j-1].isEmpty()) {
+                    for (int val : dp[j-1]) {
+                        int result = val + weight[i];
+                        if (result <= max) {
+                            dp[j].add(result);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/4384

## 🧭 풀이 시간
70분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N명이 있는데 인원 차이는 1명차이나 0명차이에 각 그룹의 합의 차가 최소가 되는 방법

## 🔍 풀이 방법
Set dp를 사용했다. [모든 몸무게의 합/2]보다 같거나 작은 몸무게만 dp에 담으며, 중복이 되면 안되므로 역순으로 계산했다.
작은 몸무게가 dp[dp.length-1]에 있거나 N이 홀수일 경우 dp[dp.length-2]에 있을 수도 있어서 둘 다 체크했다.

## ⏳ 회고
준희는 boolean dp로 풀었고 그게 정석풀이 같다. 더 빠르고 더 효율적이다. 그 방법으로 주말에 풀어봐야겠다. 하지만, dp의 상태를 정의해 접근해서 뿌듯하다.