### PR TITLE
[20250923] BOJ / G3 / Number Reduction / 권혁준

### DIFF
--- a/khj20006/202509/23 BOJ G3 Number Reduction.md
+++ b/khj20006/202509/23 BOJ G3 Number Reduction.md
@@ -1,0 +1,83 @@
+```java
+import java.io.*;
+import java.util.*;
+
+class IOController {
+    BufferedReader br;
+    BufferedWriter bw;
+    StringTokenizer st;
+
+    public IOController() {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        st = new StringTokenizer("");
+    }
+
+    String nextLine() throws Exception {
+        String line = br.readLine();
+        st = new StringTokenizer(line);
+        return line;
+    }
+
+    String nextToken() throws Exception {
+        while (!st.hasMoreTokens())
+            nextLine();
+        return st.nextToken();
+    }
+
+    int nextInt() throws Exception {
+        return Integer.parseInt(nextToken());
+    }
+
+    long nextLong() throws Exception {
+        return Long.parseLong(nextToken());
+    }
+
+    double nextDouble() throws Exception {
+        return Double.parseDouble(nextToken());
+    }
+
+    void close() throws Exception {
+        bw.flush();
+        bw.close();
+    }
+
+    void write(String content) throws Exception {
+        bw.write(content);
+    }
+
+}
+
+public class Main {
+
+    static IOController io;
+
+    //
+
+    static long N;
+    static TreeSet<Long> set = new TreeSet<>();
+
+    public static void main(String[] args) throws Exception {
+
+        io = new IOController();
+
+        N = io.nextLong();
+        set.add(1L);
+        bck(1);
+        io.write(set.size() + "\n");
+
+        io.close();
+
+    }
+
+    static void bck(long s) {
+        for(int i=2;i<=9;i++) if(s*i <= N) {
+            if(!set.contains(s*i) && Long.toString(s*i).contains(Integer.toString(i))) {
+                set.add(s*i);
+                bck(s*i);
+            }
+        }
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/34490

## 🧭 풀이 시간
10분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
정수에 포함되어 있는 **숫자** 중 그 정수를 나눌 수 있는 2 이상의 **숫자**가 있다면, 그 **숫자**로 정수를 나눈다.
정수 k에 이 작업을 반복해서 1로 만들 수 있다면 이 정수를 `valid`하다고 한다.

N이 주어지면, 1부터 N까지의 정수 중 `valid`한 수의 개수를 구해보자.

## 🔍 풀이 방법
- 백트래킹
---
1부터 10^9까지 valid한 수를 다 출력해봤는데, 개수가 2400개 밖에 없었다.
그래서 처음에 1에서 시작해서 백트래킹으로 valid한 수들만 set에 담도록 한 뒤 마지막에 set의 크기를 출력해줬다.

## ⏳ 회고
ez