### PR TITLE
[20250912] BOJ / P5 / 행성 터널 / 이강현

### DIFF
--- a/lkhyun/202509/12 BOJ P5 행성 터널.md
+++ b/lkhyun/202509/12 BOJ P5 행성 터널.md
@@ -1,0 +1,95 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static class Vertex{
+        int num;
+        long value;
+
+        public Vertex(int num, long value) {
+            this.num = num;
+            this.value = value;
+        }
+    }
+    
+    static class Edge{
+        int from,to;
+        long value;
+
+        public Edge(int from, int to, long value) {
+            this.from = from;
+            this.to = to;
+            this.value = value;
+        }
+    }
+    
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N;
+    static List<long[]> xyz = new ArrayList<>();
+    static int[] root;
+    static PriorityQueue<Edge> pq = new PriorityQueue<>((a,b) -> Long.compare(a.value, b.value)); 
+    
+    public static void main(String[] args) throws IOException {
+        N = Integer.parseInt(br.readLine());
+        root = new int[N];
+        for (int i = 0; i < N; i++) {
+            root[i] = i;
+        }
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            long x = Long.parseLong(st.nextToken());
+            long y = Long.parseLong(st.nextToken());
+            long z = Long.parseLong(st.nextToken());
+            xyz.add(new long[]{i, x, y, z});
+        }
+
+        for (int i = 1; i <= 3; i++) {
+            int cur = i;
+            Collections.sort(xyz, (a, b) -> Long.compare(a[cur], b[cur]));
+            
+            for (int j = 0; j < N-1; j++) {
+                long[] p1 = xyz.get(j);
+                long[] p2 = xyz.get(j+1);
+                long cost = Math.abs(p2[cur] - p1[cur]);
+                pq.offer(new Edge((int)p1[0], (int)p2[0], cost));
+            }
+        }
+
+        int cnt = 0;
+        long ans = 0;
+        while(!pq.isEmpty()) {
+            Edge cur = pq.poll();
+            if(cnt == N-1) break;
+            if(union(cur.from, cur.to)){
+                ans += cur.value;
+                cnt++;
+            }
+        }
+        bw.write(ans+"");
+        bw.close();
+    }
+    
+    public static int find(int cur){
+        if(root[cur] == cur) return cur;
+        else return root[cur] = find(root[cur]);
+    }
+
+    public static boolean union(int a, int b){
+        int rootA = find(a);
+        int rootB = find(b);
+        
+        if(rootA == rootB){
+            return false;
+        }else if(rootA < rootB){
+            root[rootA] = rootB;
+        }else{
+            root[rootB] = rootA;
+        }
+        return true;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2887
## 🧭 풀이 시간
90분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
행성들이 3차원 좌표로 이루어져있는데 이걸로 MST를 구현하라
## 🔍 풀이 방법
MST
정점이 10만개라 N^2하면 간선이 너무 많아요
그래서 x랑 y랑 z랑 따로 거리 구해서 가장 짧은 경우의 간선만 얻어내야 해요
인접한 두 행성간 x,y,z 각각 오름차순으로 정렬하고 인접한 두 행성간 간선을 얻어요
그러면 총 약 30만개의 간선을 얻어요
이제 다 우선순위 큐에 넣고 N-1번 연결할때까지 비용을 모으면 정답이에요
## ⏳ 회고
x,y,z 따로 저장하는 방식으로 했었는데, 생각해보니 이러면 값을 비교하기가 어려워요 1번 행성과 2번 행성의 x,y,z를 비교해야 하는데, 제각각이 되어버려요. 그래서 수정했는데 맞았어요.