### PR TITLE
[20250927] BOJ / G5 / 노드사이의 거리 / 이준희

### DIFF
--- a/JHLEE325/202509/27 BOJ G5 노드사이의 거리.md
+++ b/JHLEE325/202509/27 BOJ G5 노드사이의 거리.md
@@ -1,0 +1,55 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static final int INF = 987654321;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        int[][] dist = new int[n+1][n+1];
+
+
+        for (int i = 1; i <= n; i++) {
+            for (int j = 1; j <= n; j++) {
+                if (i == j) dist[i][j] = 0;
+                else dist[i][j] = INF;
+            }
+        }
+
+        for (int i = 0; i < n - 1; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            int c = Integer.parseInt(st.nextToken());
+            dist[a][b] = c;
+            dist[b][a] = c;
+        }
+
+        for (int k = 1; k <= n; k++) {
+            for (int i = 1; i <= n; i++) {
+                for (int j = 1; j <= n; j++) {
+                    if (dist[i][j] > dist[i][k] + dist[k][j]) {
+                        dist[i][j] = dist[i][k] + dist[k][j];
+                    }
+                }
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+            sb.append(dist[from][to]).append("\n");
+        }
+
+        System.out.print(sb.toString());
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1240

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
노드의 개수와 노드 사이의 거리들이 주어졌을 때
특정 노드 a에서 b까지의 거리를 구하는 문제입니다.

## 🔍 풀이 방법
플로이드-워셜로 모든 노드 사이의 거리를 구한 후
노드 번호들을 받아서 시키는대로 출력했습니다.

## ⏳ 회고
풀고보니 문제 유형에는 플로이드-워셜이 없었는데 노드 갯수가 많았으면 아마 틀렸을 수도 있을 것 같습니다.
