### PR TITLE
[20250910] BOJ / G1 / 제곱 ㄴㄴ수 / 이강현

### DIFF
--- a/lkhyun/202509/10 BOJ G1 제곱 ㄴㄴ수.md
+++ b/lkhyun/202509/10 BOJ G1 제곱 ㄴㄴ수.md
@@ -1,0 +1,44 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main{
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static StringBuilder sb = new StringBuilder();
+    static long min,max;
+    static List<Long> squares;
+    static long cnt;
+    public static void main(String[] args) throws Exception {
+        st = new StringTokenizer(br.readLine());
+        min = Long.parseLong(st.nextToken());
+        max = Long.parseLong(st.nextToken());
+        squares = new ArrayList<>();
+        cnt = max-min+1;
+
+        long temp = 2;
+        while(temp*temp<=max){ //제곱수 저장
+            squares.add(temp*temp);
+            temp++;
+        }
+
+        Set<Long> s = new HashSet<>();
+
+        for (long cur : squares) {
+            long init = min/cur;
+            long result = cur*init++;
+            if(min%cur == 0) s.add(result);
+            result = cur*init;
+            while(result<=max){
+                s.add(result);
+                result = ++init * cur;
+            }
+        }
+
+        bw.write((cnt - s.size())+"");
+        bw.close();
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1016
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
min과 max 사이의 값에서 1보다 큰 제곱수로 나누어지지 않는 수의 개수를 출력.
## 🔍 풀이 방법
set
min이 1조까지고 max가 min과 최대 100만 차이라 대략 고려해야하는 제곱수가 100만개정도 됌. 그래서 다 구해놓고
제곱수 하나씩 순회하면서 제곱수 * i가 min에서 max 사이에 있는 경우 set에 넣음.
그리고 max - min +1 에서 set의 크기를 빼주면 됨.
제곱수로 늘려가며 나누니까 시그마 1 / i^2 이면 파이/6으로 수렴하니까
시간 복잡도가 O(N)이다.
## ⏳ 회고
제곱수가 아니어도 O(NlogN) 이다.