### PR TITLE
[20250908] BOJ / G5 / 입국심사 / 이준희

### DIFF
--- a/JHLEE325/202509/08 BOJ G5 입국심사.md
+++ b/JHLEE325/202509/08 BOJ G5 입국심사.md
@@ -1,0 +1,41 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        int[] immigration = new int[n];
+
+        for (int i = 0; i < n; i++) {
+            immigration[i] = Integer.parseInt(br.readLine());
+        }
+
+        long left = 1;
+        long right = 1000000000 * (long)m;
+        long res = 0;
+
+        while (left <= right) {
+            long mid = (left + right) / 2;
+            long people = 0;
+            for (int i = 0; i < n; i++) {
+                people += mid / immigration[i];
+                if (people >= m) break;
+            }
+            if (people >= m) {
+                res = mid;
+                right = mid - 1;
+            } else {
+                left = mid + 1;
+            }
+        }
+        System.out.println(res);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/3079

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
입국 심사대가 N개 있고 K번 심사대는 각각 Tk의 시간이 걸립니다.

이 때 M명의 사람이 모두 입국심사를 마치는 최소 시간을 구하는 문제입니다.

## 🔍 풀이 방법
이분탐색을 이용하여 풀었습니다.

## ⏳ 회고
놀이공원 문제와 똑같은 문제였습니다.
접근법을 알고 있어서 로직은 엄청 빨리 나왔는데
long에 저장할 때 10억을 100억으로 착각해서 틀려버렸습니다
