### PR TITLE
[20250908] BOJ / G3 / 행렬 곱셈 순서 / 한종욱

### DIFF
--- a/Ukj0ng/202509/8 BOJ G3 행렬 곱셈 순서.md
+++ b/Ukj0ng/202509/8 BOJ G3 행렬 곱셈 순서.md
@@ -1,0 +1,53 @@
+```
+import java.io.*;
+        import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static int[][] matrix, dp;
+    private static int N;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        DP();
+
+        bw.write(dp[1][N] + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+
+        matrix = new int[N+1][2];
+        dp = new int[N+1][N+1];
+
+        for (int i = 1; i <= N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            matrix[i][0] = Integer.parseInt(st.nextToken());
+            matrix[i][1] = Integer.parseInt(st.nextToken());
+        }
+    }
+
+    private static void DP() {
+        for (int i = 1; i < N; i++) {
+            dp[i][i+1] = matrix[i][0] * matrix[i][1] * matrix[i+1][1];
+        }
+
+        for (int len = 2; len <= N; len++) {
+            for (int start = 1; start <= N - len + 1; start++) {
+                int end = start + len - 1;
+                dp[start][end] = Integer.MAX_VALUE;
+
+                for (int k = start; k < end; k++) {
+                    int cost = dp[start][k] + dp[k+1][end]
+                            + matrix[start][0] * matrix[k][1] * matrix[end][1];
+                    dp[start][end] = Math.min(dp[start][end], cost);
+                }
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11049

## 🧭 풀이 시간
90분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
행렬의 곱인데 연산의 수가 제일 적은 값은?

## 🔍 풀이 방법
`dp[i][j]=i번째부터 j번째 행렬까지 곱하는 최소 연산 횟수` 
dp[i][j] = min(dp[i][k] + dp[k+1][j] + 연결비용)
         (i ≤ k < j)
연결비용 = matrix[i].행 × matrix[k].열 × matrix[j].열

길이가 2인 것부터 N인 것까지 계산 -> 각 구간을 모든 k로 쪼개서 최소값 찾기

## ⏳ 회고
3중 for문을 구현하는거 너무 어렵다.