### PR TITLE
[20251001] BOJ / P5 / 지폐가 넘쳐흘러 / 권혁준

### DIFF
--- a/khj20006/202510/01 BOJ P5 지폐가 넘쳐흘러.md
+++ b/khj20006/202510/01 BOJ P5 지폐가 넘쳐흘러.md
@@ -1,0 +1,37 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+using ll = long long;
+
+int N, Q, LIMIT;
+ll w[262144]{}, l[524288]{}, r[524288]{}, x[524288]{};
+
+void init(int n) {
+    if(n >= LIMIT) return;
+    init(n*2); init(n*2+1);
+    l[n] = w[n] + max(l[n*2], r[n*2]);
+    r[n] = w[n] + max(l[n*2+1], r[n*2+1]);
+    x[n] = max({x[n*2], x[n*2+1], l[n] + r[n] - w[n]});
+}
+
+int main(){
+    cin.tie(0)->sync_with_stdio(0);
+
+    cin>>N;
+    for(int i=1;i<=N;i++) cin>>w[i];
+    LIMIT = N+1;
+    init(1);
+    cout<<x[1]<<'\n';
+    for(cin>>Q;Q--;) {
+        int i,d;
+        cin>>i>>d;
+        for(w[i]=d;i;i>>=1) {
+            l[i] = w[i] + max(l[i*2], r[i*2]);
+            r[i] = w[i] + max(l[i*2+1], r[i*2+1]);
+            x[i] = max({x[i*2], x[i*2+1], l[i] + r[i] - w[i]});
+        }
+        cout<<x[1]<<'\n';
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17422

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
정점 N개인 포화 이진 트리의 각 정점에는 w[i]만큼의 지폐가 있다.
이 트리에서 `놀이`는 아래 과정으로 이루어진다.
1. 임의의 점을 루트로 잡는다.
2. 루트에서 내려가며 지폐를 수집한다.
3. 이렇게 했을 때 모을 수 있는 지폐 개수의 최댓값을 구한다.

Q번의 놀이를 수행해보자. 각 놀이를 시작하기 전에, 한 정점의 지폐 개수를 임의로 바꾼다.

## 🔍 풀이 방법
- DP
---
`놀이`에서 요구하는 것은 트리의 지름이다.
정점 n에 대해,
$W_n$ = `n번 점의 지폐 개수`
$L_n$ = `n번 점에서 왼쪽으로 내려갔을 때 수집 가능한 최대 지폐 개수`
$R_n$ = `n번 점에서 오른쪽으로 내려갔을 때 수집 가능한 최대 지폐 개수`
$X_n$ = `n번 점을 루트로 하는 서브트리의 지름`
으로 두고 DP를 수행했다.
$L_n = W_n + \max(L_{2n}, R_{2n})$
$R_n = W_n + \max(L_{2n+1}, R_{2n+1})$
$X_n = \max(X_{2n}, X_{2n+1}, L_n + R_n - W_n)$

업데이트가 주어지면 해당 점부터 모든 조상까지 지나가면서 $L, R, X$를 업데이트 해줬다.

## ⏳ 회고
이왜플