### PR TITLE
[20250921] BOJ / G4 / LCS3 / 이준희

### DIFF
--- a/JHLEE325/202509/21 BOJ G4 LCS3.md
+++ b/JHLEE325/202509/21 BOJ G4 LCS3.md
@@ -1,0 +1,33 @@
+```java
+import java.io.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String a = br.readLine();
+        String b = br.readLine();
+        String c = br.readLine();
+
+        int alength = a.length();
+        int blength = b.length();
+        int clength = c.length();
+
+        int[][][] dp = new int[alength + 1][blength + 1][clength + 1];
+
+        for (int i = 1; i <= alength; i++) {
+            for (int j = 1; j <= blength; j++) {
+                for (int k = 1; k <= clength; k++) {
+                    if (a.charAt(i - 1) == b.charAt(j - 1) && b.charAt(j - 1) == c.charAt(k - 1)) {
+                        dp[i][j][k] = dp[i - 1][j - 1][k - 1] + 1;
+                    } else {
+                        dp[i][j][k] = Math.max(dp[i - 1][j][k],
+                                Math.max(dp[i][j - 1][k], dp[i][j][k - 1]));
+                    }
+                }
+            }
+        }
+
+        System.out.println(dp[alength][blength][clength]);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1958

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
3 문자열의 LCS를 구하는 문제입니다.

## 🔍 풀이 방법
DP를 활용해서 풀었습니다. 일반적인 LCS가 두 문자열이라 이중배열을 사용했다면
이 문제는 3 문자열이기 때문에 3중으로 사용했습니다.

## ⏳ 회고
간단한 LCS 문제였습니다.
