### PR TITLE
[20250920] BOJ / G2 / 가장 긴 증가하는 부분 수열 3 / 이준희

### DIFF
--- a/JHLEE325/202509/20 BOJ G2 가장 긴 증가하는 부분 수열 3.md
+++ b/JHLEE325/202509/20 BOJ G2 가장 긴 증가하는 부분 수열 3.md
@@ -1,0 +1,41 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        int n = Integer.parseInt(br.readLine());
+        int[] arr = new int[n];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int[] lis = new int[n];
+        int size = 0;
+
+        for (int num : arr) {
+            int pos = lowerBound(lis, 0, size, num);
+            lis[pos] = num;
+            if (pos == size) size++;
+        }
+
+        System.out.println(size);
+    }
+
+    static int lowerBound(int[] arr, int left, int right, int num) {
+        while (left < right) {
+            int mid = (left + right) / 2;
+            if (arr[mid] < num) {
+                left = mid + 1;
+            } else {
+                right = mid;
+            }
+        }
+        return left;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/12738

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
-10억 부터 10억 사이의 수로 이루어진 최대 길이가 100만인 수열에서
가장 긴 증가하는 부분 수열의 길이를 구하는 문제입니다.

## 🔍 풀이 방법
이분탐색을 이용해서 풀었습니다.
부분수열을 구성하는 배열을 이용하고 원배열의 원소마다 이분탐색으로 위치할 수 있는 최소 인덱스를 구한 후
갱신해가면서 풀었습니다.

## ⏳ 회고
처음에는 날로 먹으려고 DP로 풀었는데 절대로 시간초과가 해결이 안되서 힌트를 얻어서 풀었습니다.
아는 문제 + 아는 개념이 있다보니 이 개념에서 벗어나지지가 않아서 1시간 동안 고민해도 풀리지가 않았습니다.
