### PR TITLE
[20250918] BOJ / P5 / 뱀 / 이종환

### DIFF
--- a/0224LJH/202509/18 BOJ 뱀.md
+++ b/0224LJH/202509/18 BOJ 뱀.md
@@ -1,0 +1,168 @@
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+	
+	static final char LEFT = 'L'; // 감소 
+	static final char RIGHT = 'R'; // 증가
+	static ArrayList<Line> lines = new ArrayList<>();
+	
+	static int[] dy = {0,-1,0,1};
+	static int[] dx = {1,0,-1,0};
+	
+	static int maxLimit,minLimit,turnCnt,curDir,curX,curY;
+	static long curTime;
+	static Turn[] turns;
+	
+	static class Turn{
+		int after;
+		char dir;
+		
+		public Turn(int after, String dir) {
+			this.after = after;
+			this.dir = dir.charAt(0);
+		}
+	}
+	
+	static class Line{
+		int stX, stY, endX, endY;
+		boolean isVertical;
+		
+		public Line(int stX, int stY, int endX, int endY) {
+
+			isVertical = (stX == endX);
+			if (isVertical) {
+				this.stX = this.endX = stX;
+				this.stY = Math.min(stY, endY);
+				this.endY = Math.max(stY, endY);
+			} else {
+				this.stY = this.endY = stY;
+				this.stX = Math.min(stX, endX);
+				this.endX = Math.max(stX, endX);
+			}
+		}
+		
+		public boolean check(Line l) {
+			// 둘이 크로스되는지, 아니면 평행한지 부터 판단
+			if (this.isVertical && l.isVertical) {
+				if (this.stX != l.stX) return true;
+				if (this.stY > l.endY || this.endY < l.stY) return true; 
+				return false;
+			} else if (!this.isVertical && !l.isVertical){
+				if (this.stY != l.stY) return true;
+				if (this.stX > l.endX || this.endX < l.stX) return true;
+				return false;
+			}else {
+				if (!this.isVertical) {
+					if((this.stY >= l.stY && this.stY <= l.endY)&&
+							(l.stX >= this.stX && l.stX <= this.endX))return false;
+					return true;
+				} else {
+					if((l.stY >= this.stY && l.stY <= this.endY)&&
+							(this.stX >= l.stX && this.stX <= l.endX))return false;
+					return true;
+				}
+			}
+			
+		}
+	}
+
+	
+
+	
+    
+    public static void main(String[] args) throws NumberFormatException, IOException {
+		init();
+		process();
+		print();
+    }
+    
+    public static void init() throws NumberFormatException, IOException {
+    	BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    	maxLimit = Integer.parseInt(br.readLine());
+    	minLimit = maxLimit*(-1);
+    	turnCnt = Integer.parseInt(br.readLine());
+    	turns = new Turn[turnCnt+1];
+    	curDir = 0;
+    	curTime = 0;
+    	curY = 0;
+    	curX = 0;
+    	
+    	for (int i = 0; i < turnCnt; i++) {
+    		StringTokenizer st = new StringTokenizer(br.readLine());
+    		int after = Integer.parseInt(st.nextToken());
+    		String dir = st.nextToken();
+    		turns[i] = new Turn(after,dir);
+    	}
+    	
+ 
+
+
+    	
+    }
+    
+    public static void process() { 	
+    	lines.add(new Line(minLimit, minLimit-1, maxLimit, minLimit-1));
+    	lines.add(new Line(minLimit-1, minLimit, minLimit-1, maxLimit));
+    	lines.add(new Line(maxLimit+1, minLimit, maxLimit+1, maxLimit));
+    	lines.add(new Line(minLimit, maxLimit+1, maxLimit, maxLimit+1));
+    	
+    	turns[turnCnt] = new Turn(1000000000,"L");
+    	
+    	
+    	for(int i = 0 ; i <= turnCnt; i++) {
+    		Turn t = turns[i];
+    		int nX = curX + dx[curDir] * t.after;
+    		int nY = curY + dy[curDir] * t.after;
+    		int minTime = Integer.MAX_VALUE;
+    		boolean isOkay = true;
+    		
+    		
+    		Line nLine = new Line(curX, curY, nX, nY);
+    		
+    		for (Line l: lines) {
+    			
+    			if(!l.check(nLine)) {
+    				int tempMin = Integer.MAX_VALUE;
+    				
+    				if(curDir == 0) tempMin = Math.min(tempMin, l.stX - curX);
+    				if(curDir == 1) tempMin = Math.min(tempMin,  curY - l.endY);
+    				if(curDir == 2) tempMin = Math.min(tempMin, curX - l.endX);
+    				if(curDir == 3) tempMin = Math.min(tempMin, l.stY - curY);
+    				
+    				
+    				if (tempMin == 0) continue;
+    				isOkay = false;
+    				minTime = Math.min(minTime, tempMin);
+    			}
+    		}
+    		
+    		lines.add(nLine);
+    		
+    		
+    		if (isOkay) {
+    			curTime += t.after;
+    			if (t.dir == LEFT) curDir = (curDir +3)%4;
+    			else curDir = (curDir+1)%4;
+    			
+    			curX = nX;
+    			curY = nY;
+    		} else {
+    			curTime += minTime;
+    			return;
+    		}
+    		
+    	}
+
+    }
+
+
+
+
+	public static void print() {
+		System.out.println(curTime);
+    }
+}


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/10875

