### PR TITLE
[20250912] BOJ / P5 / 히스토그램 / 이종환

### DIFF
--- a/0224LJH/202509/12 BOJ 히스토그램.md
+++ b/0224LJH/202509/12 BOJ 히스토그램.md
@@ -1,0 +1,105 @@
+```java
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+	
+	
+	static int blockCnt;
+	static long ans;
+	static int[] blocks;
+	static PriorityQueue<Block> pq = new PriorityQueue<>();
+	static HashSet<Integer> nums = new HashSet<>();
+	static PriorityQueue<Integer> numPq = new PriorityQueue<>();
+	
+	static class Block implements Comparable<Block>{
+		int start;
+		int height;
+		
+		public Block (int start, int height) {
+			this.start = start;
+			this.height = height;
+		}
+		
+		@Override
+		public int compareTo(Block b) {
+			return Integer.compare(b.height, this.height);
+		}
+	}
+
+    
+    public static void main(String[] args) throws NumberFormatException, IOException {
+		init();
+		process();
+		print();
+    }
+    
+    public static void init() throws NumberFormatException, IOException {
+    	BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    	blockCnt = Integer.parseInt(br.readLine());
+    	blocks = new int[blockCnt];
+    	ans = 0;
+    	for (int i = 0; i < blockCnt; i++) {
+    		blocks[i] = Integer.parseInt(br.readLine());
+    		nums.add(blocks[i]);
+    	}
+
+    	
+    }
+    
+    public static void process() { 	
+    	ans = findLargest(0,blockCnt-1);
+    	
+    	
+    }
+    
+    public static long findLargest(int start, int end) {
+    	
+    	if (start == end) return blocks[start];
+    	
+    	int mid = (start+end)/2;
+    	long leftMax = findLargest(start,mid);
+    	long rightMax = findLargest(mid+1,end);
+    	long max = Math.max(leftMax, rightMax);
+    	
+    	int leftIdx = mid;
+    	int rightIdx = mid+1;
+    	long curNum = Math.min(blocks[leftIdx], blocks[rightIdx]);
+    	long curMax =curNum*(rightIdx-leftIdx+1);
+    	
+    	while(true) {	
+    		
+    		if (leftIdx == start && rightIdx == end) break;
+    		int nLeftNum = 0;
+    		int nRightNum = 0;
+    		if (start < leftIdx) nLeftNum = blocks[leftIdx-1];
+    		if (rightIdx < end) nRightNum = blocks[rightIdx+1];
+    		
+    		if (nLeftNum <= nRightNum && rightIdx != end) {
+    			rightIdx++;
+    		} else {
+    			leftIdx--;
+    		}
+    		
+    		curNum = Math.min(curNum, blocks[rightIdx]);
+    		curNum = Math.min(curNum, blocks[leftIdx]);
+    		curMax = Math.max(curMax, curNum*(rightIdx-leftIdx+1));
+    		
+    	}
+    	
+    	max = Math.max(max, curMax);
+    	
+    	return max;
+    }
+    
+    
+
+
+    public static void print() {
+    	System.out.println(ans);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1725

## 🧭 풀이 시간
120분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
히스토그램의 내부에 가장 넓이가 큰 직사각형을 그리려고 한다. 이 직사각형의 밑변은 항상 히스토그램의 아랫변에 평행하게 그려져야 한다.

첫 행에는 N (1 ≤ N ≤ 100,000) 이 주어진다. N은 히스토그램의 가로 칸의 수이다. 다음 N 행에 걸쳐 각 칸의 높이가 왼쪽에서부터 차례대로 주어진다. 각 칸의 높이는 1,000,000,000보다 작거나 같은 자연수 또는 0이다.


## 🔍 풀이 방법

다양한 방법을 시도해봤는데, 다 실패했다.
결국 힌트에서 분할정복이라는 것을 보고 , 지금의 로직을 떠올렸다.

s부터 e 까지 범위에서 가장 큰 직사각형의 크기를 f(s,e)라 해보자.
mid = (s+e)/2일때, 
f(s,e)는 f(s,mid) , f(mid+1, e), 그리고 mid,mid+1칸을 포함하는 직사각형들중 가장 큰 값을 구하면 된다.

## ⏳ 회고
세그먼트라는 힌트때문에 오히려 시간을 더 썼다. 논리상으로는 들어가긴 하지만...
