### PR TITLE
[20250920] BOJ / G4 / 인문예술탐사주간 / 한종욱

### DIFF
--- a/Ukj0ng/202509/20 BOJ G4 인문예술탐사주간.md
+++ b/Ukj0ng/202509/20 BOJ G4 인문예술탐사주간.md
@@ -1,0 +1,72 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static int[] trees;
+    private static long[] prefix;
+    private static int N, Q;
+
+    public static void main(String[] args) throws IOException {
+        init();
+
+        while (Q-->0) {
+            int X = Integer.parseInt(br.readLine());
+
+            int pos = binarySearch(X);
+
+            int a = pos;
+            long A = prefix[pos];
+
+            int b = N - pos;
+            long B = prefix[N] - prefix[pos];
+
+            long result = ((long) X * a - A) + (B - (long) X * b);
+            bw.write(result + "\n");
+        }
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        Q = Integer.parseInt(st.nextToken());
+
+        trees = new int[N];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            trees[i] = Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.sort(trees);
+
+        prefix = new long[N+1];
+        for (int i = 0; i < N; i++) {
+            prefix[i+1] = prefix[i] + trees[i];
+        }
+    }
+
+    private static int binarySearch(int n) {
+        int start = 0;
+        int end = N-1;
+
+        while (start <= end) {
+            int mid = start + (end-start)/2;
+
+            if (trees[mid] <= n) {
+                start = mid + 1;
+            } else {
+                end = mid - 1;
+            }
+        }
+
+        return start;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/23829

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
배열과 숫자가 주어졌을 때, 각 원소와 숫자의 차의 합을 구하라. 

## 🔍 풀이 방법
X보다 큰 수와 작은 수로 나누어서 계산한다. 누적합으로 먼저 계산해 놓고, 
- X보다 작은 수가 a개, 합이 A
- X보다 큰 수가 b개, 합이 B
에서 (X * a - A) + (B - X * b)를 계산한다. 

## ⏳ 회고
처음에 하나하나 계산할라했는데 낚시였다.
