### PR TITLE
[20250923] BOJ / G3 / 두 단계 최단 경로 2 / 이강현

### DIFF
--- a/lkhyun/202509/23 BOJ G3 두 단계 최단 경로 2.md
+++ b/lkhyun/202509/23 BOJ G3 두 단계 최단 경로 2.md
@@ -1,0 +1,95 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main{
+    static class Edge{
+        int to;
+        long weight;
+        Edge(int to, long weight){
+            this.to = to;
+            this.weight = weight;
+        }
+    }
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static StringBuilder sb = new StringBuilder();
+    static int N,M;
+    static List<Edge>[] adjEdges;
+    static int X,Z;
+    static int P;
+    static long[] distStart;
+    static long[] distEnd;
+
+    public static void main(String[] args) throws Exception {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        adjEdges = new List[N+1];
+        for (int i = 1; i <= N; i++) {
+            adjEdges[i] = new ArrayList<>();
+        }
+
+        distStart = new long[N+1];
+        distEnd = new long[N+1];
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+            long weight = Long.parseLong(st.nextToken());
+
+            adjEdges[from].add(new Edge(to, weight));
+            adjEdges[to].add(new Edge(from, weight));
+        }
+
+        st = new StringTokenizer(br.readLine());
+        X = Integer.parseInt(st.nextToken());
+        Z = Integer.parseInt(st.nextToken());
+
+        P = Integer.parseInt(br.readLine());
+        List<Integer> middleVertex = new ArrayList<>(P);
+        
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < P; i++) {
+            middleVertex.add(Integer.parseInt(st.nextToken()));
+        }
+
+        dijkstra(X, distStart);
+        dijkstra(Z, distEnd);
+
+        long min = Long.MAX_VALUE;
+        for (int Y : middleVertex) {
+            if(distStart[Y] == Long.MAX_VALUE || distEnd[Y] == Long.MAX_VALUE) continue;  // Integer -> Long
+            min = Math.min(min, distStart[Y] + distEnd[Y]);
+        }
+        if(min == Long.MAX_VALUE) bw.write("-1");
+        else bw.write(min + "");
+        bw.close();
+    }
+    
+    public static void dijkstra(int start, long[] dist){
+        PriorityQueue<Edge> pq = new PriorityQueue<>((a,b) -> Long.compare(a.weight,b.weight));  // Integer -> Long
+        Arrays.fill(dist, Long.MAX_VALUE);
+
+        pq.offer(new Edge(start, 0));
+        dist[start] = 0;
+        
+        while(!pq.isEmpty()){
+            Edge cur = pq.poll();
+
+            if(dist[cur.to] < cur.weight) continue;
+
+            for (Edge next : adjEdges[cur.to]) {
+                long newDistance = cur.weight + next.weight;
+                if(newDistance < dist[next.to]){
+                    dist[next.to] = newDistance;
+                    pq.offer(new Edge(next.to, newDistance));
+                }
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/23801
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
X에서 Z로 가는데 Y들을 적어도 하나 거쳐서 가야함.
이때 최단 거리 출력
## 🔍 풀이 방법
다익스트라
X에서 다익, Z에서 다익하고 distX[Y] + distZ[Y]의 최소를 Y들중 구하면댐
## ⏳ 회고
다익스트라를 해야하는데 중간에서 만난다면 양끝에서 해보는 것을 생각해보자!