### PR TITLE
[20250911] PGM / LV2 / 시소 짝꿍 / 김수연

### DIFF
--- a/suyeun84/202509/11 PGM LV2 시소 짝꿍.md
+++ b/suyeun84/202509/11 PGM LV2 시소 짝꿍.md
@@ -1,0 +1,23 @@
+```java
+import java.util.*;
+class Solution {
+    public long solution(int[] weights) {
+    	long answer = 0;
+        Arrays.sort(weights);
+        Map<Double, Integer> map = new HashMap<>();
+        for(int i : weights) {
+    		double a = i*1.0;
+    		double b = (i*2.0)/3.0;
+    		double c = (i*1.0)/2.0;
+    		double d = (i*3.0)/4.0;
+    		if(map.containsKey(a)) answer += map.get(a);
+    		if(map.containsKey(b)) answer += map.get(b);
+    		if(map.containsKey(c)) answer += map.get(c);
+    		if(map.containsKey(d)) answer += map.get(d);
+    		map.put((i*1.0), map.getOrDefault((i*1.0), 0)+1);
+        }
+        
+        return answer;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/152996
## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
놀이터에 시소가 하나 있고, 시소의 중심으로부터 2, 3, 4 거리의 지점에 좌석이 하나씩 있을 때,
시소를 두 명이 마주 보고 탄다고 할 때, 시소가 평형인 상태를 이룰 수 있는 두 사람을 시소 짝꿍이라고 한다.
탐승한 사람의 무게 x 좌석 간 거리 가 같아야함
시소 짝꿍이 몇 쌍 존재하는지 구하기
## 🔍 풀이 방법
HashMap 사용
한 사람이 2,3,4 각각의 자리에 앉았을 때 필요한 시소 짝꿍의 무게를 HashMap에 넣어두고, 해당하는 사람이 존재하면 answer를 늘려줌
## ⏳ 회고
쉬움