### PR TITLE
[20250916] BOJ / G5 / 전깃줄 / 이인희

### DIFF
--- a/LiiNi-coder/202509/16 BOJ 전깃줄.md
+++ b/LiiNi-coder/202509/16 BOJ 전깃줄.md
@@ -1,0 +1,33 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        int[][] wires = new int[N][2];
+
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            wires[i][0] = Integer.parseInt(st.nextToken());
+            wires[i][1] = Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.sort(wires, (a, b) -> a[0] - b[0]); // a와 b는 wires배열의 원소로, 이들의 0번째 원소를 기준으로 소팅
+
+        int[] dp = new int[N];
+        int maxLen = 0;
+        for (int i = 0; i < N; i++) {
+            dp[i] = 1;
+            for (int j = 0; j < i; j++) {
+                if (wires[j][1] < wires[i][1]) {
+                    dp[i] = Math.max(dp[i], dp[j] + 1);
+                }
+            }
+            maxLen = Math.max(maxLen, dp[i]);
+        }
+        System.out.println(N - maxLen);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2565
## 🧭 풀이 시간
70 분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
- A, B각각의 배열이 세로로 마주보고 서있다. 여기에서 각각의 원소를 하나씩골라 전깃줄을 연결할수있는데, 이 전깃줄이 교차되지않도록 최소한으로 전깃줄을 없애는 개수
## 🔍 풀이 방법
- 정렬 + 가장 긴 증가 부분수열(DP)
## ⏳ 회고
- 우선 문제를 보고 정말 감이 안잡혀서 A를 기준으로 정렬하여 B만을 본다는 생각못함
- 여기에서 어떻게 가장 긴 증가 부분수열을 찾아낼까 2차 멘붕
- 이문제는 상당히 나에게 어려웠다... 그리고 가장 긴 증가 부분수열도 dp의 일종인 것을 보고 아직 더 공부해야겠다 생각