### PR TITLE
[20250907] BOJ / P5 / 폭탄 던지는 태영이 / 권혁준

### DIFF
--- a/khj20006/202509/07 BOJ P5 폭탄 던지는 태영이.md
+++ b/khj20006/202509/07 BOJ P5 폭탄 던지는 태영이.md
@@ -1,0 +1,93 @@
+```java
+import java.util.*;
+import java.io.*;
+
+class IOController {
+	BufferedReader br;
+	BufferedWriter bw;
+	StringTokenizer st;
+
+	public IOController() {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		st = new StringTokenizer("");
+	}
+
+	String nextLine() throws Exception {
+		String line = br.readLine();
+		st = new StringTokenizer(line);
+		return line;
+	}
+
+	String nextToken() throws Exception {
+		while (!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+
+	int nextInt() throws Exception {
+		return Integer.parseInt(nextToken());
+	}
+
+	long nextLong() throws Exception {
+		return Long.parseLong(nextToken());
+	}
+
+	double nextDouble() throws Exception {
+		return Double.parseDouble(nextToken());
+	}
+
+	void close() throws Exception {
+		bw.flush();
+		bw.close();
+	}
+
+	void write(String content) throws Exception {
+		bw.write(content);
+	}
+
+}
+
+public class Main {
+
+	static IOController io;
+
+	//
+
+	static int N, M;
+	static long[][] h, c, s;
+
+	public static void main(String[] args) throws Exception {
+
+		io = new IOController();
+
+		N = io.nextInt();
+		M = io.nextInt();
+		h = new long[N+1][N+1];
+		c = new long[N+1][N+1];
+		s = new long[N+1][N+1];
+		for(int i=0;i<N;i++) for(int j=0;j<N;j++) h[i][j] = -io.nextLong();
+
+		for(int i=0;i+M<=N;i++) {
+			for(int j=0;j+M<=N;j++) {
+				long res = h[i][j] - c[i][j];
+				s[i+M/2][j+M/2] = res;
+				c[i+1][j] += h[i][j];
+				c[i][j+1] += h[i][j];
+				c[i+1][j+1] -= h[i][j];
+				c[i+M][j] -= res;
+				c[i][j+M] -= res;
+				c[i+M][j+M] += res;
+			}
+		}
+
+		for(int i=0;i<N;i++) {
+			for(int j=0;j<N;j++) io.write(s[i][j] + " ");
+			io.write("\n");
+		}
+
+		io.close();
+
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/20543

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N*N크기의 격자 내에 폭탄이 설치되어 있다.
(i,j)에 위치한 폭탄이 k개이면, (i,j)를 중심으로 하는 M*M 정사각형 범위의 고도가 k만큼 깎인다.

깎인 고도 배열이 주어지면, 각 칸에 폭탄이 몇 개 있는지 구해보자.

## 🔍 풀이 방법
- imos
---
어떤 칸 (i,j)에 추가된 폭탄이 k개면, (i+1, j)와 (i, j+1)에 k개가 추가되어야 하고, (i+M, j)와 (i, j+M)에는 k개가 제거되어야 한다. -> 2차원 imos법으로 해결했다.

중복 추가를 방지하기 위해 (i+1,j+1)에는 k개를 빼주고 (i+M, j+M)에는 k개를 더해줬다.

## ⏳ 회고
2차원이라 좀 힘들었다