### PR TITLE
[20250924] BOJ / G5 / 합 분해 / 이준희

### DIFF
--- a/JHLEE325/202509/24 BOJ G5 합 분해.md
+++ b/JHLEE325/202509/24 BOJ G5 합 분해.md
@@ -1,0 +1,34 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static final int mod = 1000000000;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+        
+        int[][] dp = new int[k + 1][n + 1];
+
+        for (int j = 0; j <= n; j++) {
+            dp[1][j] = 1;
+        }
+
+        for (int i = 1; i <= k; i++) {
+            dp[i][0] = 1;
+        }
+
+        for (int i = 2; i <= k; i++) {
+            for (int j = 1; j <= n; j++) {
+                dp[i][j] = dp[i - 1][j] + dp[i][j - 1];
+                if (dp[i][j] >= mod) dp[i][j] = dp[i][j] % mod;
+            }
+        }
+
+        System.out.println(dp[k][n]);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2225

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
n과 k가 주어졌을 때 0부터 n까지의 수 k개를 더해서 n이 되는 경우의 수를 구하는 문제입니다.

덧셈의 순서가 바뀌면 다른 경우로 세며 하나의 수를 여러번 사용할 수 있습니다.

## 🔍 풀이 방법
DP를 활용해서 풀었습니다. dp[i][j] 에서 i개의 수를 써서 j를 만들 수 있는 경우의 수를 구했습니다.

## ⏳ 회고
간단한 dp 였던 것 같았는데 점화식이 생각이 잘 나지 않았습니다
