### PR TITLE
[20250829] BOJ / G5 / 생일선물 / 이강현

### DIFF
--- a/lkhyun/202508/29 BOJ G5 생일선물.md
+++ b/lkhyun/202508/29 BOJ G5 생일선물.md
@@ -1,0 +1,45 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N,D;
+    static class present{
+        int price,value;
+
+        present(int price, int value){
+            this.price = price;
+            this.value = value;
+        }
+    }
+    static present[] arr;
+
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        D = Integer.parseInt(st.nextToken());
+        arr = new present[N];
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            arr[i] = new present(Integer.parseInt(st.nextToken()),Integer.parseInt(st.nextToken()));
+        }
+        Arrays.sort(arr,(a,b) -> Integer.compare(a.price,b.price));
+        long cur = 0,max = 0;
+        int left = 0,right = 0;
+        while(right < N){
+            if(arr[right].price - arr[left].price < D){
+                cur += arr[right++].value;
+                max = Math.max(max,cur);
+            }else{
+                cur -= arr[left++].value;
+            }
+        }
+        bw.write(max+"");
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/12892
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
가격 차이가 D만큼 나지 않도록 하는 선물 만족도의 합을 구하는 문제
## 🔍 풀이 방법
투 포인터, 슬라이딩 윈도우
포인터 두개 두고 같은 방향으로 밀면서 합을 관리.
## ⏳ 회고
진짜 쉬운 문젠데 괜히 큰 숫자를 보고 이분 탐색에 꽂혀가지고 이상하게 생각했다.