### PR TITLE
[20250917] BOJ / G5 / Fly me to the Alpha Centauri / 이강현

### DIFF
--- a/lkhyun/202509/17 BOJ G5 Fly me to the Alpha Centauri.md
+++ b/lkhyun/202509/17 BOJ G5 Fly me to the Alpha Centauri.md
@@ -1,0 +1,40 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main{
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static StringBuilder sb = new StringBuilder();
+    
+    public static void main(String[] args) throws Exception {
+        int T = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i < T; i++) {
+            st = new StringTokenizer(br.readLine());
+            int x = Integer.parseInt(st.nextToken());
+            int y = Integer.parseInt(st.nextToken());
+            int diff = (y-x);
+            int cnt = 1;
+
+
+            double candidate = Math.sqrt(diff);
+            int temp = (int)candidate;
+            if(candidate*candidate == temp*temp) {
+                bw.write((temp*2 - 1)+"\n");
+                continue;
+            }else{
+                cnt = temp;
+            }
+                        
+            int rest = diff - cnt*cnt;
+            if(rest>cnt) bw.write((cnt*2 + 1) + "\n");
+            else bw.write((cnt*2)+"\n");
+        }
+        
+        bw.close();
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
x에서 y까지 가는데 자신이 이전에 이동했던 크기에 -1,0,1을 더한 값만큼만 이동할 수 있다. 그리고 y에 도착할때는 1만큼 이동해서 도착해야한다. 이때 최소이동횟수를 구하자.
## 🔍 풀이 방법
수학
1부터 시작해서 1로 끝나야하니까 최대한 범위를 늘려가며 가다가 낮추면서 와야함.
y-x의 값이 1+2+3+4+3+2+1 이런식으로 늘었다가 주는 방식으로 가야하고 이 합은 n^2임.
따라서 차이를 sqrt하여서 n을 구하고 남는 값을 경로 사이에 넣어줘야함.
이때 남는 값이 n보다 크면 두 개 넣어야할거고 아니면 1개 넣으면 댐
## ⏳ 회고
수학적으로 생각해야해서 좀 헷갈렸지만 어려운 문제는 아니었던 것 같다. 1부터 n까지의 합이 n*(n+1) / 2라는 수식을 알아서 풀 수 있었따.