### PR TITLE
[20250907] PGM / LV3 / 야근 지수 / 이강현

### DIFF
--- a/lkhyun/202509/07 PGM LV3 야근 지수.md
+++ b/lkhyun/202509/07 PGM LV3 야근 지수.md
@@ -1,0 +1,26 @@
+```java
+import java.util.*;
+class Solution {
+    static PriorityQueue<Integer> pq = new PriorityQueue<>((a,b) -> Integer.compare(b,a));
+    public long solution(int n, int[] works) {
+        long answer = 0;
+        for(int i : works){
+            pq.offer(i);
+        }
+        for(int i=0;i<n;i++){
+            if(!pq.isEmpty()){
+                int cur = pq.poll();
+                if(cur > 1){
+                    pq.offer(--cur);
+                }
+            }else{
+                return 0;
+            }
+        }
+        for(int i : pq){
+            answer += i*i;
+        }
+        return answer;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/12927
## 🧭 풀이 시간
5분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
1시간에 일은 1만큼 할 수 있음.
일을 n시간만큼 하고 남은 일들을 제곱하여 피로도를 구할때, 피로도가 최소가 되는 값을 구하자.
## 🔍 풀이 방법
우선순위 큐
그냥 더하는 것보다 제곱해서 더해지는게 무조건 크기때문에 남은 일중 가장 많이 남은 일부터 해야한다.
따라서 매 시간마다 가장 많이 남은 일을 뽑아내야하고 크기를 유지하기위해 우선순위 큐를 사용했다.
## ⏳ 회고
ez