### PR TITLE
[20250929] BOJ / G5 / 1로 만들기 2 / 이준희

### DIFF
--- a/JHLEE325/202509/29 BOJ G5 1로 만들기 2.md
+++ b/JHLEE325/202509/29 BOJ G5 1로 만들기 2.md
@@ -1,0 +1,71 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static class Node {
+        int num;
+        int depth;
+        Node prev;
+        Node(int num, int depth, Node prev) {
+            this.num = num;
+            this.depth = depth;
+            this.prev = prev;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+
+        boolean[] visited = new boolean[n + 1];
+        Queue<Node> q = new LinkedList<>();
+        q.offer(new Node(n, 0, null));
+        visited[n] = true;
+
+        Node end = null;
+
+        while (!q.isEmpty()) {
+            Node cur = q.poll();
+
+            if (cur.num == 1) {
+                end = cur;
+                break;
+            }
+
+            if (cur.num - 1 >= 1 && !visited[cur.num - 1]) {
+                visited[cur.num - 1] = true;
+                q.offer(new Node(cur.num - 1, cur.depth + 1, cur));
+            }
+
+            if (cur.num % 2 == 0 && !visited[cur.num / 2]) {
+                visited[cur.num / 2] = true;
+                q.offer(new Node(cur.num / 2, cur.depth + 1, cur));
+            }
+
+            if (cur.num % 3 == 0 && !visited[cur.num / 3]) {
+                visited[cur.num / 3] = true;
+                q.offer(new Node(cur.num / 3, cur.depth + 1, cur));
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(end.depth).append("\n");
+
+        List<Integer> path = new ArrayList<>();
+        while (end != null) {
+            path.add(end.num);
+            end = end.prev;
+        }
+
+        for (int i = path.size()-1; i >= 0; i--) {
+            sb.append(path.get(i) + " ");
+        }
+
+        System.out.println(sb.toString());
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/12852

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
숫자가 주어지고 사용할 수 있는 연산은 아래의 3가지 입니다.
1. X가 3으로 나누어 떨어지면, 3으로 나눈다.
2. X가 2로 나누어 떨어지면, 2로 나눈다.
3. 1을 뺀다.

이 때 숫자 X를 1로 만드는 최소 연산 횟수를 구하고 그 때 각 연산마다 거치는 숫자를 출력하는 문제입니다.

## 🔍 풀이 방법
BFS를 이용해서 풀었습니다.
각 3개의 연산을 모두 수행하면서 연산 단계를 진행하였고
X가 1이 되는 경우 BFS를 종료했습니다.

node 에는 현재 수, 연산 횟수, 이전 숫자를 기록하여 거쳐가는 숫자를 관리할 수 있게 하였습니다.

최종적으로는 루트를 역으로 계산해야하므로 리스트에 입력한 후 거꾸로 꺼내면서 출력했습니다.

## ⏳ 회고
크게 어렵지 않은 BFS 역추적 문제였습니다.
