### PR TITLE
[20250924] BOJ / G5 / Steps / 한종욱

### DIFF
--- a/Ukj0ng/202509/23 BOJ G5 Steps.md
+++ b/Ukj0ng/202509/23 BOJ G5 Steps.md
@@ -1,0 +1,42 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        int T = Integer.parseInt(br.readLine());
+
+        while (T-- > 0) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            long x = Long.parseLong(st.nextToken());
+            long y = Long.parseLong(st.nextToken());
+            long d = y - x;
+
+            if (d == 0) {
+                bw.write("0\n");
+                continue;
+            }
+
+            long k = (long) Math.sqrt(d);
+
+            while (k * k < d) k++;
+            while (k * k > d) k--;
+
+            if (k * k == d) {
+                bw.write((2 * k - 1) + "\n");
+            } else if (d <= k * k + k) {
+                bw.write((2 * k) + "\n");
+            } else {
+                bw.write((2 * k + 1) + "\n");
+            }
+        }
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/4395

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
첫 이동과 마지막 이동은 반드시 1칸
이동할 때마다 이전 이동거리의 ±1 or 0 이동 가능

## 🔍 풀이 방법
대칭 구조를 가짐
- `d = k²` → `2k-1`번
- `k² < d ≤ k²+k` → `2k`번
- `k²+k < d ≤ (k+1)²` → `2k+1`번

## ⏳ 회고
x, y가 같은 걸 체크안했다. 