### PR TITLE
[20251003] BOJ / G4 / 이중 우선순위 큐 / 이종환

### DIFF
--- a/0224LJH/202510/03 BOJ 이중 우선순위 큐
+++ b/0224LJH/202510/03 BOJ 이중 우선순위 큐
@@ -1,0 +1,121 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+	
+	static final String DELETE = "D";
+	static final int MIN= -1;
+	static final int MAX = 1;
+	
+	static BufferedReader br= new BufferedReader(new InputStreamReader(System.in));;
+	static StringBuilder sb = new StringBuilder();
+	static int orderCnt,curIdx;
+	
+	static PriorityQueue<Node> minPq = new PriorityQueue<>();
+	static PriorityQueue<Node> maxPq = new PriorityQueue<>(Collections.reverseOrder());
+	
+	static class Node implements Comparable<Node>{
+		int idx;
+		int num;
+		boolean isAlive = true;
+		
+		public Node(int num) {
+			this.num = num;
+			this.idx = curIdx++;
+		}
+		
+		public int compareTo(Node n) {
+			if ( this.num == n.num) {
+				return Integer.compare(this.idx, n.idx);
+			}
+			return Integer.compare(this.num, n.num);
+		}
+		
+	}
+
+	
+
+    
+    public static void main(String[] args) throws NumberFormatException, IOException {
+    	int TC = Integer.parseInt(br.readLine());
+    	for (int tc  = 1 ; tc <= TC; tc++) {
+    		init();
+    		process();
+
+    	}
+		print();
+    }
+    
+
+    
+    public static void init() throws NumberFormatException, IOException {
+    	orderCnt = Integer.parseInt(br.readLine());
+    	minPq.clear();
+    	maxPq.clear();
+    	curIdx=0;
+	}
+    
+    public static void process() throws IOException { 	
+    	for (int i = 0; i < orderCnt; i++) {
+    		StringTokenizer st = new StringTokenizer(br.readLine());
+    		String order = st.nextToken();
+    		int num = Integer.parseInt(st.nextToken());
+    		if (order.equals(DELETE)) {
+    			// 삭제
+    			if (num == MIN) {
+    				while(!minPq.isEmpty()) {
+    					Node n = minPq.poll();
+    					if (n.isAlive) {
+    						n.isAlive = false;
+    						break;
+    					}
+    				}
+    				
+    			} else if (num == MAX) {
+    				while(!maxPq.isEmpty()) {
+    					Node n = maxPq.poll();
+    					if (n.isAlive) {
+    						n.isAlive = false;
+    						break;
+    					}
+    				}
+    			}
+    			
+    			
+    		} else {
+    			//삽입
+    			Node n = new Node(num);
+    			minPq.add(n);
+    			maxPq.add(n);
+    		}
+    	}
+    	
+    	
+    	while(!minPq.isEmpty() && !minPq.peek().isAlive) {
+    		minPq.poll();
+    	}
+    	
+    	while(!maxPq.isEmpty() && !maxPq.peek().isAlive) {
+    		maxPq.poll();
+    	}   	
+    	
+    	if (maxPq.isEmpty()) {
+    		sb.append("EMPTY").append("\n");
+    	} else {
+    		sb.append(maxPq.poll().num).append(" ").append(minPq.poll().num).append("\n");
+    	}
+
+    }
+    
+
+
+
+	public static void print() {
+		System.out.print(sb);
+
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/7662

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
이중 우선순위 큐(dual priority queue)는 전형적인 우선순위 큐처럼 데이터를 삽입, 삭제할 수 있는 자료 구조이다. 전형적인 큐와의 차이점은 데이터를 삭제할 때 연산(operation) 명령에 따라 우선순위가 가장 높은 데이터 또는 가장 낮은 데이터 중 하나를 삭제하는 점이다. 이중 우선순위 큐를 위해선 두 가지 연산이 사용되는데, 하나는 데이터를 삽입하는 연산이고 다른 하나는 데이터를 삭제하는 연산이다. 데이터를 삭제하는 연산은 또 두 가지로 구분되는데 하나는 우선순위가 가장 높은 것을 삭제하기 위한 것이고 다른 하나는 우선순위가 가장 낮은 것을 삭제하기 위한 것이다.

정수만 저장하는 이중 우선순위 큐 Q가 있다고 가정하자. Q에 저장된 각 정수의 값 자체를 우선순위라고 간주하자.

Q에 적용될 일련의 연산이 주어질 때 이를 처리한 후 최종적으로 Q에 저장된 데이터 중 최댓값과 최솟값을 출력하는 프로그램을 작성하라.

## 🔍 풀이 방법
두 개의 우선순위 큐를 만들고, 진행하면 된다. 이때 양쪽에서 동시에 삭제는 불가능하니, 한쪽에서 처음것을 꺼내 삭제할 시, 그 객체에 표시를 남겨, 나중에 큐의 헤드의 표시를 확인하여 레이지하게 삭제를 진행하면 된다.

## ⏳ 회고
