### PR TITLE
[20250909] BOJ / G3 / 파일 합치기 / 한종욱

### DIFF
--- a/Ukj0ng/202509/9 BOJ G3 파일 합치기.md
+++ b/Ukj0ng/202509/9 BOJ G3 파일 합치기.md
@@ -1,0 +1,53 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static int[][] dp;
+    private static int[] file, sum;
+    private static int K;
+
+    public static void main(String[] args) throws IOException {
+        int T = Integer.parseInt(br.readLine());
+        while (T-- > 0) {
+            init();
+            DP();
+            bw.write(dp[1][K] + "\n");
+        }
+        bw.flush();
+        bw.close();
+        br.close();
+
+    }
+
+    private static void init() throws IOException {
+        K = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        file = new int[K+1];
+        sum = new int[K+1];
+        dp = new int[K+1][K+1];
+
+        for (int i = 1; i <= K; i++) {
+            file[i] = Integer.parseInt(st.nextToken());
+            sum[i] = sum[i-1] + file[i];
+        }
+    }
+
+    private static void DP() {
+        for (int i = 2; i <= K; i++) {
+            for (int j = 1; j <= K-i+1; j++) {
+                int k = i+j-1;
+                dp[j][k] = Integer.MAX_VALUE;
+
+                for (int l = j; l < k; l++) {
+                    int cost = dp[j][l] + dp[l+1][k] + sum[k] - sum[j-1];
+                    dp[j][k] = Math.min(cost, dp[j][k]);
+                }
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11066

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
파일을 합치는데 cost가 듬. 파일을 저장할 때 누적으로 저장하기 때문에, 어떤걸 먼저 더하냐에 따라 값이 달라짐

## 🔍 풀이 방법
`dp[i][j]=i번째부터 j번째 파일을 하나로 합치는데 필요한 최소 비용`
따라서 dp[i][j]는 `min(dp[i][j], dp[i][k] + dp[k+1][j] + (sum[j] - sum[i-1])`이다.

## ⏳ 회고
누적 합은 생각을 못했네