### PR TITLE
[20250911] BOJ / G4 / 고층 건물 / 이강현

### DIFF
--- a/lkhyun/202509/11 BOJ G4 고층 건물.md
+++ b/lkhyun/202509/11 BOJ G4 고층 건물.md
@@ -1,0 +1,47 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N;
+    static int[] buildings;
+    static int[] cnt;
+    static int max;
+    
+    public static void main(String[] args) throws IOException {
+        N = Integer.parseInt(br.readLine());
+        buildings = new int[N+1];
+        cnt = new int[N+1];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= N; i++) {
+            buildings[i] = Integer.parseInt(st.nextToken());
+        }
+
+        for (int i = 1; i < N; i++) {
+            for (int j = i+1; j <= N; j++) {
+                double slope = (double)(buildings[j]-buildings[i]) / (j-i);
+                boolean isPossible = true;
+                for (int k = 1; i+k < j; k++) {
+                    if(buildings[i]+(slope*k) <= buildings[i+k]){
+                        isPossible = false;
+                        break;
+                    }
+                }
+                if(isPossible){
+                    cnt[i]++;
+                    cnt[j]++;
+                }
+            }
+        }
+        for (int i = 1; i <= N; i++) {
+            max = Math.max(cnt[i], max);
+        }
+        bw.write(max+"");
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1027
## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
고층 건물들이 줄지어서 있음. 지붕과 지붕을 이었을때, 사이에 고층건물이 접하거나 겹치면 서로 못봄. 가장 많은 건물을 볼 수 있는 건물이 보는 건물의 수를 출력 
## 🔍 풀이 방법
수학, 브루트포스
모든 건물 쌍에 대해 기울기 구하고 그 사이에 있는 건물들이 겹치는지만 파악하면됨. 
## ⏳ 회고
모든 값이 max를 구하는지 사용되었는지와 double 형변환 잘해주는거 조심
기초적인 것을 놓쳐서 오래걸렸다.