### PR TITLE
[20250928] BOJ / G5 / 알약 / 이준희

### DIFF
--- a/JHLEE325/202509/28 BOJ G5 알약.md
+++ b/JHLEE325/202509/28 BOJ G5 알약.md
@@ -1,0 +1,42 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    
+    static long[][] dp = new long[31][31];
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+
+        while (true) {
+            int n = Integer.parseInt(br.readLine());
+            if (n == 0) {
+                break;
+            }
+            sb.append(countPills(n, 0)).append("\n");
+        }
+        System.out.print(sb);
+    }
+    
+    static long countPills(int w, int h) {
+        if (dp[w][h] != 0) {
+            return dp[w][h];
+        }
+        
+        if (w == 0) {
+            return 1;
+        }
+
+        long result = countPills(w - 1, h + 1);
+        
+        if (h > 0) {
+            result += countPills(w, h - 1);
+        }
+
+        dp[w][h] = result;
+        return result;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/4811

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
매일매일 약 반알을 먹는 할아버지가 있고, 온전한 약 한알을 반으로 나눠서 먹은 후에는 다시 병에 집어넣습니다.

이 때 알약 한조각을 꺼내는 날에는 W, 반쪽자리를 꺼내는 날에는 H 라고 쓸 때

알약 N개를 전부 먹었을 때 가능한 문자열의 가짓수를 구하는 문제입니다.

## 🔍 풀이 방법
2차원 DP를 이용해서 풀었습니다.
dp[w][h] 인 경우가 온전한 알약 w개, 반쪽자리 h개가 있는 경우의 문자열의 가짓수이고
재귀를 이용하여 계속 2차원 배열 값을 갱신했습니다.

수가 커서 메모이제이션을 활용해서 시간을 줄였습니다.

## ⏳ 회고
시간도 없어서 만만하게 봤다가 생각보다 어려웠던 문제였던 것 같습니다.
큰 수 + 여러 케이스 때문에 long, 메모이제이션을 활용했어야 했습니다.
