### PR TITLE
[20250902] BOJ / G5 / 전깃줄 / 이준희

### DIFF
--- a/JHLEE325/202509/02 BOJ G5 전깃줄.md
+++ b/JHLEE325/202509/02 BOJ G5 전깃줄.md
@@ -1,0 +1,45 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+        int[][] elec = new int[n][2];
+        int[] dp = new int[n];
+
+        for(int i=0;i<n;i++){
+            st = new StringTokenizer(br.readLine());
+            elec[i][0]= Integer.parseInt(st.nextToken());
+            elec[i][1] = Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.sort(elec,(o1,o2)->{
+            return o1[0]-o2[0];
+        });
+
+        for(int i=0;i<n;i++){
+            dp[i]=1;
+
+            for(int j=0;j<i;j++){
+                if(elec[i][1]>elec[j][1]){
+                    dp[i] = Math.max(dp[i],dp[j]+1);
+                }
+            }
+        }
+
+        int result = 0;
+        for(int i=0;i<n;i++){
+            if(result<dp[i]){
+                result=dp[i];
+            }
+        }
+
+        System.out.println(n-result);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2565

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
전봇대 A B 사이를 잇는 전깃줄이 있을 때
전깃줄이 서로 교차되지 않게 하기 위해 제거해야 하는 전깃줄의 최소 개수를 구하는 문제입니다

## 🔍 풀이 방법
LIS를 구하는 문제로 풀이하였습니다.
전깃줄 배열을 A, B 둘 중 하나로 정렬을 한 후
정렬한 반대편 전봇대의 번호를 이용하여 LIS를 구했습니다.
이 때 전체 전깃줄 갯수에서 LIS를 빼게 되면 교차되는 전깃줄 갯수이므로 이렇게 구현하였습니다.

## ⏳ 회고
2차원 배열 정렬 방법을 안다면 쉽게 풀 수 있는 문제 같습니다.
