### PR TITLE
[20250905] BOJ / G4 / 동전1 / 이종환

### DIFF
--- a/0224LJH/202509/05 BOJ 동전1
+++ b/0224LJH/202509/05 BOJ 동전1
@@ -1,0 +1,57 @@
+```java
+import java.io.IOException;
+import java.io.*;
+import java.util.*;
+
+
+public class Main {
+	static int[] dp,coins;
+	static int coinCnt, goal;
+
+	public static void main(String[] args) throws IOException {
+		init();
+		process();
+		print();
+	}
+	
+	public static void init() throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		coinCnt = Integer.parseInt(st.nextToken());
+		goal = Integer.parseInt(st.nextToken());
+		
+		coins = new int[coinCnt];
+		dp = new int[goal+1];
+		dp[0] = 1;
+		
+		for (int i = 0; i < coinCnt; i++) {
+			coins[i] = Integer.parseInt(br.readLine());
+		}
+
+		
+	}
+
+	public static void process() throws IOException {
+		
+		for (int i = 0; i < coinCnt; i++) {
+			int cost = coins[i];
+			
+			for (int j = cost; j <= goal; j++) {
+				dp[j] += dp[j-cost];
+			}
+		}
+
+	}
+
+	
+
+
+	
+
+
+	public static void print() {
+		System.out.println(dp[goal]);
+	}
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2293

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
n가지 종류의 동전이 있다. 각각의 동전이 나타내는 가치는 다르다. 이 동전을 적당히 사용해서, 그 가치의 합이 k원이 되도록 하고 싶다. 그 경우의 수를 구하시오. 각각의 동전은 몇 개라도 사용할 수 있다.

사용한 동전의 구성이 같은데, 순서만 다른 것은 같은 경우이다.


## 🔍 풀이 방법
전형적인 dp문제이다. 동전 개수에 제한이 없기에 0부터 쌓아올라가면 된다.


## ⏳ 회고
이게 왜 골드지