### PR TITLE
[20250905] BOJ / G1 / 구간 곱 구하기 / 이준희

### DIFF
--- a/JHLEE325/202509/05 BOJ G1 구간 곱 구하기.md
+++ b/JHLEE325/202509/05 BOJ G1 구간 곱 구하기.md
@@ -1,0 +1,77 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        StringBuilder sb = new StringBuilder();
+
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+
+        long[] arr = new long[n];
+        long[] tree = new long[4 * n];
+
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(br.readLine());
+        }
+
+        init(arr, tree, 1, 0, n - 1);
+
+        for (int i = 0; i < m + k; i++) {
+            st = new StringTokenizer(br.readLine());
+            int op = Integer.parseInt(st.nextToken());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            if (op == 2) {
+                sb.append(query(tree, 1, 0, n - 1, a - 1, b - 1) + "\n");
+            } else {
+                update(arr, tree, 1, 0, n - 1, a - 1, b);
+            }
+        }
+
+        System.out.println(sb.toString());
+    }
+
+    static void init(long[] arr, long[] tree, int node, int start, int end) {
+        if (start == end) {
+            tree[node] = arr[start];
+        } else {
+            init(arr, tree, node * 2, start, (start + end) / 2);
+            init(arr, tree, node * 2 + 1, (start + end) / 2 + 1, end);
+            tree[node] = tree[node * 2] * tree[node * 2 + 1] % 1000000007;
+        }
+    }
+
+    static void update(long[] arr, long[] tree, int node, int start, int end, int index, long val) {
+        if (index < start || index > end) {
+            return;
+        }
+        if (start == end) {
+            arr[index] = val;
+            tree[node] = val;
+            return;
+        }
+        update(arr, tree, node * 2, start, (start + end) / 2, index, val);
+        update(arr, tree, node * 2 + 1, (start + end) / 2 + 1, end, index, val);
+        tree[node] = tree[node * 2] * tree[node * 2 + 1] % 1000000007;
+    }
+
+    static long query(long[] tree, int node, int start, int end, int left, int right) {
+        if (left > end || right < start) {
+            return 1;
+        }
+        if (left <= start && end <= right) {
+            return tree[node];
+        }
+        long lmul = query(tree, node * 2, start, (start + end) / 2, left, right);
+        long rmul = query(tree, node * 2 + 1, (start + end) / 2 + 1, end, left, right);
+        return lmul * rmul % 1000000007;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11505

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
n개의 수가 주어지고
특정 인덱스의 값을 바꾸는 연산 m번
특정 인덱스부터 인덱스 까지의 곱을 구하는 연산 k번 이 주어졌을 때
연산의 결과를 출력하는 문제입니다.

## 🔍 풀이 방법
세그먼트 트리를 이용해서 풀었습니다.
곱셈이기 때문에 long을 사용했고 출력 조건이 1000000007로 나눈 나머지를 구하는 것이기 때문에 오버플로우 방지를 위해 매 곱셈마다 나머지 연산을 수행했습니다.

## ⏳ 회고
그냥 세그트리의 3개 메소드를 외웠는데, 생각보다 잘 떠오르지 않아서 구현하는데 시간이 걸렸습니다.
다 구현하고 나서는 그냥 외웠던 대로 만들어 버리니깐 구간 합 구하기에서 처럼, 범위를 벗어나는 경우에 0을 리턴해 버려서 모든 곱이 0으로 나오게 됐는데 이 부분을 파악하는데 불필요하게 시간을 소요한 것 같습니다.
