### PR TITLE
[20250929] BOJ / P2 / 준하의 정수론 과제 (Divmaster) / 권혁준

### DIFF
--- a/khj20006/202509/29 BOJ P2 준하의 정수론 과제 (Divmaster).md
+++ b/khj20006/202509/29 BOJ P2 준하의 정수론 과제 (Divmaster).md
@@ -1,0 +1,163 @@
+```java
+import java.io.*;
+import java.util.*;
+
+class IOController {
+	BufferedReader br;
+	BufferedWriter bw;
+	StringTokenizer st;
+
+	public IOController() {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		st = new StringTokenizer("");
+	}
+
+	String nextLine() throws Exception {
+		String line = br.readLine();
+		st = new StringTokenizer(line);
+		return line;
+	}
+
+	String nextToken() throws Exception {
+		while (!st.hasMoreTokens())
+			nextLine();
+		return st.nextToken();
+	}
+
+	int nextInt() throws Exception {
+		return Integer.parseInt(nextToken());
+	}
+
+	long nextLong() throws Exception {
+		return Long.parseLong(nextToken());
+	}
+
+	double nextDouble() throws Exception {
+		return Double.parseDouble(nextToken());
+	}
+
+	void close() throws Exception {
+		bw.flush();
+		bw.close();
+	}
+
+	void write(String content) throws Exception {
+		bw.write(content);
+	}
+
+}
+
+public class Main {
+
+	static IOController io;
+
+	//
+
+	static int N, Q;
+	static int[] f, g, sieve, max;
+	static long[] sum;
+
+	public static void main(String[] args) throws Exception {
+
+		io = new IOController();
+
+		preprocess(1_000_000);
+
+		N = io.nextInt();
+		Q = io.nextInt();
+		max = new int[N*4];
+		sum = new long[N*4];
+		for(int i=1;i<=N;i++) {
+			int a = io.nextInt();
+			pointUpdate1(1,N,i,a,1);
+			pointUpdate2(1,N,i,g[a],1);
+		}
+
+		while(Q-->0) {
+			int o = io.nextInt();
+			int s = io.nextInt();
+			int e = io.nextInt();
+			if(o == 1) rangeUpdate(1,N,s,e,1);
+			else io.write(find(1,N,s,e,1) + "\n");
+		}
+
+		io.close();
+
+	}
+
+	private static void preprocess(int limit) {
+		sieve = new int[limit+1];
+		for(int i=2;i*i<=limit;i++) if(sieve[i] == 0) for(int j=i*i;j<=limit;j+=i) if(sieve[j] == 0) sieve[j] = i;
+
+		f = new int[limit+1];
+		g = new int[limit+1];
+		f[1] = 1;
+		f[2] = 2;
+		for(int i=3;i<=limit;i++) {
+			int t = i, prev = 0, cnt = 0;
+			f[i] = 1;
+			while(sieve[t] != 0) {
+				if(prev != sieve[t]) {
+					f[i] *= (cnt+1);
+					cnt = 0;
+					prev = sieve[t];
+				}
+				cnt++;
+				t /= sieve[t];
+			}
+			if(t == 1) f[i] *= (cnt+1);
+			else {
+				if(prev == t) f[i] *= (cnt+2);
+				else f[i] *= (cnt+1) * 2;
+			}
+			g[i] = g[f[i]] + 1;
+		}
+	}
+
+	private static void pointUpdate1(int s, int e, int i, int v, int n) {
+		if(s == e) {
+			sum[n] = v;
+			return;
+		}
+		int m = (s+e)>>1;
+		if(i <= m) pointUpdate1(s,m,i,v,n*2);
+		else pointUpdate1(m+1,e,i,v,n*2+1);
+		sum[n] = sum[n*2] + sum[n*2+1];
+	}
+
+	private static void pointUpdate2(int s, int e, int i, int v, int n) {
+		if(s == e) {
+			max[n] = v;
+			return;
+		}
+		int m = (s+e)>>1;
+		if(i <= m) pointUpdate2(s,m,i,v,n*2);
+		else pointUpdate2(m+1,e,i,v,n*2+1);
+		max[n] = Math.max(max[n*2], max[n*2+1]);
+	}
+
+	private static void rangeUpdate(int s, int e, int l, int r, int n) {
+		if(l>r || l>e || r<s) return;
+		if(max[n] == 0) return;
+		if(s == e) {
+			sum[n] = f[(int)sum[n]];
+			max[n] = g[(int)sum[n]];
+			return;
+		}
+		int m = (s+e)>>1;
+		if(max[n*2] > 0) rangeUpdate(s,m,l,r,n*2);
+		if(max[n*2+1] > 0) rangeUpdate(m+1,e,l,r,n*2+1);
+		sum[n] = sum[n*2] + sum[n*2+1];
+		max[n] = Math.max(max[n*2], max[n*2+1]);
+	}
+
+	private static long find(int s, int e, int l, int r, int n) {
+		if(l>r || l>e || r<s) return 0;
+		if(l<=s && e<=r) return sum[n];
+		int m = (s+e)>>1;
+		return find(s,m,l,r,n*2) + find(m+1,e,l,r,n*2+1);
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16136

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
길이 N인 수열에 아래 두 종류의 쿼리를 처리해보자.
- 1 S E : S번째 수부터 E번째 수를 모두 각 수의 약수의 개수로 바꾼다.
- 2 S E : S번째 수부터 E번째 수까지의 합을 출력한다.

## 🔍 풀이 방법
- 에라토스테네스의 체
- 세그먼트 트리
---
어떤 수 N의 약수의 개수는 O(logN)임.
그래서 N을 수렴시키는데 필요한 갱신 횟수가 매우 낮음.

`f(x) = x의 약수의 개수`
`g(x) = x의 남은 갱신 횟수`

1. 선형 체로 소인수분해 -> 모든 f(x), g(x)값 구해놓기
2. g(x)의 max와 f(x)의 합을 관리하는 세그먼트 트리 만들기
3. 1번 쿼리의 구간에서 g가 0이 아닌 구간으로만 들어가고, 거기선 직접 갱신

## ⏳ 회고
자바 추가 시간이 없어서 시간 제한이 좀 빡빡한 듯