### PR TITLE
[20250930] BOJ / G4 / 뮤탈리스크 / 김민진

### DIFF
--- a/zinnnn37/202509/30 BOJ G4 뮤탈리스크.md
+++ b/zinnnn37/202509/30 BOJ G4 뮤탈리스크.md
@@ -1,0 +1,76 @@
+```java
+import java.io.*;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BJ_12869_뮤탈리스크 {
+
+	private static final int[][] dir = new int[][] {
+			{ 9, 3, 1 },
+			{ 9, 1, 3 },
+			{ 3, 9, 1 },
+			{ 3, 1, 9 },
+			{ 1, 9, 3 },
+			{ 1, 3, 9 }
+	};
+
+	private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+	private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	private static       StringTokenizer st;
+
+	private static int       N;
+	private static int[]     scv;
+	private static int[][][] dp;
+
+	public static void main(String[] args) throws IOException {
+		init();
+		sol();
+	}
+
+	private static void init() throws IOException {
+		N = Integer.parseInt(br.readLine());
+
+		scv = new int[3];
+		st  = new StringTokenizer(br.readLine());
+		for (int i = 0; i < N; i++) {
+			scv[i] = Integer.parseInt(st.nextToken());
+		}
+
+		dp = new int[scv[0] + 1][scv[1] + 1][scv[2] + 1];
+
+		for (int i = 0; i <= scv[0]; i++) {
+			for (int j = 0; j <= scv[1]; j++) {
+				Arrays.fill(dp[i][j], -1);
+			}
+		}
+		dp[scv[0]][scv[1]][scv[2]] = 0;
+	}
+
+	private static void sol() throws IOException {
+		for (int i = scv[0]; i >= 0; i--) {
+			for (int j = scv[1]; j >= 0; j--) {
+				for (int k = scv[2]; k >= 0; k--) {
+					// 도달 불가
+					if (dp[i][j][k] == -1) continue;
+
+					for (int[] d : dir) {
+						int ni = Math.max(i - d[0], 0);
+						int nj = Math.max(j - d[1], 0);
+						int nk = Math.max(k - d[2], 0);
+
+						// 첫 방문 혹은 작은 수
+						if (dp[ni][nj][nk] == -1 || dp[ni][nj][nk] > dp[i][j][k] + 1) {
+							dp[ni][nj][nk] = dp[i][j][k] + 1;
+						}
+					}
+				}
+			}
+		}
+		bw.write(dp[0][0][0] + "");
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[뮤탈리스크](https://www.acmicpc.net/problem/12869)

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
scv를 몰살시킬 수 있는 최소 횟수

## 🔍 풀이 방법
bfs로 푸는 거 좀 반칙같아서 dp로 풀었음
```java
dp[i][j][k] = scv0이 체력 i만큼 남았을 때, scv1이 j .... 일 때 최소 공격 횟수
```
처음은 전부 -1로 초기화하고 초기 체력일 때는 0으로 설정
3중 반복 + 방향 반복 돌리면서 최소값 업데이트

## ⏳ 회고
연휴동안 잠만 잘 거임