### PR TITLE
[20250903] BOJ / G5 / 퇴사 2 / 이준희

### DIFF
--- a/JHLEE325/202509/03 BOJ G5 퇴사 2.md
+++ b/JHLEE325/202509/03 BOJ G5 퇴사 2.md
@@ -1,0 +1,38 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+
+        int[][] arr =new int[n+2][2];
+        int[] dp = new int[n+2];
+        for(int i=1; i<n+1; i++) {
+            st = new StringTokenizer(br.readLine());
+
+            int t = Integer.parseInt(st.nextToken());
+            int p = Integer.parseInt(st.nextToken());
+            arr[i][0] = t;
+            arr[i][1] = p;
+        }
+
+        int max = -1;
+        for(int i=1; i<=n+1; i++) {
+            if(max < dp[i]) {
+                max = dp[i];
+            }
+
+            int nd = i +arr[i][0];
+            if(nd < n+2) {
+                dp[nd] = Math.max(dp[nd], max+arr[i][1]);
+            }
+        }
+        System.out.println(dp[n+1]);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/15486

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
백준이가 n일 후에 퇴사 하려고 n일 동안 최대한 많은 돈을 땡기려고 합니다.

이 때 각 일차별로 걸리는 시간과 그에 대한 보수가 주어졌을 때 퇴사할 때 가장 많이 벌어서 나갈 수 있는 경우의 수익을 구하는 문제입니다.

## 🔍 풀이 방법
dp를 이용하여 풀었습니다.
1일차에 책정된 일이 3일이 걸리고 보수가 20 이라면 dp[4]=20 으로 저장하고
n일을 순회하면서 dp[현재일+걸리는시간] = math.max(dp[현재일+걸리는시간], dp[현재일]+오늘 받은 일의 보수) 식을 이용했습니다.

## ⏳ 회고
설명이 조금 어렵게 됐는데 풀어보면 쉽게 풀 수 있는 문제였습니다.