### PR TITLE
[20250923] BOJ / G5 / 선수과목 / 이종환

### DIFF
--- a/0224LJH/202509/23 BOJ 선수과목.md
+++ b/0224LJH/202509/23 BOJ 선수과목.md
@@ -1,0 +1,92 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+	
+	static int nodeCnt, preCnt,ans;
+	static Node[] nodes;;
+	static StringBuilder sb = new StringBuilder();
+	
+	
+	static class Node{
+		int semester;
+		int num;
+		int parentCnt;
+		HashSet<Node> children;
+		
+		public Node(int num) {
+			semester = 1;
+			parentCnt = 0;
+			this.num = num;
+			children = new HashSet<>();
+			
+		}
+	}
+
+    public static void main(String[] args) throws NumberFormatException, IOException {
+    	init();
+    	process();
+    	print();
+    	
+
+    }
+    
+    public static void init() throws NumberFormatException, IOException {
+    	BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    	StringTokenizer st = new StringTokenizer(br.readLine());
+    	nodeCnt = Integer.parseInt(st.nextToken());
+    	preCnt = Integer.parseInt(st.nextToken());
+    	nodes = new Node[nodeCnt+1];
+    	for (int i = 1; i <= nodeCnt; i++) {
+    		nodes[i] = new Node(i);
+    	}
+    	
+    	for (int i = 0; i < preCnt; i++) {
+    		st = new StringTokenizer(br.readLine());
+    		int parent = Integer.parseInt(st.nextToken());
+    		int child = Integer.parseInt(st.nextToken());
+    		
+    		nodes[parent].children.add(nodes[child]);
+    		nodes[child].parentCnt++;
+    		
+    	}
+
+    }
+    
+    public static void process() { 	
+    	Queue<Node> pq = new LinkedList<>();
+    	
+    	for (int i = 1; i <= nodeCnt; i++ ) {
+    		
+    		Node node = nodes[i];
+    		if (node.parentCnt ==0) pq.add(node);
+    			
+    	}
+    	
+    	while (!pq.isEmpty()) {
+    		Node node = pq.poll();
+    		for (Node n: node.children ) {
+    			n.parentCnt--;
+    			if (n.parentCnt == 0) {
+    				n.semester = node.semester+1;
+    				pq.add(n);
+    			}
+    		}
+    	}
+
+    	
+    	for (int i = 1; i<= nodeCnt; i++) {
+    		sb.append(nodes[i].semester+ " ");
+    	}
+    }
+
+
+
+	public static void print() {
+		System.out.println(sb.toString());
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14567

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
올해 Z대학 컴퓨터공학부에 새로 입학한 민욱이는 학부에 개설된 모든 전공과목을 듣고 졸업하려는 원대한 목표를 세웠다. 어떤 과목들은 선수과목이 있어 해당되는 모든 과목을 먼저 이수해야만 해당 과목을 이수할 수 있게 되어 있다. 공학인증을 포기할 수 없는 불쌍한 민욱이는 선수과목 조건을 반드시 지켜야만 한다. 민욱이는 선수과목 조건을 지킬 경우 각각의 전공과목을 언제 이수할 수 있는지 궁금해졌다. 계산을 편리하게 하기 위해 아래와 같이 조건을 간소화하여 계산하기로 하였다.

한 학기에 들을 수 있는 과목 수에는 제한이 없다.
모든 과목은 매 학기 항상 개설된다.
모든 과목에 대해 각 과목을 이수하려면 최소 몇 학기가 걸리는지 계산하는 프로그램을 작성하여라.

## 🔍 풀이 방법
전형적인 MST문제이다. 문제 조건도 간단하기에 PQ도 아닌 Queue를 통해 문제를 해결하였다/
## ⏳ 회고
