### PR TITLE
[20250929] BOJ / G5 / 최소 회의실 개수 / 이종환

### DIFF
--- a/0224LJH/202509/29 BOJ 최소 회의실 개수
+++ b/0224LJH/202509/29 BOJ 최소 회의실 개수
@@ -1,0 +1,80 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+class Main {
+	
+	static PriorityQueue<Meeting> mPq = new PriorityQueue<>();
+	static int size,ans;
+	
+	static class Meeting implements Comparable<Meeting>{
+		int start;
+		int end;
+		
+		
+		public Meeting (int start, int end) {
+			this.start = start;
+			this.end = end;
+		}
+		
+		@Override
+		public int compareTo(Meeting m) {
+			return Integer.compare(this.start, m.start);
+		}
+	}
+	
+
+	
+    public static void main(String[] args) throws NumberFormatException, IOException {
+       init();
+       process();
+       print();
+
+    }
+
+    
+    public static void init() throws NumberFormatException, IOException {
+    	BufferedReader br= new BufferedReader(new InputStreamReader(System.in));
+    	size = Integer.parseInt(br.readLine());
+    	
+    	for (int i = 0; i < size; i++) {
+    		StringTokenizer st = new StringTokenizer(br.readLine());
+    		int start = Integer.parseInt(st.nextToken());
+    		int end = Integer.parseInt(st.nextToken());
+    		
+    		Meeting m = new Meeting(start, end);
+    		mPq.add(m);
+    	}
+    	
+
+    }
+    
+    public static void process() throws IOException {   
+    	PriorityQueue<Integer> pq = new PriorityQueue<>();
+    	// pq에 각 회의실 사용이 끝나는 시간을 넣음 -> 가장 작은애가 지금 회의의 시작시간보다 크면 새롭게 추가. 끝.
+    	pq.add(mPq.poll().end);
+    	
+    	while (!mPq.isEmpty()) {
+    		Meeting m = mPq.poll();
+    		
+    		if ( pq.peek() <= m.start) {
+    			pq.poll();
+    		}
+    		pq.add(m.end);
+    			
+    		
+    	}
+    	ans = pq.size();
+    	
+
+
+    }
+    
+
+   public static void print() {
+      System.out.println(ans);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/19598

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
서준이는 아빠로부터 N개의 회의를 모두 진행할 수 있는 최소 회의실 개수를 구하라는 미션을 받았다. 각 회의는 시작 시간과 끝나는 시간이 주어지고 한 회의실에서 동시에 두 개 이상의 회의가 진행될 수 없다. 단, 회의는 한번 시작되면 중간에 중단될 수 없으며 한 회의가 끝나는 것과 동시에 다음 회의가 시작될 수 있다. 회의의 시작 시간은 끝나는 시간보다 항상 작다. N이 너무 커서 괴로워 하는 우리 서준이를 도와주자.

## 🔍 풀이 방법
그리디 + PQ라 생각하면 편하다. 지금 현존하는 회의실 중에, 가장 빨리 회의가 끝나는 회의실의 종료 시각을 확인하고, 그것이 지금 시작해야하는 회의보다 일찍끝나면 종료시각을 갱신, 아니라면 새롭게 회의실을 추가하면 된다.

## ⏳ 회고
내일부턴 진짜 어려운것좀 풀어야지...
