### PR TITLE
[20250921] BOJ / G4 / 수들의 합 4 / 이강현

### DIFF
--- a/lkhyun/202509/21 BOJ G4 수들의 합 4.md
+++ b/lkhyun/202509/21 BOJ G4 수들의 합 4.md
@@ -1,0 +1,38 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N,K;
+    static long[] A;
+    
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+        A = new long[N+1];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= N; i++) {
+            A[i] = A[i-1] + Integer.parseInt(st.nextToken());
+        }
+
+        Map<Long, Integer> SumCount = new HashMap<>();
+        long count = 0;
+        
+        SumCount.put(0L, 1);
+        
+        for (int j = 1; j <= N; j++) {
+            long target = A[j] - K;
+            count += SumCount.getOrDefault(target, 0);
+            
+            SumCount.put(A[j], SumCount.getOrDefault(A[j], 0) + 1);
+        }
+        bw.write(count + "\n");
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2015
## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
i부터 j까지의 합이 K가 되는 경우의 수 출력.
## 🔍 풀이 방법
누적합, 맵
입력받을때 누적합 구해놓기
i부터 j까지의 합이 K라는 건
A[j] - A[i-1] = K임.
배열의 앞에서부터 A[j]-K를 집합에서 찾고 있으면 카운트하는 방식.
즉, j가 i의 역할도 함께 하는 것.
## ⏳ 회고
누적합까지 바로 생각하고 투포인터를 써야하나 했는데 값들이 정수라서 고민했다.
정수일때, 누적합을 맵을 통해 구해낼 수 있다는 것을 알게 되었다.