### PR TITLE
[20250909] BOJ / G5 / 벼락치기 / 이준희

### DIFF
--- a/JHLEE325/202509/09 BOJ G5 벼락치기.md
+++ b/JHLEE325/202509/09 BOJ G5 벼락치기.md
@@ -1,0 +1,29 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int t = Integer.parseInt(st.nextToken());
+
+        int[] dp = new int[t+1];
+
+        for(int i=0;i<n;i++){
+            st = new StringTokenizer(br.readLine());
+            int k = Integer.parseInt(st.nextToken());
+            int s = Integer.parseInt(st.nextToken());
+
+            for (int j = t; j >= k; j--) {
+                dp[j] = Math.max(dp[j], dp[j - k] + s);
+            }
+        }
+
+        System.out.println(dp[t]);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14728

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
단원이 융햡된 문제가 존재하지 않고, 각 단원 별로 1문제씩만 출제되는 시험이 있습니다.

이 때 총 공부 가능한 시간과
각 단원별 공부가 필요한 시간, 배점이 주어졌을 때

가장 고득점인 경우의 점수를 출력하는 문제입니다.

## 🔍 풀이 방법
dp를 이용해서 풀었습니다.
최대 시간 부터 각 단원을 공부해야하는 시간 k까지 역으로 순회하며 dp를 갱신했습니다

## ⏳ 회고
기본적인 dp 문제였습니다