### PR TITLE
[20250830] BOJ / G4 / 스카이라인 쉬운거 / 이종환

### DIFF
--- a/0224LJH/202508/30 BOJ 스카이라인 쉬운거.md
+++ b/0224LJH/202508/30 BOJ 스카이라인 쉬운거.md
@@ -1,0 +1,55 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static int cnt,ans;
+    static int[] arr;
+
+    public static void main(String[] args) throws Exception {
+        init();
+        process();
+        print();
+
+    }
+
+    public static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        cnt = Integer.parseInt(br.readLine());
+        arr = new int[cnt];
+        for (int i = 0; i < cnt; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            st.nextToken();
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+        ans = 0;
+    }
+
+    public static void process(){
+        PriorityQueue<Integer> pq = new PriorityQueue<>(Collections.reverseOrder());
+        for (int i = 0; i < cnt; i++) {
+            int height = arr[i];
+
+            while (!pq.isEmpty() && pq.peek() > height) {
+                pq.poll();
+                ans++;
+            }
+
+            if (height == 0) continue;
+
+            if (pq.isEmpty() ||  pq.peek() != height) pq.add(height);
+
+
+        }
+
+        ans += pq.size();
+    }
+
+    public static void print(){
+        System.out.println(ans);
+    }
+
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1863

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명

스카이라인만을 보고서 도시에 세워진 건물이 몇 채인지 알아 낼 수 있을까? 건물은 모두 직사각형 모양으로 밋밋하게 생겼다고 가정한다.

정확히 건물이 몇 개 있는지 알아내는 것은 대부분의 경우에 불가능하고, 건물이 최소한 몇 채 인지 알아내는 것은 가능해 보인다. 이를 알아내는 프로그램을 작성해 보자.

첫째 줄에 n이 주어진다. (1 ≤ n ≤ 50,000) 다음 n개의 줄에는 왼쪽부터 스카이라인을 보아 갈 때 스카이라인의 고도가 바뀌는 지점의 좌표 x와 y가 주어진다. (1 ≤ x ≤ 1,000,000. 0 ≤ y ≤ 500,000) 첫 번째 지점의 x좌표는 항상 1이다.

## 🔍 풀이 방법
고민을 많이 했는데, 잘 생각해보니 우선 X좌표는 필요하지 않다. 결국 어느 높이가 언제 나오는 지를 확인하면 된다. 그렇기에 PQ를 이용하여서 넣었다. 지금 PQ에 있는 Y값중 제일 높은 것부터 새로운 값과 비교하며, 더 작다면 PQ에서 내보내고 건물 개수를 하나 추가하는 식으로 해결하였다.

## ⏳ 회고
굳이 어려운 로직, 어려운 알고리즘 쓰려고 하지 말아야겠다.