### PR TITLE
[20250831] BOJ / G5 / 개똥벌레 / 이강현

### DIFF
--- a/lkhyun/202508/31 BOJ G5 개똥벌레.md
+++ b/lkhyun/202508/31 BOJ G5 개똥벌레.md
@@ -1,0 +1,50 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N,H;
+
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        H = Integer.parseInt(st.nextToken());
+
+        int[] top = new int[H+1];
+        int[] bot = new int[H+1];
+        for (int i = 0; i < N; i++) {
+            int cur = Integer.parseInt(br.readLine());
+            if(i%2 == 0){
+                bot[cur]++;
+            }else{
+                top[cur]++;
+            }
+        }
+
+        for (int i = H-1; i > 1; i--) {
+            bot[i-1] += bot[i];
+        }
+        for (int i = H-1; i > 1; i--) {
+            top[i-1] += top[i];
+        }
+
+        int min = N;
+        int cnt = 0;
+        for (int i = 1; i <= H; i++) {
+            int cur = top[H-i+1] + bot[i];
+            if(min == cur){
+                cnt++;
+            }else if(min > cur){
+                min = cur;
+                cnt = 1;
+            }
+        }
+
+        bw.write(min+" "+cnt);
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/3020
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
석순과 종유석이 번갈아가며 나타나는 동굴이 있음.
개똥벌레가 특정 높이에서 일직선으로 부수면서 지나갈거임.
최소의 개수로 석순 혹은 종유석을 부수면서 지나갈때 그 개수와 최소로 부수게 되는 높이의 수를 출력  
## 🔍 풀이 방법
누적합
입력시 석순과 종유석을 따로 입력받음.
그리고 각각 H만큼 반복하면서 특정 높이에서 부딫히는 수를 누적합으로 계산
특정 높이에서 마주치는 석순과 종유석의 합을 구함. 이때 종유석은 위에서 자라나기 때문에 높이 변환을 해줌. 
## ⏳ 회고
누적합이 약점인거 같아서 좀 풀어보려는데 너무 어려웠다.
힌트를 봤는데도 잘 모르겠어서 이해하는데 좀 걸렸다.