### PR TITLE
[20250919] BOJ / D4 / mod와 쿼리 / 권혁준

### DIFF
--- a/khj20006/202509/19 BOJ D4 mod와 쿼리.md
+++ b/khj20006/202509/19 BOJ D4 mod와 쿼리.md
@@ -1,0 +1,99 @@
+```cpp
+#pragma GCC optimize("Ofast")
+#pragma GCC optimize("unroll-loops")
+#include <bits/stdc++.h>
+using namespace std;
+using ll = long long;
+
+ll N, Q, sq=1359;
+pair<ll, ll> seg[262144]{};
+ll a[100001]{}, cnt[100001]{}, q1[100001]{};
+
+pair<ll, ll> operator+(pair<ll, ll> a, pair<ll, ll> b) {
+    return {a.first + b.first, a.second + b.second};
+}
+
+void upd(int s, int e, int i, ll v, int n) {
+    if(s == e) {
+        seg[n].first += v;
+        seg[n].second += v*s;
+        return;
+    }
+    int m = (s+e)>>1;
+    if(i<=m) upd(s,m,i,v,n<<1);
+    else upd(m+1,e,i,v,(n<<1)+1);
+    seg[n] = seg[n<<1] + seg[(n<<1)+1];
+}
+
+pair<ll, ll> find(int s, int e, int l, int r, int n) {
+    if(l>r || l>e || r<s) return {0,0};
+    if(l<=s && e<=r) return seg[n];
+    int m = (s+e)>>1;
+    return find(s,m,l,r,n<<1) + find(m+1,e,l,r,(n<<1)+1);
+}
+
+int main() {
+    cin.tie(0)->sync_with_stdio(0);
+    
+    cin>>N;
+    for(int i=1;i<=N;i++) {
+        cin>>a[i];
+        cnt[a[i]]++;
+        upd(1,100000,a[i],1,1);
+    }
+
+    for(int i=1;i<sq;i++) for(int j=1;j<=N;j++) q1[i] += a[j] % i;
+
+    for(cin>>Q;Q--;) {
+        int op, i, x;
+        cin>>op;
+        if(op == 3) {
+            cin>>i>>x;
+            ll prev = a[i];
+            for(int k=1;k<sq;k++) q1[k] += x%k - prev%k;
+            cnt[prev]--;
+            cnt[x]++;
+            a[i] = x;
+            upd(1,100000,prev,-1,1);
+            upd(1,100000,x,1,1);
+        }
+        else {
+            cin>>x;
+            if(op == 1) {
+                if(x < sq) cout<<q1[x]<<'\n';
+                else {
+                    ll ans = 0;
+                    for(int k=1;(k-1)*x<=100000;k++) {
+                        auto [c,s] = find(1,100000,max(1,(k-1)*x), min(100000,k*x-1),1);
+                        ans += s - c*(k-1)*x;
+                    }
+                    cout<<ans<<'\n';
+                }
+            }
+            else {
+                ll ans = N*x;
+                if(x <= 4) {
+                    for(int p=1;p<=x;p++) ans -= cnt[p] * (x/p) * p;
+                }
+                else {
+                    ans -= cnt[1] * x;
+                    ll prev = x, last = x+1, p = 2;
+                    for(;p<=x/p;p++) {
+                        ll q = x/p;
+                        ll s = find(1,100000,q+1,prev,1).second;
+                        ans -= s*(p-1);
+                        ans -= cnt[p] * q * p;
+                        prev = q;
+                        last = q+1;
+                    }
+                    if(p < last) {
+                        ans -= find(1,100000,p,last-1,1).second*(p-1);
+                    }
+                }
+                cout<<ans<<'\n';
+            }
+        }
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/24547

## 🧭 풀이 시간
150분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
길이 N인 수열에 아래 쿼리를 Q번 처리해보자.
<img width="831" height="171" alt="image" src="https://github.com/user-attachments/assets/c7c1b144-c329-46d3-8d50-e432e9284e71" />

## 🔍 풀이 방법
- 제곱근 분할법
- 세그먼트 트리
---
1번 쿼리를 처리할 때 두 가지 경우로 나눈다.
$X$가 $\sqrt{100000}$보다 클 때는 (전체 합) - ([(k-1)X,kX)에 존재하는 A[i]의 개수) * (k-1)X 를 직접 구해도 $O(\sqrt{100000})$에 처리할 수 있다.
$X$가 $\sqrt{N}$ 이하일 때는 미리 전처리로 배열에 해당 값이 X일 때의 정답을 계산해둔다.
전처리 비용은 $O(N\sqrt{100000})$이고, 값이 바뀔 때 이것도 같이 갱신해주면 $O(\sqrt{100000})$이 된다.
개수를 구할 때 세그먼트 트리가 필요해서 log 시간이 추가로 붙는다.

2,3번 쿼리도 위와 마찬가지로 쿼리당 $O(\sqrt{100000} \times \log{100000})$에 처리할 수 있다.

## ⏳ 회고
$O(N\sqrt{100000}\log{100000})$이 많이 빡센가보다.
상수를 열심히 깎았는데도 안 뚫린다.
내일 세그먼트 트리 대신 펜윅 트리를 적용해서 다시 해봐야겠다