### PR TITLE
[20250915] BOJ / G5 / 조 짜기 / 이준희

### DIFF
--- a/JHLEE325/202509/15 BOJ G5 조 짜기.md
+++ b/JHLEE325/202509/15 BOJ G5 조 짜기.md
@@ -1,0 +1,38 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static List<Deque<Integer>> wheel = new ArrayList<>();
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+        int[] arr = new int[n];
+        int[] dp = new int[n];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        for (int i = 0; i < n; i++) {
+            int max = arr[i];
+            int min = arr[i];
+            for (int j = i; j >= 0; j--) {
+                max = Math.max(max, arr[j]);
+                min = Math.min(min, arr[j]);
+                if (j == 0) {
+                    dp[i] = Math.max(dp[i], max - min);
+                } else {
+                    dp[i] = Math.max(dp[i], dp[j - 1] + (max - min));
+                }
+            }
+        }
+
+        System.out.println(dp[n - 1]);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2229

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
각 사람들의 능력치(정수) 가 나이 순서대로 주어지고
팀은 나이 순서대로 짜야합니다.(인덱스가 연속되어야함)

각 팀의 잘 짜여진 정도는 그 팀의 능력치 최대값 - 능력치 최솟값일 때
팀 편성을 완료 했을 때 팀의 잘 짜여진 정도가 가장 높은 경우를 구하는 문제입니다.

## 🔍 풀이 방법
dp를 이용해서 풀었습니다.
각 인덱스 i 마다 i 부터 0까지 순회하며 최댓값을 갱신하는 방식으로 풀었습니다.
```
for (int j = i; j >= 0; j--) {
                max = Math.max(max, arr[j]);
                min = Math.min(min, arr[j]);
                if (j == 0) {
                    dp[i] = Math.max(dp[i], max - min);
                } else {
                    dp[i] = Math.max(dp[i], dp[j - 1] + (max - min));
                }
            }
```

## ⏳ 회고
처음 문제를 봤을 때 dp 인 것 같기는 했는데 어떻게 dp 인지 쉽게 생각이 안났습니다.
