### PR TITLE
[20250918] BOJ / G3 / 흩날리는 시험지 속에서 내 평점이 느껴진거야 / 이인희

### DIFF
--- a/LiiNi-coder/202509/18 BOJ 흩날리는 시험지 속에서 내 평점이 느껴진거야.md
+++ b/LiiNi-coder/202509/18 BOJ 흩날리는 시험지 속에서 내 평점이 느껴진거야.md
@@ -1,0 +1,50 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        var br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int K = Integer.parseInt(st.nextToken());
+        int[] arr = new int[N];
+        
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+        long left = Arrays.stream(arr).min().getAsInt();
+        long right = 0;
+        for (int x : arr)
+            right += x;
+
+        long answer = 0;
+        while(left <= right) {
+            long mid = (left + right) / 2;
+            int groupCount = 0;
+            long sum = 0;
+            
+            for (int i = 0; i < N; i++) {
+                sum += arr[i];
+                if (sum >= mid) {
+                    groupCount++;
+                    sum = 0;
+                }
+            }
+            
+            if (groupCount >= K) {
+                answer = mid;
+                left = mid + 1;
+            } else {
+                right = mid - 1;
+            }
+        }
+        System.out.println(answer);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17951
## 🧭 풀이 시간
50 분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
- 수열에서 K개 그룹으로 나눌떄, 각 그룹에서 숫자의 합을 구하여, 그중 최솟값이 시험점수인데, 최대 점수를 출력.
## 🔍 풀이 방법
- 출력값을 기준으로 하는 이분탐색
## ⏳ 회고
- 정말 이분탐색일줄 꿈에도 몰랐다.
- K그룹으로 나누는 로직을 조건값을 이분탐색으로 구하며, 그것에 의해 그룹이 정해지는 원리로 구한다는 개념자체가 너무 생소했다.