## 🧭 풀이 시간
80분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
가로 길이와 세로 길이가 모두 2L + 1인 2차원 격자판이 있다. 이 격자판의 각 칸을 그 좌표에 따라 (x, y)로 표현하기로 한다. 격자판의 가운데 칸의 좌표는 (0, 0)이고, 맨 왼쪽 맨 아래 칸의 좌표는 (−L, −L), 그리고 맨 오른쪽 맨 위 칸의 좌표는 (L, L)이다. x좌표는 왼쪽에서 오른쪽으로 갈수록, y좌표는 아래에서 위로 갈수록 증가한다.

이 격자판의 (0, 0) 칸에 한 마리의 뱀이 자리를 잡고 있다. 처음에는 뱀의 크기가 격자판의 한 칸의 크기와 같으며, 뱀의 머리는 격자판의 오른쪽을 바라보고 있다. 이 뱀은 자신이 바라보고 있는 방향으로 1초에 한 칸씩 몸을 늘려나가며, 뱀의 머리는 그 방향의 칸으로 옮겨가게 된다. 예를 들어 위의 그림과 같이 L = 3인 경우를 생각해 보자. 뱀은 처음에 (0, 0)에 있으며, 그 크기는 격자판 한 칸 만큼이고, 뱀의 머리가 바라보고 있는 방향은 오른쪽이다. 1초가 지나고 나면 이 뱀은 몸을 한 칸 늘려서 (0, 0)과 (1, 0)의 두 칸을 차지하게 되며, 이때 (1, 0) 칸에 뱀의 머리가 놓이게 된다. 1초가 더 지나고 나면 (0, 0), (1, 0), (2, 0)의 세 칸을 차지하게 되고, 뱀의 머리는 (2, 0)에 놓이게 된다.

이 뱀은 자신의 머리가 향하고 있는 방향을 일정한 규칙에 따라 시계방향, 혹은 반시계방향으로 90도 회전한다. 1번째 회전은 뱀이 출발한지 t1 초 후에 일어나며 i(i > 1)번째 회전은 i − 1번째 회전이 끝난 뒤 ti 초 후에 일어난다. 단, 뱀은 ti 칸 만큼 몸을 늘린 후에 머리를 회전하며 머리를 회전하는 데에는 시간이 소요되지 않는다고 가정한다.

만일 뱀의 머리가 격자판 밖으로 나가게 되면, 혹은 뱀의 머리가 자신의 몸에 부딪히게 되면 이 뱀은 그 즉시 숨을 거두며 뱀은 숨을 거두기 직전까지 몸을 계속 늘려나간다.

뱀이 머리를 회전하는 규칙, 즉 ti 와 그 방향에 대한 정보가 주어졌을 때, 뱀이 출발한지 몇 초 뒤에 숨을 거두는지를 알아내는 프로그램을 작성하라.

## 🔍 풀이 방법
우선 문제를 보자마자 상어시리즈와 같은 구현 문제임을 알았다.
결국 이전 동선과 겹치는 지를 확인하는 것이 중요했다. 그런데 좌표가 1억까지이기에 이차원배열로 직접할 하나씩 체크할 수는 없다.
단 회전이 1000번이 최대인 것이 포인트였다.  한번 회전할때마다 하나의 선으로 간주하여 기록하면 된다.

새로운 선을 만들때마다 이전 선들과 교차되지는 않는지 확인하면 되는 간단한 로직이 완성된다.
이때 테두리를 나가면 끝나는 것의 경우, 처음부터 경계선바로 밖에 선 네개를 추가해놓으면 된다.


## ⏳ 회고
요즘 다시 재활이 슬슬 되는 것 같다