### PR TITLE
[20250905] BOJ / G5 / 솜 사이 수열 / 이인희

### DIFF
--- a/LiiNi-coder/202509/05 BOJ 솜 사이 수열.md
+++ b/LiiNi-coder/202509/05 BOJ 솜 사이 수열.md
@@ -1,0 +1,72 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+    private static BufferedReader br;
+    private static int N;
+    private static int[] X;
+    private static int[] answer;
+    private static boolean[] used;
+    private static boolean found;
+
+    public static void main(String[] args) throws IOException {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        X = new int[N];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            X[i] = Integer.parseInt(st.nextToken());
+        }
+        Arrays.sort(X);
+        answer = new int[2 * N];
+        Arrays.fill(answer, -1);
+        used = new boolean[N];
+
+        backtrack(0);
+
+        if (!found) {
+            System.out.println(-1);
+        }
+    }
+
+    private static void backtrack(int idx) {
+        if (found)
+            return;
+
+
+        if (idx == 2 * N) {
+            StringBuilder sb = new StringBuilder();
+            for (int v : answer) sb.append(v).append(' ');
+            System.out.println(sb.toString());
+            found = true;
+            return;
+        }
+        if (answer[idx] != -1) {
+            backtrack(idx + 1);
+            return;
+        }
+
+        for (int i = 0; i < N; i++) {
+            if (used[i])
+                continue;
+            int val = X[i];
+            int secIdx = idx + val + 1;
+            if (secIdx >= 2 * N || answer[secIdx] != -1) continue;
+
+            answer[idx] = val;
+            answer[secIdx] = val;
+            used[i] = true;
+
+            backtrack(idx + 1);
+
+            answer[idx] = -1;
+            answer[secIdx] = -1;
+            used[i] = false;
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1469
## 🧭 풀이 시간
50 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 솜사이 수열을 만드는것. 수열 X가 주어지고, 그것에 대한 솜사이 수열은, 두가지 조건을 만족함. 1, X에 들어있는 모든 수는 숌 사이 수열 S에 정확히 두 번 등장해야 한다. / 2. X에 등장하는 수가 i라면, S에서 두 번 등장하는 i사이에는 수가 i개 등장해야 한다.
- 이때 X가 인풋으로 주어질때 사전순으로 가장 빠른 솜사이 수열을 출력
## 🔍 풀이 방법
- 백트래킹
## ⏳ 회고
- 숫자를 넣고, 그에 대응되는 숫자를 찾는것은 너무 느리다고 판단하여, 그 대응되는 숫자도 같이 넣어서 백트래킹하는 방법을 사용. 백트래킹을 어떻게 할까 고민을 하다가 다른 정답을 참고하였다... 너무 기존풀이에 갇혀있지말자