### PR TITLE
[20250831] BOJ / P3 / 같은 탑 / 한종욱

### DIFF
--- a/Ukj0ng/202508/31 BOJ P5 같은 탑.md
+++ b/Ukj0ng/202508/31 BOJ P5 같은 탑.md
@@ -1,0 +1,63 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static int[] block, dp;
+    private static int N, sum;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        DP();
+
+        int answer = dp[0] > 0 ? dp[0] : -1;
+
+        bw.write(answer + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+        sum = 0;
+
+        block = new int[N];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            block[i] = Integer.parseInt(st.nextToken());
+            sum += block[i];
+        }
+
+        dp = new int[sum + 1];
+        Arrays.fill(dp, -1);
+        dp[0] = 0;
+    }
+
+    private static void DP() {
+        for (int i = 0; i < N; i++) {
+            int[] newDp = dp.clone();
+
+            for (int j = 0; j <= sum; j++) {
+                if (dp[j] == -1) continue;
+
+                int higher = dp[j];
+                int lower = higher - j;
+
+                newDp[j + block[i]] = Math.max(newDp[j + block[i]], higher + block[i]);
+
+                int newLower = lower + block[i];
+                if (newLower > higher) {
+                    newDp[newLower - higher] = Math.max(newDp[newLower - higher], newLower);
+                } else {
+                    newDp[higher - newLower] = Math.max(newDp[higher - newLower], higher);
+                }
+            }
+
+            dp = newDp;
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1126

## 🧭 풀이 시간
90분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
블럭을 두 그룹으로 쌓을 껀데 두 탑의 높이를 같게 하려고 함. 이 때 탑의 높이의 최댓값

## 🔍 풀이 방법
첫 번째 접근 방식
`dp[i] = i의 높이를 갖는 탑들의 모든 경우의 수(index를 담음)`으로 상태를 정의했다. 답을 찾을 땐, 가장 높은 높이부터 내림차순으로 탐색하고 각 탑들의 집합이 서로소일 경우 답을 내는 방식을 사용했다. 이 방법으로 구현하면서 불안했던 점은 dp[i]의 원소로 몇 개의 탑의 경우의 수가 쌓일지 모르는 점이었다. N과 모든 조각의 높이의 합이 500000을 넘지 않길래 '운 좋으면 되겠다.'라는 생각에 풀었는데 메모리 초과가 발생했다.

두 번째 접근 방식
`dp[i] = 두 탑의 높이 차가 i일 경우 더 높은 탑의 높이`로 상태를 정의했다. 왜 같은 높이 차인 경우 더 높은 탑의 높이를 저장해도 될까? 문제를 풀 땐 그리디적으로 더 낫지 않을까? 라는 생각을 했다. 
```
상태1: (a, a-d) where a ≥ a-d
상태2: (b, b-d) where b ≥ b-d, b > a

임의의 블록 x를 추가할 때:
- 더 낮은 탑에 추가: (a, a-d+x) vs (b, b-d+x)
- 더 높은 탑에 추가: (a+x, a-d) vs (b+x, b-d)

모든 경우에서 b > a이므로 상태2가 더 좋은 결과를 만듦
```
이렇게 정의하니 더 높은 탑의 높이를 저장해야 했다. 우리는 dp를 계산할 때 중복을 피하기 위해 뒤에서 부터 검사한다. 하지만 이 DP 연산은 한 방향으로만 갱신하지 않기 때문에 `newDp`를 사용한다. 

1. 더 높은 탑에 블록 추가
2. 더 낮은 탑에 블록을 추가하는데 더 낮던 탑이 높아짐
3. 더 낮은 탑에 블록을 추가하고 상태가 그대로임
4. 블록을 사용하지 않음

의 경우의 수로 나눠서 구현하니 직관적이고 문제를 단순하게 정의할 수 있었다. 

## ⏳ 회고
`dp[i] = 두 탑의 높이 차가 i일 경우 더 높은 탑의 높이`로 상태를 정의하는 걸 처음 봤다. 이 방식은 두 탑의 높이도 알 수 있기 때문에 근거있는 상태 정의였다. 더 유연하게 생각해야 할 꺼 같고 그러려면 더 많은 문제를 접해야겠다.