### PR TITLE
[20250924] BOJ / G5 / Sunny Days / 권혁준

### DIFF
--- a/khj20006/202509/24 BOJ G5 Sunny Days.md
+++ b/khj20006/202509/24 BOJ G5 Sunny Days.md
@@ -1,0 +1,85 @@
+```java
+import java.io.*;
+import java.util.*;
+
+class IOController {
+	BufferedReader br;
+	BufferedWriter bw;
+	StringTokenizer st;
+
+	public IOController() {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		st = new StringTokenizer("");
+	}
+
+	String nextLine() throws Exception {
+		String line = br.readLine();
+		st = new StringTokenizer(line);
+		return line;
+	}
+
+	String nextToken() throws Exception {
+		while (!st.hasMoreTokens())
+			nextLine();
+		return st.nextToken();
+	}
+
+	int nextInt() throws Exception {
+		return Integer.parseInt(nextToken());
+	}
+
+	long nextLong() throws Exception {
+		return Long.parseLong(nextToken());
+	}
+
+	double nextDouble() throws Exception {
+		return Double.parseDouble(nextToken());
+	}
+
+	void close() throws Exception {
+		bw.flush();
+		bw.close();
+	}
+
+	void write(String content) throws Exception {
+		bw.write(content);
+	}
+
+}
+
+public class Main {
+
+	static IOController io;
+
+	//
+
+	static int N;
+	static int[] a, l, r;
+
+	public static void main(String[] args) throws Exception {
+
+		io = new IOController();
+
+		N = io.nextInt();
+		a = new int[N+2];
+		for(int i=1;i<=N;i++) a[i] = io.nextToken().equals("S") ? 1 : 0;
+
+		l = new int[N+2];
+		for(int i=1;i<=N;i++) l[i] = a[i] == 1 ? l[i-1] + 1 : 0;
+		r = new int[N+2];
+		for(int i=N;i>=1;i--) r[i] = a[i] == 1 ? r[i+1] + 1 : 0;
+
+		int ans = 0;
+		for(int i=1;i<=N;i++) {
+			if(a[i] == 0) ans = Math.max(ans, l[i-1] + r[i+1] + 1);
+			else ans = Math.max(ans, Math.max(l[i-1], r[i+1]));
+		}
+		io.write(ans + "\n");
+
+		io.close();
+
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/34457

## 🧭 풀이 시간
10분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
'S'랑 'P'만으로 이루어진 수열이 있다.
원소 하나를 무조건 반대로 바꿔야 할 때, 연속된 'S'의 개수의 최댓값을 구해보자.

## 🔍 풀이 방법
- 누적 합
---
l[i], r[i]를 정의해서 각각 왼쪽, 오른쪽에서부터 i번째 원소까지 연속된 'S'의 개수로 관리한다.
누적 합으로 둘 다 구해줬고, 답을 구할 때는 i번째 원소가 바뀐 경우를 생각한다.
i번째 원소가 'P'인 경우에는 연속된 'S'의 개수가 l[i-1] + r[i+1] + 1이고,
반대인 경우에는 max(l[i-1], r[i+1])개가 된다.

## ⏳ 회고
다른 풀이로 빠지기 쉬운듯