### PR TITLE
[20250829] BOJ / P5 / 바리스타의 힘 / 권혁준

### DIFF
--- a/khj20006/202508/29 BOJ P5 바리스타의 힘.md
+++ b/khj20006/202508/29 BOJ P5 바리스타의 힘.md
@@ -1,0 +1,135 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+	BufferedReader br;
+	BufferedWriter bw;
+	StringTokenizer st;
+
+	public IOController() {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		st = new StringTokenizer("");
+	}
+
+	String nextLine() throws Exception {
+		String line = br.readLine();
+		st = new StringTokenizer(line);
+		return line;
+	}
+
+	String nextToken() throws Exception {
+		while (!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+
+	int nextInt() throws Exception {
+		return Integer.parseInt(nextToken());
+	}
+
+	long nextLong() throws Exception {
+		return Long.parseLong(nextToken());
+	}
+
+	double nextDouble() throws Exception {
+		return Double.parseDouble(nextToken());
+	}
+
+	void close() throws Exception {
+		bw.flush();
+		bw.close();
+	}
+
+	void write(String content) throws Exception {
+		bw.write(content);
+	}
+
+}
+
+public class Main {
+
+	static IOController io;
+
+	//
+
+	static final int INF = (int)1e9 + 7;
+	static final int[] dx = {1,0,-1,0};
+	static final int[] dy = {0,1,0,-1};
+
+	static int N, M;
+	static boolean[][] wall;
+
+	public static void main(String[] args) throws Exception {
+
+		io = new IOController();
+
+		N = io.nextInt();
+		M = io.nextInt();
+		wall = new boolean[N][M];
+		for(int i=0;i<N;i++) {
+			char[] tmp = io.nextToken().toCharArray();
+			for(int j=0;j<M;j++) wall[i][j] = tmp[j] == '1';
+		}
+
+		int[][] from = bfs(0,0, false);
+		int[][] to = bfs(N-1,M-1, true);
+
+		int[][] right = new int[N][M];
+		for(int i=0;i<N;i++) {
+			right[i][M-1] = Math.min(INF, to[i][M-1] + M-1);
+			for(int j=M-2;j>=0;j--) {
+				right[i][j] = Math.min(right[i][j+1], to[i][j] + j);
+			}
+		}
+
+		int[][] up = new int[N][M];
+		for(int j=0;j<M;j++) {
+			up[N-1][j] = Math.min(INF, to[N-1][j] + N-1);
+			for(int i=N-2;i>=0;i--) {
+				up[i][j] = Math.min(up[i+1][j], to[i][j] + i);
+			}
+		}
+
+		int ans = INF;
+		for(int i=0;i<N;i++) for(int j=0;j<M;j++) if(from[i][j] != INF) {
+			int res = Math.min(from[i][j] + right[i][j] - j, from[i][j] + up[i][j] - i);
+			ans = Math.min(ans, res);
+		}
+		io.write((ans == INF ? "-1" : ans) + "\n");
+
+		io.close();
+
+	}
+
+	static int[][] bfs(int a, int b, boolean can) {
+		int[][] res = new int[N][M];
+		for(int i=0;i<N;i++) Arrays.fill(res[i], INF);
+
+		boolean[][] vis = new boolean[N][M];
+		Queue<int[]> q = new ArrayDeque<>();
+		q.offer(new int[]{a,b,0});
+		vis[a][b] = true;
+		while(!q.isEmpty()) {
+			int[] cur = q.poll();
+			int x = cur[0], y = cur[1], t = cur[2];
+			res[x][y] = t;
+			for(int i=0;i<4;i++) {
+				int xx = x+dx[i], yy = y+dy[i];
+				if(xx<0 || xx>=N || yy<0 || yy>=M || vis[xx][yy]) continue;
+				if(wall[xx][yy]) {
+					if(can) {
+						res[xx][yy] = t+1;
+						vis[xx][yy] = true;
+					}
+					continue;
+				}
+				q.offer(new int[]{xx,yy,t+1});
+				vis[xx][yy] = true;
+			}
+		}
+		return res;
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/24439

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N*M 크기의 격자판에서 (1,1) -> (N,M)으로 이동하려 한다.
능력을 쓰면 상하좌우 중 한 방향을 골라서 벽을 모두 없애버릴 수 있다.
능력을 최대 한 번 사용할 때, 최소 이동 횟수를 구해보자.

## 🔍 풀이 방법
- BFS
---
어떤 칸 (i,j)에서 왼쪽 혹은 위쪽으로 능력을 썼을 때 절대 이득을 볼 수 없다.
(i,j)로 오면서 지났던 칸 중에서 오른쪽 혹은 아래쪽으로 능력을 쓰는 게 더 이득이기 때문임

(1,1)에서 BFS를 돌렸을 때의 최단 거리 배열을 A,
(N,M)에서 BFS를 돌렸을 떄의 최단 거리 배열을 B로 둔다.

어떤 칸 (i,j)에서 오른쪽으로 능력을 써서 (i,y)까지 이동했다면, 거리는 A[i][j] + (y-j) + B[i][y]가 된다.
이때, i와 j는 고정된 값이기 때문에 B[i][y] + y가 가장 작은 곳으로 이동하는 게 제일 이득이다.
-> 누적 합 비슷한 느낌으로 각 행 별로 어디로 가야하는지 누적 최소를 이용해 미리 구할 수 있음

아래쪽으로 능력을 쓰는 경우도 위에서 한 거랑 같은 논리로 구해준 다음, 모든 칸에서 능력을 한 번씩 썼을 때 언제 최소가 되는지 구해줬다.

## ⏳ 회고
easy