### PR TITLE
[20251002] BOJ / G4 / 사탕가게 / 이준희

### DIFF
--- a/JHLEE325/202510/02 BOJ G4 사탕가게.md
+++ b/JHLEE325/202510/02 BOJ G4 사탕가게.md
@@ -1,0 +1,43 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        while (true) {
+            st = new StringTokenizer(br.readLine());
+
+            int n = Integer.parseInt(st.nextToken());
+            int m = (int) (Double.parseDouble(st.nextToken()) * 100.0 + 0.5);
+
+            if (n == 0 && m == 0) {
+                break;
+            }
+
+            int[] dp = new int[m + 1];
+
+            int[] cal = new int[n];
+            int[] price = new int[n];
+
+            for (int i = 0; i < n; i++) {
+                st = new StringTokenizer(br.readLine());
+                cal[i] = Integer.parseInt(st.nextToken());
+                price[i] = (int) (Double.parseDouble(st.nextToken()) * 100.0 + 0.5);
+            }
+
+            for (int i = 1; i <= m; i++) {
+                for (int j = 0; j < n; j++) {
+                    if (i >= price[j]) {
+                        dp[i] = Math.max(dp[i], dp[i - price[j]] + cal[j]);
+                    }
+                }
+            }
+
+            System.out.println(dp[m]);
+        }
+    }
+}```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/4781

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
상근이가 가지고 있는 돈과
사탕의 칼로리, 사탕 가격이 주어졌을 때
상근이가 살 수 있는 사탕의 가장 칼로리가 높은 경우를 구하는 문제입니다.

## 🔍 풀이 방법
DP를 이용해 풀었습니다.
상근이의 지갑 사정과 사탕의 가격이 소수점 2자릿수까지 나타나기 때문에
100을 곱해서 정수로 변환하여 풀었습니다.

## ⏳ 회고
부동 소수점 때문에 100 곱해서 정수 변환 시 0.5를 더해서 해야
234.50 이 실제로 234.49999997 인 경우 같은 것을 해결할 수 있었는데
검색해서 알아보지 않았으면 평생 못풀었습니다.
