### PR TITLE
[20251005] BOJ / G4 / 타일 채우기 / 김민진

### DIFF
--- a/zinnnn37/202510/5 BOJ G4 타일 채우기.md
+++ b/zinnnn37/202510/5 BOJ G4 타일 채우기.md
@@ -1,0 +1,38 @@
+```java
+import java.io.*;
+
+public class BJ_2133_타일_채우기 {
+
+	private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+	private static int   N;
+	private static int[] dp;
+
+	public static void main(String[] args) throws IOException {
+		init();
+		sol();
+	}
+
+	private static void init() throws IOException {
+		N  = Integer.parseInt(br.readLine());
+		dp = new int[N + 1];
+
+		if (N <= 1) return;
+
+		dp[0] = 1;
+		dp[2] = 3;
+	}
+
+	private static void sol() throws IOException {
+		for (int i = 4; i <= N; i += 2) {
+			dp[i] = dp[i - 2] * 4 - dp[i - 4];
+		}
+		bw.write(dp[N] + "\n");
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[타일 채우기](https://www.acmicpc.net/problem/2133)

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
`3 x N` 배열에 `2 x 1` `1 x 2` 타일을 채울 수 있는 경우의 수

## 🔍 풀이 방법
홀수는 무조건 0
짝수는 점화식 세우면 되는데
솔직히 경우의 수 구하는 거 너무 귀찮아서 6이랑 8은 찾아봄 ㅎ

## ⏳ 회고
기차타고싶다