### PR TITLE
[20251005] BOJ / G5 / 내려가기 / 이준희

### DIFF
--- a/JHLEE325/202510/05 BOJ G5 내려가기.md
+++ b/JHLEE325/202510/05 BOJ G5 내려가기.md
@@ -1,0 +1,45 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+
+        int[][] map = new int[n][3];
+        int[][] dpmax = new int[n][3];
+        int[][] dpmin = new int[n][3];
+
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < 3; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+                if (i == 0) {
+                    dpmax[i][j] = dpmin[i][j] = map[i][j];
+                }
+            }
+        }
+
+        for (int i = 1; i < n; i++) {
+            for (int j = 0; j < 3; j++) {
+                if (j == 0) {
+                    dpmax[i][j] = Math.max(dpmax[i - 1][j], dpmax[i - 1][j + 1]) + map[i][j];
+                    dpmin[i][j] = Math.min(dpmin[i - 1][j], dpmin[i - 1][j + 1]) + map[i][j];
+                } else if (j == 1) {
+                    dpmax[i][j] = Math.max(Math.max(dpmax[i - 1][j], dpmax[i - 1][j + 1]), dpmax[i - 1][j - 1]) + map[i][j];
+                    dpmin[i][j] = Math.min(Math.min(dpmin[i - 1][j], dpmin[i - 1][j + 1]), dpmin[i - 1][j - 1]) + map[i][j];
+                } else {
+                    dpmax[i][j] = Math.max(dpmax[i - 1][j], dpmax[i - 1][j - 1]) + map[i][j];
+                    dpmin[i][j] = Math.min(dpmin[i - 1][j], dpmin[i - 1][j - 1]) + map[i][j];
+                }
+            }
+        }
+
+        System.out.println(Math.max(Math.max(dpmax[n - 1][0], dpmax[n - 1][1]), dpmax[n - 1][2]) + " " + Math.min(Math.min(dpmin[n - 1][0], dpmin[n - 1][1]), dpmin[n - 1][2]));
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2096

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
열이 3개이고 n개의 행이 있는 배열이 있을 때 배열을 내려갈 때는 바로 아래에 있거나 그 인접한 칸으로만 내려갈 수 있습니다.
이 때 내려가면서 더한 숫자들이 최대인 값과 최소인 값을 구하는 문제입니다.

## 🔍 풀이 방법
최대, 최소를 구할 dp 배열을 각각 사용해서 내려가면서 풀었습니다. 열이 3개로 적었기 때문에 하드코딩 했습니다.

## ⏳ 회고
간단한 dp 문제였습니다.
