### PR TITLE
[20250902] BOJ / G5 / 동전 2 / 이강현

### DIFF
--- a/lkhyun/202509/02 BOJ G5 동전 2.md
+++ b/lkhyun/202509/02 BOJ G5 동전 2.md
@@ -1,0 +1,38 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N,K;
+    static Set<Integer> coins;
+    static int[] dp; //dp[i]: i원을 만드는데 필요한 동전의 최소 개수
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        coins = new HashSet<>();
+        dp = new int[K+1];
+        for (int i = 0; i < N; i++) {
+            coins.add(Integer.parseInt(br.readLine()));
+        }
+
+        Arrays.fill(dp,Integer.MAX_VALUE);
+        dp[0] = 0;
+
+        for (int i : coins) {
+            for (int j = i; j <= K; j++) {
+                if(dp[j-i] != Integer.MAX_VALUE){
+                    dp[j] = Math.min(dp[j],dp[j-i]+1);
+                }
+            }
+        }
+        int ans = dp[K] == Integer.MAX_VALUE ? -1 : dp[K];
+
+        bw.write(ans + "");
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2294
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
동전이 n개 있다.
동전을 여러개 사용하여 k원을 만드는데 필요한 동전의 최소 개수를 출력.
각각의 동전은 여러개 사용할 수 있다.
## 🔍 풀이 방법
dp
각각의 동전에 대해서 그 동전 금액을 뺀 곳에서 +1을 하는 경우와 현재 최소 개수와 비교하여 최소 개수를 반영하는 것을 반복
## ⏳ 회고
동전 금액을 뺀 곳이 유효하지 않은지 생각하는 것을 놓쳤다.
각각의 동전들을 고려하는 방식인데, 이전까지의 동전들을 모두 고려해서 i원을 만들 수 없다면, i원에서 오는 경우는 고려하지 않아야 한다.
알고리즘은 왜 하루 이틀전에 푼 유형만 기억이 날까.....