### PR TITLE
[20250831] BOJ / D5 / 그래프와 쿼리 / 권혁준

### DIFF
--- a/khj20006/202508/31 BOJ D5 그래프와 쿼리.md
+++ b/khj20006/202508/31 BOJ D5 그래프와 쿼리.md
@@ -1,0 +1,184 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+	BufferedReader br;
+	BufferedWriter bw;
+	StringTokenizer st;
+
+	public IOController() {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		st = new StringTokenizer("");
+	}
+
+	String nextLine() throws Exception {
+		String line = br.readLine();
+		st = new StringTokenizer(line);
+		return line;
+	}
+
+	String nextToken() throws Exception {
+		while (!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+
+	int nextInt() throws Exception {
+		return Integer.parseInt(nextToken());
+	}
+
+	long nextLong() throws Exception {
+		return Long.parseLong(nextToken());
+	}
+
+	double nextDouble() throws Exception {
+		return Double.parseDouble(nextToken());
+	}
+
+	void close() throws Exception {
+		bw.flush();
+		bw.close();
+	}
+
+	void write(String content) throws Exception {
+		bw.write(content);
+	}
+
+}
+
+class DisjointSet {
+	int size;
+	int[] root, rank;
+	Stack<int[]> works;
+
+	DisjointSet(int size) {
+		this.size = size;
+		root = new int[size+1];
+		rank = new int[size+1];
+		for(int i=1;i<=size;i++) {
+			root[i] = i;
+			rank[i] = 1;
+		}
+		works = new Stack<>();
+	}
+
+	int find(int x) { return x == root[x] ? x : find(root[x]); }
+
+	void union(int a, int b) {
+		int x = find(a), y = find(b);
+		if(x == y) {
+			works.push(new int[]{-1,-1,-1});
+			return;
+		}
+		if(rank[x] < rank[y]) {
+			rank[y] += rank[x];
+			root[x] = y;
+			works.add(new int[]{x, y, rank[x]});
+		}
+		else {
+			rank[x] += rank[y];
+			root[y] = x;
+			works.add(new int[]{y, x, rank[y]});
+		}
+	}
+
+	void rollback() {
+		if (!works.isEmpty()) {
+			int[] last = works.pop();
+			int x = last[0], y = last[1], r = last[2];
+			if(x == -1) return;
+			rank[y] -= r;
+			root[x] = x;
+		}
+	}
+
+}
+
+public class Main {
+
+	static IOController io;
+
+	//
+
+	static int N, M;
+	static List<int[]>[] lists;
+	static DisjointSet ds;
+	static List<int[]>[] needAnswer;
+
+	static void update(int s, int e, int l, int r, int n, int a, int b) {
+		if(l>r || l>e || r<s) return;
+		if(l<=s && e<=r) {
+			lists[n].add(new int[]{a,b});
+			return;
+		}
+		int m = (s+e)>>1;
+		update(s,m,l,r,n*2,a,b);
+		update(m+1,e,l,r,n*2+1,a,b);
+	}
+
+	static void clear(int s, int e, int n) throws Exception {
+		for(int[] edge : lists[n]) {
+			int a = edge[0], b = edge[1];
+			ds.union(a,b);
+		}
+		if(s == e) {
+			for(int[] info : needAnswer[s]) {
+				int a = info[0], b = info[1];
+				if(ds.find(a) == ds.find(b)) io.write("1\n");
+				else io.write("0\n");
+			}
+			for(int i=0;i<lists[n].size();i++) ds.rollback();
+			return;
+		}
+		int m = (s+e)>>1;
+		clear(s,m,n*2);
+		clear(m+1,e,n*2+1);
+		for(int i=0;i<lists[n].size();i++) ds.rollback();
+	}
+
+	public static void main(String[] args) throws Exception {
+
+		io = new IOController();
+
+		N = io.nextInt();
+		M = io.nextInt();
+		lists = new List[M*4];
+		for(int i=0;i<M*4;i++) lists[i] = new ArrayList<>();
+		ds = new DisjointSet(N);
+		needAnswer = new List[M];
+		for(int i=0;i<M;i++) needAnswer[i] = new ArrayList<>();
+		Map<String, Integer> map = new TreeMap<>();
+		for(int i=0;i<M;i++) {
+			int op = io.nextInt();
+			int a = io.nextInt();
+			int b = io.nextInt();
+			if(a > b) {
+				int t = a;
+				a = b;
+				b = t;
+			}
+			if(op == 1) map.put(a+","+b, i);
+			else if(op == 2) {
+				update(0,M-1,map.get(a+","+b),i,1,a,b);
+				map.remove(a+","+b);
+			}
+			else {
+				needAnswer[i].add(new int[]{a,b});
+			}
+		}
+		for(String key : map.keySet()) {
+			String[] words = key.split(",");
+			int a = Integer.parseInt(words[0]);
+			int b = Integer.parseInt(words[1]);
+			update(0,M-1,map.get(key),M,1,a,b);
+		}
+
+		clear(0,M-1,1);
+
+		io.close();
+
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16911

## 🧭 풀이 시간
90분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
간선이 없이 N개의 정점으로 이루어진 그래프에 쿼리들을 수행해보자.
- 1 A B : A와 B를 잇는 간선을 추가
- 2 A B : A와 B를 잇는 간선을 제거
- 3 A B : A와 B가 연결되어 있는지 확인

## 🔍 풀이 방법
- 분리 집합
- 분할 정복
---
각 쿼리가 들어온 시점을 모두 기록해두고, 시간을 기준으로 분할 정복을 하게 되면, 시간 구간이 총 NlogN개 만들어진다.
특정 간선의 lifetime을 미리 계산해두고 각각의 시간 구간에 완전히 포함될 때만 그 간선을 해당 시간 구간에 저장해둔다.

마지막에 dfs로 시간 구간 트리를 순회하면서 각 구간에 속하는 간선들을 분리 집합으로 이었다가 마지막에 다시 rollback해준다. 이렇게 하면 연결성 판별이 가능.
rollback을 하기 위해서, 연산 최적화 시 경로 압축 대신 union by rank를 이용해 find연산을 O(logN)으로 줄인다.

## ⏳ 회고
배워가는 게 정말 많았음.
분리 집합 union연산이 rollback 가능하다는 것을 알게 됐고,
시간 축을 기준으로 분할 정복을 수행하는 관찰도 도움이 많이 되었다.