### PR TITLE
[20250917] BOJ / P4 / 옥토끼는 통신교육을 풀어라!! / 이종환

### DIFF
--- a/0224LJH/202509/17 BOJ 옥토끼는 통신교육을 풀어라!!.md
+++ b/0224LJH/202509/17 BOJ 옥토끼는 통신교육을 풀어라!!.md
@@ -1,0 +1,71 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+	
+	static int problemCnt;
+	static Long ans;
+	static long [] arr;
+    
+    public static void main(String[] args) throws NumberFormatException, IOException {
+		init();
+		process();
+		print();
+    }
+    
+    public static void init() throws NumberFormatException, IOException {
+    	BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    	problemCnt = Integer.parseInt(br.readLine());
+    	StringTokenizer st = new StringTokenizer(br.readLine());
+    	ans = 1000_000_0000L;
+    	arr = new long[problemCnt];
+    	for (int i = 0; i < problemCnt; i++) {
+    		arr[i] = Long.parseLong(st.nextToken());
+    	}
+
+
+    	
+    }
+    
+    public static void process() { 	
+    	Long st = 1L;
+    	Long end = 1000_000_001L;
+    	Long mid = (st+end)/2;
+    	
+    	while(st < end) {
+    		boolean result = test(mid);
+    		
+    		if (result) {
+    			ans = Math.min(ans, mid);
+    			end = mid;
+    		} else st = mid+1;
+    		
+    		mid = (st+end)/2;
+    		
+    	}
+    }
+
+
+	private static boolean test(Long diff) {
+		long cnt = 0;
+		
+		for (int i = 0; i < problemCnt; i++) {
+			long result = arr[i]/diff;
+			if (arr[i]%diff ==0) result--;
+			cnt += result;
+		}
+		
+		if (cnt >= problemCnt) return false;
+
+
+		return true;
+	}
+
+	public static void print() {
+		System.out.println(ans);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17383

## 🧭 풀이 시간
70분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
UCPC World Finals 2020을 준비하는 옥토끼는 여름학교에 가기 위하여 통신교육 문제를 푼다. 그러나 악덕 조교 tncks0121은 옥토끼가 오랫동안 문제를 풀지 않으면 '옥통풀'을 외치며 독촉한다.

옥토끼는 N개의 문제를 모두 풀어야 하며 각 문제를 푸는 데 Ti분이 걸린다. 옥토끼는 멀티태스킹 능력이 발달하여 한 번에 동시에 두 개의 문제를 풀 수 있다. 모든 문제는 정수 시각에 풀기 시작해야 하며 한 번 풀기 시작한 문제는 도중에 풀이를 중단하지 않는다. 옥토끼가 항상 문제를 풀고 있을 필요는 없으며 문제를 푸는 순서에는 제약이 없다.

tncks0121은 옥토끼가 문제를 해결한 시점만 볼 수 있을 뿐, 옥토끼가 지금 문제를 풀고 있는지 쉬고 있는지 모른다. 문제 하나를 풀고 나서 다음 문제를 풀기까지 걸리는 시간이 길어지면 tncks0121의 독촉이 심해지기 때문에, 옥토끼는 이 간격의 최댓값이 최소가 되도록 계획을 세워 모든 문제를 풀려고 한다. 옥토끼를 도와 문제를 푸는 전략을 짜는 프로그램을 작성하여라. tncks0121은 통신교육이 시작되자마자 독촉을 시작하므로, 옥토끼가 첫 문제를 푸는 데 걸리는 시간도 고려해야 함에 유의하여라.

## 🔍 풀이 방법
너무 복잡하게 생각하지 않고, 특정 시간이 되냐, 안되냐만 판단하는 것을 우선 생각했다.
그렇기에 이분탐색을 생각하였고, 매 이분탐색마다 특정 값이 되는 지 안되는 지 판단은 맨 처음에는 treeSet으로 진행하였다.

그런데 시간초과가 떠서 잘 생각해보니 그냥 나눴을 때 몫 & 나머지만 고려하면 되는거였다.

## ⏳ 회고
이분탐색이 확실히 만능인듯