### PR TITLE
[20250917] BOJ / G5 / 조짜기 / 이인희

### DIFF
--- a/LiiNi-coder/202509/17 BOJ 조짜기.md
+++ b/LiiNi-coder/202509/17 BOJ 조짜기.md
@@ -1,0 +1,37 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+    private static BufferedReader br;
+
+    public static void main(String[] args) throws IOException {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        int[] Arr = new int[N + 1];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+
+        for (int i = 1; i <= N; i++) {
+            Arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int[] dp = new int[N + 1];
+        dp[0] = 0;
+        for (int i = 1; i <= N; i++) {
+            int max = Arr[i];
+            int min = Arr[i];
+            dp[i] = Integer.MAX_VALUE;
+            for (int j = i; j >= 1; j--) {
+                max = Math.max(max, Arr[j]);
+                min = Math.min(min, Arr[j]);
+                dp[i] = Math.min(dp[i], dp[j - 1] + (max - min));
+            }
+        }
+
+        System.out.println(dp[N]);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2229
## 🧭 풀이 시간
40 분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
- 학생을 나눌때, 나뉜것의 최소와 최대의 차이를 조가 잘짜여진 값으로 정의. 이것의 최댓값
## 🔍 풀이 방법
- dp
## ⏳ 회고
- 그런데 시간이 없어서 디버깅시간이 없어서 못풀었다..