### PR TITLE
[20250901] BOJ / P3 / 식당 / 권혁준

### DIFF
--- a/khj20006/202509/01 BOJ P3 식당.md
+++ b/khj20006/202509/01 BOJ P3 식당.md
@@ -1,0 +1,102 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+    BufferedReader br;
+    BufferedWriter bw;
+    StringTokenizer st;
+
+    public IOController() {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        st = new StringTokenizer("");
+    }
+
+    String nextLine() throws Exception {
+        String line = br.readLine();
+        st = new StringTokenizer(line);
+        return line;
+    }
+
+    String nextToken() throws Exception {
+        while (!st.hasMoreTokens()) nextLine();
+        return st.nextToken();
+    }
+
+    int nextInt() throws Exception {
+        return Integer.parseInt(nextToken());
+    }
+
+    long nextLong() throws Exception {
+        return Long.parseLong(nextToken());
+    }
+
+    double nextDouble() throws Exception {
+        return Double.parseDouble(nextToken());
+    }
+
+    void close() throws Exception {
+        bw.flush();
+        bw.close();
+    }
+
+    void write(String content) throws Exception {
+        bw.write(content);
+    }
+
+}
+
+public class Main {
+
+    static IOController io;
+
+    //
+
+    static final int INF = (int)1e9 + 7;
+
+    static int N, M;
+    static int[] a;
+    static int[][] dp, idx;
+    static int[] min;
+
+    public static void main(String[] args) throws Exception {
+
+        io = new IOController();
+
+        N = io.nextInt();
+        M = io.nextInt();
+        a = new int[N+1];
+        for(int i=1;i<=N;i++) a[i] = io.nextInt();
+        dp = new int[N+1][201];
+        idx = new int[N+1][201];
+        min = new int[N+1];
+        Arrays.fill(min, INF);
+        min[0] = 0;
+
+        for(int k=1;k<=200;k++) {
+            int[] cnt = new int[M+1];
+            int count = 0;
+            for(int s=1,e=1;e<=N;e++) {
+                if(cnt[a[e]]++ == 0) count++;
+                while(count > k) {
+                    if(--cnt[a[s++]] == 0) count--;
+                }
+
+                idx[e][k] = s;
+            }
+        }
+
+        for(int i=1;i<=N;i++) {
+            for(int k=1;k<=200;k++) dp[i][k] = min[idx[i][k]-1] + k*k;
+            for(int k=1;k<=200;k++) min[i] = Math.min(min[i], dp[i][k]);
+        }
+
+        io.write(min[N] + "\n");
+
+        io.close();
+
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/6101

## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N마리의 소들에게 M종류의 음식을 제공하며, 각 소들은 선호하는 음식이 정해져있다.
소들이 서있는 순서대로 그룹화했을 때, 그룹의 비용은 해당 그룹에서 선호하는 음식의 합집합 크기의 제곱이다.
그룹의 비용 합을 최소화 해보자.

## 🔍 풀이 방법
- DP
- 투 포인터
---
비용 계산식에 따라, 한 그룹의 합집합 크기의 상한은 200이다. (sqrt(40000)이 200이기 때문)

그래서 dp[n][k]를 40000 * 200 크기로 잡고 dp식을 설계했다.
`dp[n][k] = n번째 원소를 포함하는 합집합의 크기가 k인 경우의 최소 비용`
이걸 계산하려면 n번째 원소를 포함하는 크기 k인 합집합의 시작 인덱스를 O(1)에 알 수 있어야 한다.

그래서 카운팅 배열과 투 포인터로 미리 모든 (n,k)에 대한 시작 인덱스를 구해놓고 dp를 돌렸다.

## ⏳ 회고
ez