### PR TITLE
[20251003] BOJ / G2 / 시그마 함수 / 권혁준

### DIFF
--- a/khj20006/202510/03 BOJ G2 시그마 함수.md
+++ b/khj20006/202510/03 BOJ G2 시그마 함수.md
@@ -1,0 +1,34 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+using ll = long long;
+
+ll N;
+
+unordered_set<ll> m;
+bitset<1000001> e;
+vector<ll> p = {2};
+
+void bck(ll n) {
+    for(ll i:p) {
+        if((__int128)n*i > (__int128)N) break;
+        if(m.count(n*i)) continue;
+        m.insert(n*i);
+        bck(n*i);
+    }
+}
+
+int main(){
+    cin.tie(0)->sync_with_stdio(0);
+    
+    for(int i=2;i*i<=1000000;i++) if(!e[i]) for(int j=i*i;j<=1000000;j+=i) e[j] = 1;
+    for(ll i=3;i<=1000000;i++) if(!e[i]) p.push_back(i*i);
+
+    cin>>N;
+    m.insert(1);
+    bck(1);
+    
+    cout<<N-m.size()<<'\n';
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11692

## 🧭 풀이 시간
45분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
1이상 N이하의 수 중, 약수의 합이 짝수인 수의 개수를 구해보자.

## 🔍 풀이 방법
- 에라토스테네스의 체
- 백트래킹
---
홀수인 개수를 구해서 전체에서 빼기

약수 중 홀수의 개수가 짝수개
-> 소인수분해 했을 때 2가 아닌 것들로만 개수 구하기

N = 2^m * a1^p1 * a2^p2 * ...
라고 하면, N의 홀수인 약수의 개수는 (p1+1) * (p2+1) * ...
이게 홀수이려면 pk+1 이 모두 홀수여야 함. == pk가 모두 짝수여야 함.

-> 소인수분해의 결과가, 2를 제외한 다른 소수들은 모두 짝수번 곱해져있는 꼴이어야 함.

1부터 출발해서 DFS느낌으로 백트래킹, 수가 크니까 HashSet으로 중복 방지

## ⏳ 회고
시간 초과가 나야 하는 풀이같은데 억지로 뚫은 느낌...
개어려운데 왜 골드지