### PR TITLE
[20250921] PGM / LV3 / 다단계 칫솔 판매 / 김수연

### DIFF
--- a/suyeun84/202509/21 PGM LV3 다단계 칫솔 판매.md
+++ b/suyeun84/202509/21 PGM LV3 다단계 칫솔 판매.md
@@ -1,0 +1,38 @@
+```java
+import java.util.*;
+class Solution {
+    static Map<String,Integer> map = new HashMap();
+    static Map<String,String> recommand = new HashMap();
+    public int[] solution(String[] enroll, String[] referral, String[] seller, int[] amount) {
+        int[] count = new int[enroll.length];
+        
+        for(int i =0; i<enroll.length;i++){
+            map.put(enroll[i],0);
+            recommand.put(enroll[i],referral[i]);
+        }
+        
+        for(int i=0; i<seller.length; i++){
+            dfs(seller[i],amount[i]*100);
+        }
+        
+        for(int i=0; i<enroll.length;i++){
+            count[i] = map.get(enroll[i]);
+        }
+        
+        return count;
+
+    }
+    
+    public static void dfs(String name, int income){
+        if(name.equals("-") || income==0){
+            return;
+        }
+        
+        int parents = income/10; 
+        int mine =   income-parents;
+        String next = recommand.get(name);
+        map.replace(name,map.get(name)+mine);
+        dfs(next,parents);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/77486
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
모든 판매원은 자신이 칫솔 판매에서 발생한 이익 뿐만 아니라, 자신이 조직에 추천하여 가입시킨 판매원에게서 발생하는 이익의 10% 까지 자신에 이익이 됨
판매원과 각 판매원을 다단계 조직에 참여시킨 다른 판매원이름이 주어지고,
판매량 집계 데이터의 판매원 이름과 판매량 집계 데이터의 판매 수량이 주어질 때,
각 판매원이 득한 이익금 배열 구하기
## 🔍 풀이 방법
dfs, HashMap 이용
dfs를 돌리면서 각 판매원이 자신을 참여시킨 상위 판매원에서 얼마를 줘야하는지 재귀 돌리면서 쭈우우욱 계산
## ⏳ 회고
문제가 오지게 길어서 어려울 줄 알았는데, 생각보다는 괜춘