### PR TITLE
[20250926] BOJ / G4 / 미로만들기 / 이준희

### DIFF
--- a/JHLEE325/202509/26 BOJ G4 미로만들기.md
+++ b/JHLEE325/202509/26 BOJ G4 미로만들기.md
@@ -1,0 +1,64 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int n;
+    static int[][] map;
+    static int[][] dist;
+    static int[] dx = {1, -1, 0, 0};
+    static int[] dy = {0, 0, 1, -1};
+    static final int INF = 987654321;
+
+    static class Node {
+        int x, y;
+        Node(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        map = new int[n][n];
+        dist = new int[n][n];
+
+        for (int i = 0; i < n; i++) {
+            String line = br.readLine();
+            for (int j = 0; j < n; j++) {
+                map[i][j] = line.charAt(j) - '0';
+                dist[i][j] = INF;
+            }
+        }
+
+        bfs();
+        System.out.println(dist[n - 1][n - 1]);
+    }
+
+    static void bfs() {
+        Deque<Node> dq = new ArrayDeque<>();
+        dist[0][0] = 0;
+        dq.add(new Node(0, 0));
+
+        while (!dq.isEmpty()) {
+            Node cur = dq.pollFirst();
+            int x = cur.x, y = cur.y;
+
+            for (int dir = 0; dir < 4; dir++) {
+                int nx = x + dx[dir];
+                int ny = y + dy[dir];
+                if (nx < 0 || ny < 0 || nx >= n || ny >= n) continue;
+
+                int cost = (map[nx][ny] == 0 ? 1 : 0);
+                if (dist[x][y] + cost < dist[nx][ny]) {
+                    dist[nx][ny] = dist[x][y] + cost;
+                    if (cost == 0) dq.addFirst(new Node(nx, ny));
+                    else dq.addLast(new Node(nx, ny));
+                }
+            }
+        }
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2665

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
n*n 모양의 맵에 n^2개의 방이 있는데 이 중 흰방은 지나갈 수 있고 검은방은 지나갈 수 없습니다.

0,0 에서 n-1,n-1 까지의 미로를 만들려고 할 때 흰방으로 바꿔야하는 검은방의 최소 갯수를 구하는 문제입니다.

## 🔍 풀이 방법
0-1 BFS를 활용하여 풀었습니다.
흰방은 코스트가 0, 검은방은 코스트가 1로 계산하여 코스트가 1인 경우에는 큐의 마지막에 집어넣어서 연산을 후순위로 미뤘습니다.
그리고 dist 배열을 갱신해 가며 풀었습니다.

## ⏳ 회고
예전에 0-1BFS 문제를 한 번 풀었던 적이 있는데 그 기억으로 풀었습니다.
