### PR TITLE
[20250830] BOJ / G5 / 탑 / 김민진

### DIFF
--- a/zinnnn37/202508/30 BOJ G5 탑.md
+++ b/zinnnn37/202508/30 BOJ G5 탑.md
@@ -1,0 +1,60 @@
+```java
+import java.io.*;
+import java.util.Stack;
+import java.util.StringTokenizer;
+
+public class BJ_2493_탑 {
+
+	private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+	private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	private static final StringBuilder   sb = new StringBuilder();
+	private static       StringTokenizer st;
+
+	private static int   N;
+	private static int[] height;
+
+	private static Stack<Integer> s;
+
+	public static void main(String[] args) throws IOException {
+		init();
+		sol();
+	}
+
+	private static void init() throws IOException {
+		N = Integer.parseInt(br.readLine());
+
+		height = new int[N];
+		st     = new StringTokenizer(br.readLine());
+		for (int i = 0; i < N; i++) {
+			height[i] = Integer.parseInt(st.nextToken());
+		}
+
+		s = new Stack<>();
+		s.push(0);
+		sb.append("0 ");
+
+		br.close();
+	}
+
+	private static void sol() throws IOException {
+		for (int i = 1; i < N; i++) {
+			// 현재 건물보다 높이가 높은 건물이 나올 때 까지 pop
+			while (!s.isEmpty() && height[s.peek()] < height[i]) {
+				s.pop();
+			}
+
+			// 왼쪽에 현재 건물보다 높은 건물 부재
+			if (s.isEmpty()) {
+				sb.append("0 ");
+			} else {
+				sb.append(s.peek() + 1).append(" ");
+			}
+			s.push(i);
+		}
+		bw.write(sb.toString());
+		bw.flush();
+		bw.close();
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[탑](https://www.acmicpc.net/problem/2493)

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
왼쪽에 있는 건물 중 현재 건물보다 큰 건물의 인덱스를 구하는 문제입니다.

## 🔍 풀이 방법
첫 번째는 0으로 고정시켜두고 두 번째 부터 확인하면 됩니다.
스택에 더 큰 건물의 인덱스가 나올 때까지 `pop()` 진행하고 없으면 `0`, 있으면 `peek() + 1`을 출력합니다.

## ⏳ 회고
스택인 것만 알면 금방 나오는 듯???