### PR TITLE
[20250925] BOJ / G5 / 숫자고르기 / 이준희

### DIFF
--- a/JHLEE325/202509/25 BOJ G5 숫자고르기.md
+++ b/JHLEE325/202509/25 BOJ G5 숫자고르기.md
@@ -1,0 +1,44 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int n;
+    static int[] arr;
+    static boolean[] visited;
+    static Set<Integer> result = new TreeSet<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+
+        n = Integer.parseInt(br.readLine());
+
+        arr = new int[n +1];
+        for (int i = 1; i <= n; i++) {
+            arr[i] = Integer.parseInt(br.readLine());
+        }
+
+        for (int i = 1; i <= n; i++) {
+            visited = new boolean[n +1];
+            dfs(i, i);
+        }
+
+        sb.append(result.size()).append("\n");
+        for (int x : result) sb.append(x).append("\n");
+        System.out.print(sb);
+    }
+
+    static void dfs(int start, int cur) {
+        if (!visited[cur]) {
+            visited[cur] = true;
+            dfs(start, arr[cur]);
+        } else {
+            if (cur == start) {
+                result.add(cur);
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2668

## 🧭 풀이 시간
75분 +

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
세로로 2줄 N개의 칸으로 이루어진 표가 있고
윗줄은 1 ~ N까지 순서대로
아랫줄은 랜덤으로 이루어져 있습니다.

이 때 윗줄에서 뽑은 정수들의 집합이 바로 아래칸의 정수들의 집합과 같은 경우 중 가장 긴 집합을 구하고 그 원소들을 오름차순으로 출력하는 문제입니다.

## 🔍 풀이 방법
DFS를 활용하여 풀었습니다.
각 원소마다 DFS로 타고타고 들어가서 결국 다시 도착점에 도착하는 경우에 SET에 입력하여 유지했습니다.

## ⏳ 회고
접근 방법이 도저히 생각이 안났습니다.
매우 어려웠던 문제 같은데 골드 5네요..