### PR TITLE
[20250927] BOJ / G3 / 괄호 추가하기 / 이강현

### DIFF
--- a/lkhyun/202509/27 BOJ G3 괄호 추가하기.md
+++ b/lkhyun/202509/27 BOJ G3 괄호 추가하기.md
@@ -1,0 +1,56 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main{
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static StringBuilder sb = new StringBuilder();
+    static int N;
+    static String line;
+    static int max = Integer.MIN_VALUE;
+
+    public static void main(String[] args) throws Exception {
+        N = Integer.parseInt(br.readLine());
+        line = br.readLine();
+        
+        dfs(0, Integer.parseInt(String.valueOf(line.charAt(0))));
+        bw.write(max+"");
+        bw.close();
+    }
+    static void dfs(int idx, int cur) {
+        
+        if (idx >= N - 1) {
+            max = Math.max(max, cur);
+            return;
+        }
+        
+        char operator = line.charAt(idx + 1);
+        int nextNum = Integer.parseInt(String.valueOf(line.charAt(idx + 2)));
+        
+        int noBracket = calculate(cur, operator, nextNum);
+        dfs(idx + 2, noBracket);
+        
+        if (idx + 4 < N) {
+            char nextOperator = line.charAt(idx + 3);
+            int nextNextNum = Integer.parseInt(String.valueOf(line.charAt(idx + 4)));
+            
+            int bracketResult = calculate(nextNum, nextOperator, nextNextNum);
+            int Bracket = calculate(cur, operator, bracketResult);
+            dfs(idx + 4, Bracket);
+        }
+    }
+    static int calculate(int a, char op, int b) {
+        if(op == '+'){
+            return a+b;
+        }else if(op == '-'){
+            return a-b;
+        }else if(op == '*'){
+            return a*b;
+        }else{
+            return 0;
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16637
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
연산자간 우선순위는 원래 없음. 무조건 앞에서 부터
괄호를 쓰면 괄호부터 계산함. 괄호는 중첩되지 않음.
이때 괄호를 적절히 써서 수식 결과의 최댓값을 출력.
## 🔍 풀이 방법
브루트포스
앞에서부터 괄호를 넣는 경우와 안 넣는 경우로 분기함.
## ⏳ 회고
문자열 다루는거 헷갈려 ㅠ