### PR TITLE
[20250918] BOJ / G4 / 리모컨 / 이강현

### DIFF
--- a/lkhyun/202509/18 BOJ G4 리모컨.md
+++ b/lkhyun/202509/18 BOJ G4 리모컨.md
@@ -1,0 +1,56 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N, M;
+    static boolean[] broken = new boolean[10];
+    
+    public static void main(String[] args) throws IOException {
+        N = Integer.parseInt(br.readLine());
+        M = Integer.parseInt(br.readLine());
+        if(M!=0){
+            st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < M; i++) {
+            broken[Integer.parseInt(st.nextToken())] = true;
+        }
+        }
+        
+        int result = Math.abs(N - 100);
+        
+        for (int channel = 0; channel <= 1000000; channel++) {
+            int cnt = getCount(channel);
+            if (cnt > 0) {
+                int total = cnt + Math.abs(N - channel);
+                result = Math.min(result, total);
+            }
+        }
+        
+        bw.write(result+"");
+        bw.close();
+    }
+    
+    static int getCount(int channel) {
+        if (channel == 0) {
+            return broken[0] ? -1 : 1;
+        }
+        
+        int count = 0;
+        int temp = channel;
+        
+        while (temp > 0) {
+            int digit = temp % 10;
+            if (broken[digit]) {
+                return -1;
+            }
+            count++;
+            temp /= 10;
+        }
+        
+        return count;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1107
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
리모컨의 0~9까지의 버튼과 +,- 버튼만을 눌러서 N으로 가기위한 최소 개수를 출력
번호중 몇 개는 고장남.
## 🔍 풀이 방법
브루트 포스
N이 500000이니까 0부터 1000000까지 모든 채널에서 시작해서 N으로 +,-로 갈 수 있는지 체크
시작 채널을 고장난 버튼으로 못만들면 패스
## ⏳ 회고
숫자와 +,-를 섞어 쓰는 경우도 있을 거 같아서 고민했는데 모든 채널에 대해서 생각해보면 그것도 이미 고려된 경우였다.