### PR TITLE
[20250923] BOJ / G4 / 물통 / 이준희

### DIFF
--- a/JHLEE325/202509/23 BOJ G4 물통.md
+++ b/JHLEE325/202509/23 BOJ G4 물통.md
@@ -1,0 +1,79 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int afull, bfull, cfull;
+    static boolean[][][] visited;
+    static boolean[] possible;
+
+    static class State {
+        int a, b, c;
+        State(int a, int b, int c) {
+            this.a = a;
+            this.b = b;
+            this.c = c;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        afull = Integer.parseInt(st.nextToken());
+        bfull = Integer.parseInt(st.nextToken());
+        cfull = Integer.parseInt(st.nextToken());
+
+        visited = new boolean[afull + 1][bfull + 1][cfull + 1];
+        possible = new boolean[cfull + 1];
+
+        bfs();
+
+        StringBuilder sb = new StringBuilder();
+        for(int i=0;i<possible.length;i++){
+            if(possible[i])
+                sb.append(i+" ");
+        }
+        System.out.println(sb.toString().trim());
+    }
+
+    static void bfs() {
+        Queue<State> q = new LinkedList<>();
+
+        q.offer(new State(0, 0, cfull));
+        visited[0][0][cfull] = true;
+
+        while (!q.isEmpty()) {
+            State cur = q.poll();
+            int a = cur.a, b = cur.b, c = cur.c;
+
+            if (a == 0) {
+                possible[c]=true;
+            }
+
+            move(a, b, c, 0, 1, q);
+            move(a, b, c, 0, 2, q);
+            move(a, b, c, 1, 0, q);
+            move(a, b, c, 1, 2, q);
+            move(a, b, c, 2, 0, q);
+            move(a, b, c, 2, 1, q);
+        }
+    }
+
+    static void move(int a, int b, int c, int from, int to, Queue<State> q) {
+        int[] cur = new int[]{a, b, c};
+        int[] cap = new int[]{afull, bfull, cfull};
+
+        if (cur[from] == 0) return;
+
+        int movewater = Math.min(cur[from], cap[to] - cur[to]);
+        cur[from] -= movewater;
+        cur[to] += movewater;
+
+        int na = cur[0], nb = cur[1], nc = cur[2];
+        if (!visited[na][nb][nc]) {
+            visited[na][nb][nc] = true;
+            q.offer(new State(na, nb, nc));
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2251

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
용량이 각 A, B, C 인 물통이 있고 C에 물이 가득 차 있습니다.
물통에서는 물을 옮길 수 있는데 이 때 한 물통이 비거나 가득 찰 때 까지 옮겨야 합니다.

A 물통이 비어있을 때 C에 들어있는 물의 양을 가능한 모두 구해서 오름차순으로 출력하는 문제입니다.

## 🔍 풀이 방법
BFS를 활용해서 풀었습니다. 삼중배열을 사용하여 방문처리를 하였고 각 단계마다
총 6가지 경우의 수 ( A->B, A->C, B->A ... ) 을 모두 진행하였습니다.

각 단계별로 A가 0인 경우 C의 값을 저장하고 오름차순으로 출력했습니다.

## ⏳ 회고
처음에 문제를 읽고 접근법을 생각해내는데 오래 걸렸는데, 알고나니 쉽게 풀렸습니다.
