### PR TITLE
[20250901] BOJ / G5 / 꿀 따기 / 이강현

### DIFF
--- a/lkhyun/202509/01 BOJ G5 꿀 따기.md
+++ b/lkhyun/202509/01 BOJ G5 꿀 따기.md
@@ -1,0 +1,67 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N;
+    static int[] original;
+    static long[] leftSum;
+    static long[] rightSum;
+    static long total;
+
+    public static void main(String[] args) throws IOException {
+        N = Integer.parseInt(br.readLine());
+        
+        original = new int[N];
+        leftSum = new long[N];
+        rightSum = new long[N];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            original[i] = Integer.parseInt(st.nextToken());            
+        }
+        
+        // 왼쪽에서 오른쪽으로
+        leftSum[0] = original[0];
+        for (int i = 1; i < N; i++) {
+            leftSum[i] = leftSum[i-1] + original[i];
+        }
+        
+        // 오른쪽에서 왼쪽으로
+        rightSum[N-1] = original[N-1];
+        for (int i = N-2; i >= 0; i--) {
+            rightSum[i] = rightSum[i+1] + original[i];
+        }
+        
+        total = leftSum[N-1];
+        long max = 0;
+        
+        //벌통이 맨 오른쪽, 벌1이 맨 왼쪽 고정, 벌2 위치 선택
+        for (int i = 1; i < N-1; i++) {
+            long bee1 = total - original[0] - original[i];
+            long bee2 = total - leftSum[i];
+            max = Math.max(max, bee1 + bee2);
+        }
+        
+        //벌통이 맨 왼쪽, 벌1이 맨 오른쪽 고정, 벌2 위치 선택  
+        for (int i = N-2; i > 0; i--) {
+            long bee1 = total - original[N-1] - original[i];
+            long bee2 = total - rightSum[i];
+            max = Math.max(max, bee1 + bee2);
+        }
+        
+        //벌1이 맨 왼쪽, 벌2가 맨 오른쪽 고정, 벌통 위치 선택
+        for (int i = 1; i < N-1; i++) {
+            long bee1 = leftSum[i] - original[0];
+            long bee2 = rightSum[i] - original[N-1];
+            max = Math.max(max, bee1 + bee2);
+        }
+        
+        bw.write(max + "");
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/21758
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N개의 장소가 일렬로 있음.
이중 벌통은 하나고 벌은 두 마리가 각각 장소에 있을 수 있음.
벌들은 벌통을 향해 날아가고 자기가 출발한 장소를 제외한 경로에 꿀들을 다 먹음.(벌통위치 포함) 꿀들은 N개에 장소에 양수로 주어짐.
이때 벌 두마리가 가장 많은 꿀을 먹었을 때, 그 꿀의 양을 출력.
## 🔍 풀이 방법
누적합.
왼쪽에서 꿀을 수집하는 경우와 오른쪽으로 수집하는 경우로 누적합을 계산해둠.
벌통이 왼쪽 끝, 벌 한마리가 오른쪽 끝에 있는 경우,
벌통이 오른쪽 끝, 벌 한마리가 왼쪽 끝에 있는 경우, 
벌 한마리가 왼쪽 끝, 한마리가 오른쪽 끝에 있는 경우로 케이스를 분류하고
남은 벌 또는 벌통을 배치하며 꿀의 최댓값을 구함.
## ⏳ 회고
벌통을 N번 배치하고 벌들이 오른쪽 끝에 두 마리 붙어있는 경우, 양쪽에 있는 경우, 오른쪽 끝에 두 마리 붙어있는 경우를 보았는데, 아이디어는 비슷했으나 생각해보니 벌들이 시작위치의 꿀을 먹지 못하기 때문에, 무작정 끝에 붙여놓는 것은 최적이 아니었음.
그렇다고 벌통만 붙여놓고 벌들을 각각 배치하는 건 N^2이 되니까 시간이 안됨.

**핵심은 3가지의 변수가 있으니 두 개를 고정하고 하나만을 N번 반복해서 최적을 찾는 것이었음.** 누적합은 어렵다...