### PR TITLE
[20250921] BOJ / G4 / 줄세우기 / 이인희

### DIFF
--- a/LiiNi-coder/202509/21 BOJ 줄세우기.md
+++ b/LiiNi-coder/202509/21 BOJ 줄세우기.md
@@ -1,0 +1,29 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        int[] arr = new int[n];
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(br.readLine());
+        }
+
+        int[] dp = new int[n];
+        Arrays.fill(dp, 1);
+        int lis = 1;
+        
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < i; j++) {
+                if (arr[j] < arr[i]) {
+                    dp[i] = Math.max(dp[i], dp[j] + 1);
+                }
+            }
+            lis = Math.max(lis, dp[i]);
+        }
+        System.out.println(n - lis);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2631
## 🧭 풀이 시간
45 분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
- 1~n까지의 수가 한 줄로 임의로 섞여있음. 이때, 수를 한개씩 옮길수있는데, 옮겨지는 수의 최소 개수를 출력
## 🔍 풀이 방법
- 옮긴 수 개수 구하기==최장부분증가 개수 구하기 이것과 동치
- lis(최장 부분 증가 수열)를 dp로 구함
## ⏳ 회고
- 이것은 dp문제임을 알고 푼 문제이지만, 도대체 어떻게 dp를 할지감이 안옴.
- 그래서 찾아보니, 역으로 생각하는 센스가 필요했음.
- 앞으로 `여사건(역) 으로 생각해보는` 센스도 지녀보자