### PR TITLE
[20250930] BOJ / G5 / 가장 긴 짝수 연속한 부분 수열 (large) / 이인희

### DIFF
--- a/LiiNi-coder/202509/30 BOJ 가장 긴 짝수 연속한 부분 수열 (large).md
+++ b/LiiNi-coder/202509/30 BOJ 가장 긴 짝수 연속한 부분 수열 (large).md
@@ -1,0 +1,44 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+        int[] arr = new int[n];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+        int left = 0, right = 0;
+        int odd = 0;
+        int evenCount = 0;
+        int answer = 0;
+        while(right < n) {
+            if (arr[right] % 2 == 0) {
+                evenCount++;
+            }else {
+                odd++;
+            }
+            right++;
+
+            while(odd > k){
+                if(arr[left] % 2== 0) {
+                    evenCount--;
+                } else {
+                    odd--;
+                }
+                left++;
+            }
+            answer = Math.max(answer, evenCount);
+        }
+        
+        
+        System.out.println(answer);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/22862
## 🧭 풀이 시간
50 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 긴 수열이 있고, 이중에서 최대 k개를 삭제할수있음. 그렇게해서 최대 짝수수열의 길이 출력
## 🔍 풀이 방법
- 투포인터
## ⏳ 회고
- 꽤 어려운 투포인터 문제였음