### PR TITLE
[20250922] BOJ / G5 / 1로 만들기 2 / 이인희

### DIFF
--- a/LiiNi-coder/202509/22 BOJ 1로 만들기2.md
+++ b/LiiNi-coder/202509/22 BOJ 1로 만들기2.md
@@ -1,0 +1,43 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        int[] dp = new int[n + 1];
+        int[] before = new int[n + 1]; //이전 경로
+        
+        dp[1] = 0;
+        for (int i = 2; i <= n; i++) {
+            // 1뻄
+            dp[i] = dp[i - 1] + 1;
+            before[i] = i - 1;
+            // 2로 나눔
+            if (i % 2 == 0&& dp[i] > dp[i / 2] + 1) {
+                dp[i] = dp[i / 2] + 1;
+                before[i] = i / 2;
+            }
+            // 3으로 나눔
+            if (i % 3 == 0 && dp[i] > dp[i / 3] + 1) {
+                dp[i] = dp[i / 3] + 1;
+                before[i] = i / 3;
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(dp[n]).append("\n");
+
+        int cur = n;
+        while (cur > 0) {
+            sb.append(cur).append(" ");
+            if (cur == 1)
+                break;
+            cur = before[cur];
+        }
+        System.out.println(sb);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/12852
## 🧭 풀이 시간
50 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 어떤 수 n을 입력으로 받고 이것에 대해서 연산 3가지가 가능. 첫번짼, 수가 3으로 나눠떨어질때, 3으로 나누기, 두번짼 2, 세번짼 1을 빼는 것. 이렇게 하여서 1로 만드는 가장 최소 연산 개수를 출력 및 그 과정도 출력
## 🔍 풀이 방법
- dp, min(이전dp +1, 2로 나눠떨어질때 dp[n/2] + 1, 3으로 나눠떨어질때 dp[n/3] +1)
## ⏳ 회고
- before을 어떻게 할까에 대해서 생각을 많이 한 문제
- min에 굳이 갇히지않고 저렇게 구현가능하다는 것을 깨달음