### PR TITLE
[20250917] BOJ / G4 / 이중 우선순위 큐 / 김민진

### DIFF
--- a/zinnnn37/202509/17 BOJ G4 이중 우선순위 큐.md
+++ b/zinnnn37/202509/17 BOJ G4 이중 우선순위 큐.md
@@ -1,0 +1,101 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class BJ_7662_이중_우선순위_큐 {
+
+	private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+	private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	private static final StringBuilder   sb = new StringBuilder();
+	private static       StringTokenizer st;
+
+	private static int N;
+
+	private static PriorityQueue<Integer> minHeap = new PriorityQueue<>();
+	private static PriorityQueue<Integer> maxHeap = new PriorityQueue<>(Collections.reverseOrder());
+	private static Map<Integer, Integer>  count   = new HashMap<>();
+
+	public static void main(String[] args) throws IOException {
+		int T = Integer.parseInt(br.readLine());
+
+		while (T-- > 0) {
+			solve();
+		}
+
+		bw.write(sb.toString());
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+
+	private static void solve() throws IOException {
+		N = Integer.parseInt(br.readLine());
+
+		clear();
+
+		for (int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine());
+
+			String command = st.nextToken();
+			int    value   = Integer.parseInt(st.nextToken());
+
+			if (command.equals("I")) {
+				insert(value);
+			} else {
+				delete(value == 1 ? maxHeap : minHeap);
+			}
+		}
+
+		printResult();
+	}
+
+	private static void insert(int value) {
+		minHeap.offer(value);
+		maxHeap.offer(value);
+		count.put(value, count.getOrDefault(value, 0) + 1);
+	}
+
+	private static void delete(Queue<Integer> heap) {
+		while (!heap.isEmpty()) {
+			int current      = heap.poll();
+			int currentCount = count.getOrDefault(current, 0);
+
+			if (currentCount == 0) continue;
+
+			if (currentCount == 1) {
+				count.remove(current);
+			} else {
+				count.put(current, currentCount - 1);
+			}
+			break;
+		}
+	}
+
+	private static void printResult() {
+		if (count.isEmpty()) {
+			sb.append("EMPTY\n");
+			return;
+		}
+
+		cleanHeap(maxHeap);
+		cleanHeap(minHeap);
+
+		int max = maxHeap.poll();
+		int min = minHeap.poll();
+
+		sb.append(max).append(" ").append(min).append("\n");
+	}
+
+	private static void cleanHeap(Queue<Integer> heap) {
+		while (!heap.isEmpty() && count.getOrDefault(heap.peek(), 0) == 0) {
+			heap.poll();
+		}
+	}
+
+	private static void clear() {
+		minHeap.clear();
+		maxHeap.clear();
+		count.clear();
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[이중 우선순위 큐](https://www.acmicpc.net/problem/7662)

## 🧭 풀이 시간
45분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
이중 우선순위 큐에 값을 넣음
뺄 때 `1`이면 최대값 빼고 `-1`이면 최소값 빼기

## 🔍 풀이 방법
최소힙, 최대힙 두 개 쓰는 문제..
접근법은 5분만에 나왔는데 시간초과 해결하느라 좀 걸림

맵에는 해당 숫자가 큐에 얼마나 있는지 저장함
`delete`할 때 맵의 값이 `0`이면 다른 힙에서 삭제한 값이라 넘어가고
`0`이 아니라면 삭제가 안 된 값이니까 맵 값을 수정.
만약 `1 -> 0`인 경우 비교하기 편하라고 그냥 해당 값을 맵에서 아예 삭제

넣을 때는 힙이랑 맵에 둘 다 넣어주면 됨.

맵이 비었으면 `EMPTY` 출력, 아니면 맵의 값이 0이 아닌 가장 처음 나오는 힙의 값 출력..

## ⏳ 회고
힙은 대체로 난이도에 비해 어려운듯
그러고보니 트리맵도 정렬되네.. 훨씬 쉽겠는데