### PR TITLE
[20251002] BOJ / G5 / 조 짜기 / 이인희

### DIFF
--- a/LiiNi-coder/202510/02 BOJ 조짜기.md
+++ b/LiiNi-coder/202510/02 BOJ 조짜기.md
@@ -1,0 +1,32 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        int[] arr = new int[N + 1];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for(int i = 1; i <= N; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+        int[] dp = new int[N + 1];
+        dp[0] = 0;
+
+        for(int i = 1; i <= N; i++) {
+            dp[i] = 0;
+            int mx = arr[i];
+            int mn = arr[i];
+            for(int j = i; j >= 1; j--) {
+                mx = Math.max(mx, arr[j]);
+                mn = Math.min(mn, arr[j]);
+                dp[i] = Math.max(dp[i], dp[j-1] + (mx-mn));
+            }
+        }
+
+        System.out.println(dp[N]);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2229
## 🧭 풀이 시간
50 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
n의 길이의 자연수 배열에서 조로 나누는데, 조의 잘짜여진정도를 해당조의 가장 큰값과 작은값의 차이로 정의. 그래서 조의 잘짜여진정도의 합의 최댓값을 출력
## 🔍 풀이 방법
- dp
## ⏳ 회고
- n이 1000이라서 O(엔제곱)도 가능하다 생각하여 접근하였고 실제로 괜찮았다