### PR TITLE
[20250919] BOJ / G5 / 극장 좌석 / 이인희

### DIFF
--- a/LiiNi-coder/202509/19 BOJ 극장 좌석.md
+++ b/LiiNi-coder/202509/19 BOJ 극장 좌석.md
@@ -1,0 +1,41 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        var br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        int M = Integer.parseInt(br.readLine());
+        boolean[] vip = new boolean[N + 1];
+
+        for (int i = 0; i < M; i++) {
+            int v = Integer.parseInt(br.readLine());
+            vip[v] = true;
+        }
+
+        int[] dp = new int[N + 1];
+
+        dp[0] = 1;
+        dp[1] = 1;
+        if (N >= 2) dp[2] = 2;
+        for (int i = 3; i <= N; i++) {
+            dp[i] = dp[i - 1] + dp[i - 2]; // 피보나치 쓰
+        }
+
+        int answer = 1;
+        int prev = 0;
+        for (int i = 1; i <= N; i++) {
+            if (vip[i]) {
+                int len = i - prev - 1;
+                answer *= dp[len];
+                prev = i;
+            }
+        }
+        answer *= dp[N - prev];
+
+        System.out.println(answer);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2302
## 🧭 풀이 시간
35 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 1부터 n까지 적힌 좌석이 주루룩 있다. 그런데 vip회원은 자신의 자리에 고정적으로 앉고, 그 나머지 회원은 자신의 좌석의 양옆 및 자신의 좌석에 앉기가 가능. 이럴때, 사람이 앉는 경우의 가짓수 출ㄺ
## 🔍 풀이 방법
- vip좌석을 기준으로 좌석을 나누고 그룹마다의 명수를 기준으로 경우의 수를 dp로 구한다음에 곱하기
## ⏳ 회고
- 피보나치인지 알아내는 것이 꽤 오래걸린 문제