### PR TITLE
[20250903] BOJ / G5 / 퇴사 2 / 이강현

### DIFF
--- a/lkhyun/202509/03 BOJ G5 퇴사 2.md
+++ b/lkhyun/202509/03 BOJ G5 퇴사 2.md
@@ -1,0 +1,44 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main{
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N;
+    static int[] time;
+    static int[] reward;
+    static int[] dp;
+    
+    public static void main(String[] args) throws Exception {
+        N = Integer.parseInt(br.readLine());
+        time = new int[N+1];
+        reward = new int[N+1];
+        dp = new int[N+2];
+
+        for (int i = 1; i <= N; i++) {
+            st = new StringTokenizer(br.readLine());
+            int t = Integer.parseInt(st.nextToken());
+            int r = Integer.parseInt(st.nextToken());
+            time[i] = t;
+            reward[i] = r;
+        }
+
+        int ans = 0;
+        for (int i = 1; i <= N; i++) {
+            dp[i] = Math.max(dp[i],dp[i-1]);
+            int cur = i+time[i];
+            if(cur<=N+1){
+                dp[cur] = Math.max(dp[cur],dp[i] + reward[i]);
+            }
+            
+        }
+        for (int i = 1; i <= N+1; i++) {
+            ans = Math.max(ans,dp[i]);
+        }
+        bw.write(ans+"");
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/15486
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
N개의 상담 일자가 있음.
각각의 상담은 걸리는 시간과 소득이 있음.
N일까지만 일하고 퇴사한다고 할때, 가장 큰 소득을 출력.
## 🔍 풀이 방법
dp
dp[i]는 i일때 얻은 최대 소득을 저장함.
## ⏳ 회고
ez