### PR TITLE
[20250918] BOJ / G3 / 게임 개발 / 이준희

### DIFF
--- a/JHLEE325/202509/18 BOJ G3 게임 개발.md
+++ b/JHLEE325/202509/18 BOJ G3 게임 개발.md
@@ -1,0 +1,62 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int n;
+    static int[] buildTime;
+    static List<Integer>[] require;
+    static int[] dp;
+    static boolean[] visited;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        n = Integer.parseInt(br.readLine());
+        buildTime = new int[n + 1];
+        require = new ArrayList[n + 1];
+        dp = new int[n + 1];
+        visited = new boolean[n + 1];
+
+        for (int i = 1; i <= n; i++) {
+            require[i] = new ArrayList<>();
+        }
+
+        for (int i = 1; i <= n; i++) {
+            st = new StringTokenizer(br.readLine());
+            buildTime[i] = Integer.parseInt(st.nextToken());
+
+            while (true) {
+                int pre = Integer.parseInt(st.nextToken());
+                if (pre == -1) break;
+                require[i].add(pre);
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 1; i <= n; i++) {
+            sb.append(dfs(i)).append("\n");
+        }
+        System.out.print(sb);
+    }
+
+    static int dfs(int i) {
+        if (visited[i]) return dp[i];
+
+        if (require[i].isEmpty()) {
+            dp[i] = buildTime[i];
+        } else {
+            int maxPre = 0;
+            for (int pre : require[i]) {
+                maxPre = Math.max(maxPre, dfs(pre));
+            }
+            dp[i] = maxPre + buildTime[i];
+        }
+
+        visited[i] = true;
+        return dp[i];
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1516

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
게임에서 건물을 지을 때, 선행되어야 하는 건물이 있습니다.
이 때 각 건물을 짓는데 걸리는 시간을 모두 출력하는 문제입니다.

## 🔍 풀이 방법
DFS를 이용하여 풀었습니다.
각 건물마다 종속성이 있는경우 타고타고 들어가서 결국 최종으로 걸리는 시간을 구했습니다.

## ⏳ 회고
그냥 DFS로 풀었더니 시간초과가 나서 메모이제이션을 활용했습니다.
