### PR TITLE
[20250831] BOJ / G5 / 트리와 쿼리 / 김민진

### DIFF
--- a/zinnnn37/202508/31 BOJ G5 트리와 쿼리.md
+++ b/zinnnn37/202508/31 BOJ G5 트리와 쿼리.md
@@ -1,0 +1,84 @@
+```java
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class BJ_15681_트리와_쿼리 {
+
+	private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+	private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	private static final StringBuilder   sb = new StringBuilder();
+	private static       StringTokenizer st;
+
+	private static int N;
+	private static int R;
+	private static int Q;
+
+	private static int[]           dp;
+	private static boolean[]       visited;
+	private static List<Integer>[] tree;
+
+	public static void main(String[] args) throws IOException {
+		init();
+		sol();
+	}
+
+	private static void init() throws IOException {
+		st = new StringTokenizer(br.readLine());
+
+		N = Integer.parseInt(st.nextToken());
+		R = Integer.parseInt(st.nextToken());
+		Q = Integer.parseInt(st.nextToken());
+
+		tree = new List[N + 1];
+		for (int i = 1; i <= N; i++) {
+			tree[i] = new ArrayList<>();
+		}
+
+		for (int i = 0; i < N - 1; i++) {
+			st = new StringTokenizer(br.readLine());
+			int u = Integer.parseInt(st.nextToken());
+			int v = Integer.parseInt(st.nextToken());
+
+			tree[u].add(v);
+			tree[v].add(u);
+		}
+		visited = new boolean[N + 1];
+		dp      = new int[N + 1];
+	}
+
+	private static void sol() throws IOException {
+		dp[R] = makeDP(R);
+
+		for (int i = 0; i < Q; i++) {
+			int q = Integer.parseInt(br.readLine());
+
+			sb.append(dp[q]).append("\n");
+		}
+		bw.write(sb.toString());
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+
+	private static int makeDP(int parent) {
+		if (dp[parent] != 0) return dp[parent];
+
+		int cnt = 1;
+		for (int i = 0; i < tree[parent].size(); i++) {
+			int child = tree[parent].get(i);
+
+			if (visited[child] || child == R) {
+				continue;
+			}
+
+			visited[child] = true;
+			dp[child]      = makeDP(child);
+			cnt += dp[child];
+		}
+		return cnt;
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[트리와 쿼리](https://www.acmicpc.net/problem/15681)

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
주어진 트리에서 서브트리의 노드 수 구하기

## 🔍 풀이 방법
DFS 돌면서 `dp` 배열에 서브트리의 노드 수 저장해두고 출력만 해주면 됩니다.
다만 부모 노드부터 들어오는 게 아니라서 양방향으로 저장하고 방문 처리를 했습니다.
그래서 중간에 루트 노드가 자식 노드로 확인되는 경우가 있는데 방문 처리 하면서 같이 건너뛰었습니다.
서브트리는 본인도 포함이라 `cnt`는 1부터 시작합니다.

## ⏳ 회고
트리라고 명시되어도 자식 노드부터 나올 수 있다..