### PR TITLE
[20250910] BOJ / G5 / 수 고르기 / 이인희

### DIFF
--- a/LiiNi-coder/202509/10 BOJ 수 고르기.md
+++ b/LiiNi-coder/202509/10 BOJ 수 고르기.md
@@ -1,0 +1,35 @@
+```java
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.util.StringTokenizer;
+import java.util.Arrays;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        int[] arr = new int[N];
+        for (int i = 0; i < N; i++) {
+            arr[i] = Integer.parseInt(br.readLine());
+        }
+
+        Arrays.sort(arr);
+        int left = 0;
+        int right = 0;
+        int answer = Integer.MAX_VALUE;
+        while (right < N) {
+            int diff = arr[right] - arr[left];
+            if (left >= right || diff < M) {
+                right++;
+            } else {
+                answer = Math.min(answer, diff);
+                left++;
+            }
+        }
+        System.out.println(answer);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2230
## 🧭 풀이 시간
40 분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
- n의 길이인 자연수 수열이 주어지고, m도 주어짐. n의 두 숫자의 차이가 m보다 같거나 큰 조합 중, 가장 m에 가까운 조합의 차이를 출력
## 🔍 풀이 방법
- 투포인터
## ⏳ 회고
- 다행히 투포인터라고 생각이 딱 들은 문제이다.