### PR TITLE
[20250919] BOJ / G5 / 1학년 / 이준희

### DIFF
--- a/JHLEE325/202509/19 BOJ G5 1학년.md
+++ b/JHLEE325/202509/19 BOJ G5 1학년.md
@@ -1,0 +1,37 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+        int[] arr = new int[n];
+        long[][] dp = new long[n - 1][21];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        dp[0][arr[0]] = 1;
+
+        for (int i = 1; i < n - 1; i++) {
+            for (int j = 0; j <= 20; j++) {
+                int plus = j + arr[i];
+                int minus = j - arr[i];
+
+                if (plus <= 20)
+                    dp[i][plus] += dp[i - 1][j];
+                if (minus >= 0)
+                    dp[i][minus] += dp[i - 1][j];
+            }
+        }
+
+        System.out.println(dp[n - 2][arr[n - 1]]);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/5557

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
상근이는 숫자열을 보면 마지막 수 앞에 = 을 붙히고 그 앞 숫자들 사이에는 + 또는 - 를 붙혀서 올바른 등식을 만드는 것을 좋아합니다.

숫자열이 주어졌을 때 올바른 등식을 만들 수 있는 경우의 수를 구하는 문제입니다.

## 🔍 풀이 방법
DP를 활용하여 풀었습니다. dp[i][j] 는 i번째 수 까지 연산 했을 때 j 가 되는 경우의 수로 두어서 i-1 번째의 경우의 수를 더해주면서 풀었습니다.

## ⏳ 회고
다 풀고 제출하려고 테스트케이스를 돌려보니 갑자기 음수가 나오길래 봤더니 overflow 문제였습니다. long, int 판단을 잘 해야겠습니다.
