### PR TITLE
[20250904] BOJ / P5 / 징검다리 뒤로 건너기 / 권혁준

### DIFF
--- a/khj20006/202509/04 BOJ P5 징검다리 뒤로 건너기.md
+++ b/khj20006/202509/04 BOJ P5 징검다리 뒤로 건너기.md
@@ -1,0 +1,90 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+	BufferedReader br;
+	BufferedWriter bw;
+	StringTokenizer st;
+
+	public IOController() {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		st = new StringTokenizer("");
+	}
+
+	String nextLine() throws Exception {
+		String line = br.readLine();
+		st = new StringTokenizer(line);
+		return line;
+	}
+
+	String nextToken() throws Exception {
+		while (!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+
+	int nextInt() throws Exception {
+		return Integer.parseInt(nextToken());
+	}
+
+	long nextLong() throws Exception {
+		return Long.parseLong(nextToken());
+	}
+
+	double nextDouble() throws Exception {
+		return Double.parseDouble(nextToken());
+	}
+
+	void close() throws Exception {
+		bw.flush();
+		bw.close();
+	}
+
+	void write(String content) throws Exception {
+		bw.write(content);
+	}
+
+}
+
+public class Main {
+
+	static IOController io;
+
+	//
+
+	static final long MOD = (long)1e9 + 7;
+
+	static int N, K;
+	static long[][] dp;
+
+	public static void main(String[] args) throws Exception {
+
+		io = new IOController();
+
+		N = io.nextInt();
+		K = io.nextInt();
+		if(N <= 2) {
+			io.write("1\n");
+			return;
+		}
+
+		dp = new long[N+1][K+1];
+		for(int i=3;i<=N;i++) for(int x=1;x<=K && i-x>0;x++) {
+			if(i-x <= 2) dp[i][x] = (dp[i][x] + 1) % MOD;
+			else for(int y=1;y<=K && i-x-y>0;y++) {
+				if(i-x-y <= 2) dp[i][x] = (dp[i][x] + (i-x+1-Math.max(i-x-y+1,i-K))) % MOD;
+				else dp[i][x] = (dp[i][x] + dp[i-x][y] * (i-x+1-Math.max(i-x-y+1,i-K))) % MOD;
+			}
+		}
+
+		long ans = 0;
+		for(int x=1;x<=K && N-x>0;x++) ans = (ans + dp[N][x]) % MOD;
+		io.write(ans + "\n");
+
+		io.close();
+
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/30194

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
돌 N개가 일렬로 놓여있고, i번 돌에서는 i+x (1<=x<=K)번 돌, i-1번 돌로 갈 수 있다.
1 -> N으로 가는 경우의 수를 구해보자.

## 🔍 풀이 방법
- DP
---
`dp[n][k] = n-k번 돌에서 k번 돌로 바로 가는 경우의 수`로 정의하고 O(NK^2) DP를 돌렸다.

## ⏳ 회고
복잡한 예제에서까지 답이 잘 나오는 것 같은데 진짜 왜 틀린지 모르겠음
상태 정의를 잘못 했나 싶기도 함