### PR TITLE
[20250906] BOJ / G4 / 최소 스패닝 트리 / 이인희

### DIFF
--- a/LiiNi-coder/202509/06 BOJ 최소 스패닝 트리.md
+++ b/LiiNi-coder/202509/06 BOJ 최소 스패닝 트리.md
@@ -1,0 +1,79 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class Main {
+    private static BufferedReader br;
+    private static int V, E;
+    private static ArrayList<Edge>[] adj;
+    private static boolean[] visited;
+    private static class Edge implements Comparable<Edge> {
+        int to, weight;
+        public Edge(int to, int weight) {
+            this.to = to;
+            this.weight = weight;
+        }
+        @Override
+        public int compareTo(Edge other) {
+            return this.weight - other.weight;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        V = Integer.parseInt(st.nextToken());
+        E = Integer.parseInt(st.nextToken());
+        adj = new ArrayList[V + 1];
+        for (int i = 1; i <= V; i++) {
+            adj[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < E; i++) {
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+            int w = Integer.parseInt(st.nextToken());
+
+            adj[u].add(new Edge(v, w));
+            adj[v].add(new Edge(u, w));
+        }
+
+        System.out.println(prim());
+    }
+
+    private static long prim() {
+        boolean[] visited = new boolean[V + 1];
+        PriorityQueue<Edge> pq = new PriorityQueue<>();
+        long totalWeight = 0;
+        int visitedCount = 0;
+
+        visited[1] = true;
+        visitedCount++;
+        for (Edge e : adj[1]) {
+            pq.add(e);
+        }
+
+        while (!pq.isEmpty()) {
+            Edge edge = pq.poll();
+            if (visited[edge.to]) continue;
+            visited[edge.to] = true;
+            totalWeight += edge.weight;
+            visitedCount++;
+            for (Edge e : adj[edge.to]) {
+                if (!visited[e.to]) {
+                    pq.add(e);
+                }
+            }
+            if (visitedCount == V) break;
+        }
+
+        return totalWeight;
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1197
## 🧭 풀이 시간
40 분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
- 최소 스패닝 트리 구하기
## 🔍 풀이 방법
- 프림
## ⏳ 회고
- 이번 B형에서 어느 한 지점에서 합산거리 P 안에 포함된 집합(단, 최소경로)을 추려내는 로직이 필요해서, 이떄 프림 + 백트래킹을 사용하였는데, MST가 특정구간의 최단거리를 보장하지 못한다고한다... 그래서 그냥 다시 프림 연습함