### PR TITLE
[20250908] BOJ / P1 / 트리와 XOR 쿼리 / 권혁준

### DIFF
--- a/khj20006/202509/08 BOJ P1 트리와 XOR 쿼리.md
+++ b/khj20006/202509/08 BOJ P1 트리와 XOR 쿼리.md
@@ -1,0 +1,172 @@
+```java
+import java.io.*;
+import java.util.*;
+
+class IOController {
+	BufferedReader br;
+	BufferedWriter bw;
+	StringTokenizer st;
+
+	public IOController() {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		st = new StringTokenizer("");
+	}
+
+	String nextLine() throws Exception {
+		String line = br.readLine();
+		st = new StringTokenizer(line);
+		return line;
+	}
+
+	String nextToken() throws Exception {
+		while (!st.hasMoreTokens())
+			nextLine();
+		return st.nextToken();
+	}
+
+	int nextInt() throws Exception {
+		return Integer.parseInt(nextToken());
+	}
+
+	long nextLong() throws Exception {
+		return Long.parseLong(nextToken());
+	}
+
+	double nextDouble() throws Exception {
+		return Double.parseDouble(nextToken());
+	}
+
+	void close() throws Exception {
+		bw.flush();
+		bw.close();
+	}
+
+	void write(String content) throws Exception {
+		bw.write(content);
+	}
+
+}
+
+public class Main {
+
+	static IOController io;
+
+	//
+
+	static int N, Q;
+	static int[][] seg, lazy;
+	static int[] in, out, rev, d, par;
+	static List<int[]>[] graph;
+	static int order = 0;
+
+	public static void main(String[] args) throws Exception {
+
+		io = new IOController();
+
+		N = io.nextInt();
+		graph = new List[N+1];
+		in = new int[N+1];
+		out = new int[N+1];
+		rev = new int[N+1];
+		d = new int[N+1];
+		par = new int[N+1];
+		seg = new int[4*N][20];
+		lazy = new int[4*N][20];
+		for(int i=1;i<=N;i++) graph[i] = new ArrayList<>();
+		for(int i=1;i<N;i++) {
+			int a = io.nextInt();
+			int b = io.nextInt();
+			int c = io.nextInt();
+			graph[a].add(new int[]{b,c});
+			graph[b].add(new int[]{a,c});
+		}
+
+		dfs(1,0,0);
+
+		for(int i=0;i<20;i++) init(1,N,1,i);
+
+		for(Q=io.nextInt();Q-->0;) {
+			int o = io.nextInt();
+			int x = io.nextInt();
+			int y = io.nextInt();
+			if(o == 1) {
+				int g = par[x] ^ y;
+				for(int k=0;k<20;k++) if((g & (1<<k)) != 0) update(1,N,in[x],out[x],1,k);
+				par[x] = y;
+			}
+			else {
+				long ans = 0;
+				for(int k=0;k<20;k++) {
+					long o1 = find(1,N,in[x],out[x],1,k), z1 = (out[x]-in[x]+1) - o1;
+					long o2 = find(1,N,in[y],out[y],1,k), z2 = (out[y]-in[y]+1) - o2;
+					ans += (o1*z2 + o2*z1) * (1L<<k);
+				}
+				io.write(ans + "\n");
+			}
+		}
+
+		io.close();
+
+	}
+
+	static void dfs(int n, int p, int v) {
+		d[n] = v;
+		in[n] = ++order;
+		rev[order] = n;
+		for(int[] e:graph[n]) if(e[0] != p) {
+			dfs(e[0],n,v^e[1]);
+			par[e[0]] = e[1];
+		}
+		out[n] = order;
+	}
+
+	static void init(int s, int e, int n, int x) {
+		if(s == e) {
+			seg[n][x] = (d[rev[s]] & (1<<x)) == 0 ? 0 : 1;
+			return;
+		}
+		int m = (s+e)>>1;
+		init(s,m,n*2,x);
+		init(m+1,e,n*2+1,x);
+		seg[n][x] = seg[n*2][x] + seg[n*2+1][x];
+	}
+
+	static void prop(int s, int e, int n, int x) {
+		if(lazy[n][x] != 0) {
+			seg[n][x] = e-s+1 - seg[n][x];
+			if(s != e) {
+				lazy[n*2][x] ^= 1;
+				lazy[n*2+1][x] ^= 1;
+			}
+			lazy[n][x] = 0;
+		}
+	}
+
+	static void update(int s, int e, int l, int r, int n, int x) {
+        prop(s,e,n,x);
+		if(l>r || l>e || r<s) return;
+		if(l<=s && e<=r) {
+			seg[n][x] = e-s+1 - seg[n][x];
+			if(s != e) {
+				lazy[n*2][x] ^= 1;
+				lazy[n*2+1][x] ^= 1;
+			}
+			return;
+		}
+		int m = (s+e)>>1;
+		update(s,m,l,r,n*2,x);
+		update(m+1,e,l,r,n*2+1,x);
+        seg[n][x] = seg[n*2][x] + seg[n*2+1][x];
+	}
+
+	static int find(int s, int e, int l, int r, int n, int x) {
+        prop(s,e,n,x);
+		if(l>r || l>e || r<s) return 0;
+		if(l<=s && e<=r) return seg[n][x];
+		int m = (s+e)>>1;
+		return find(s,m,l,r,n*2,x) + find(m+1,e,l,r,n*2+1,x);
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/24532
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
정점이 N개이고, 간선에 가중치가 있는 트리가 주어지고, 트리의 루트는 1번 정점이다.
d(x,y)는 x, y를 잇는 경로 상의 가중치를 모두 xor한 값으로 정의한다.
두 쿼리를 수행해보자.
1 x v : x번 노드에서 x번 노드의 부모로 가는 간선의 가중치를 v로 바꾼다.
2 x y : x의 서브트리에 속한 점 a와 y의 서브트리에 속한 점 b에 대해, 모든 d(a,b)의 합을 출력한다.

## 🔍 풀이 방법
- 느리게 갱신되는 세그먼트 트리
- 오일러 경로 테크닉
---
루트에서 어떤 점 x까지의 경로 가중치를 xor한 값을 D[x]라고 하면, d(x,y) = D[x] ^ D[y]가 된다.
xor연산은 각 비트 별로 독립적이라, 비트 개수( = 20)만큼 세그트리를 만들고 각 비트가 켜져있는지 여부를 관리했다.

그러면 2번 쿼리 (x,y)에 대해, k번째 비트에서 x의 서브트리 아래에 켜져있는 비트 개수를 o1, 꺼져있는 비트 개수를 z1이라 하고 똑같이 y의 서브트리에 대해서는 o2, z2라고 하면 답은 (o1*z2 + o2*z1) * (1<<k)가 된다.
모든 k에 대해 이 값을 더해서 2번 쿼리의 답을 구했다.

1번 쿼리는 x의 서브트리에 대한 모든 값에 기존 가중치 p와 새로 들어온 가중치 v를 xor한 값을 xor해주는 식으로 처리했다.

트리를 펴서 세그트리에 넣기 위해 오일러 경로 테크닉을 사용했고, 구간 쿼리를 빠르게 처리하기 위해 lazy배열을 사용함.

## ⏳ 회고
lazy 구현을 이상하게 해놓고 왜 틀렸는지 못 찾고 있었음