### PR TITLE
[20250919] BOJ / G1 / K번째 수 / 이강현

### DIFF
--- a/lkhyun/202509/19 BOJ G1 K번째 수.md
+++ b/lkhyun/202509/19 BOJ G1 K번째 수.md
@@ -1,0 +1,52 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main{
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static StringBuilder sb = new StringBuilder();
+    static long N,K;
+
+    public static void main(String[] args) throws Exception {
+        N = Integer.parseInt(br.readLine());
+        K = Integer.parseInt(br.readLine());
+        bw.write(binarySearch(1, N*N) +"");
+        bw.close();
+    }
+    public static long binarySearch(long start, long end){
+        long left = start;
+        long right = end;
+        long mid = 0;
+        while (left <= right) {
+            mid = (left + right) / 2;
+
+            long smaller = 0;
+            long equal = 0;
+            
+            for (int i = 1; i <= N; i++) {
+                long maxJ = mid / i;
+                
+                if (maxJ > N) maxJ = N;
+                
+                if (mid % i == 0 && mid / i <= N) {
+                    smaller += maxJ - 1;
+                    equal++;
+                } else {
+                    smaller += maxJ;
+                }
+            }
+            
+            if (smaller >= K) {
+                right = mid - 1;
+            } else if (smaller + equal >= K) {
+                return mid;
+            } else {
+                left = mid + 1;
+            }
+        }
+        return mid;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1300
## 🧭 풀이 시간
120분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
B[i][j] = i*j 일때, 배열 B에 있는 모든 값들을 오름차순 정렬함.
그리고 K번째 값을 구하라.
## 🔍 풀이 방법
이분탐색
N이 100000이므로 1부터 100억까지의 범위에서 이분 탐색함.
그리고 mid보다 작은 것들의 개수를 구함.
모든 값은 N이하의 값들의 곱으로 나타나므로 N부터 나눠보면서 그 몫이 mid보다 작은 것들의 개수가 됨.
이때 몫이 N보다 큰 경우는 최대 N개만큼만 더해지도록 예외처리 해줌.
## ⏳ 회고
병규와 혁준이와의 이야기를 통해 아이디어를 얻었다. 혼자였으면 못풀었을 것 같다.