### PR TITLE
[20251006] PGM / Lv2 / 이모티콘 할인행사 / 이강현

### DIFF
--- a/lkhyun/202510/06 PGM Lv2 이모티콘 할인행사.md
+++ b/lkhyun/202510/06 PGM Lv2 이모티콘 할인행사.md
@@ -1,0 +1,49 @@
+```java
+class Solution {
+    static int maxCnt = 0;
+    static int maxSell = 0;
+    public int[] solution(int[][] users, int[] emoticons) {
+        saleCase(users, emoticons, 0, 0, new int[emoticons.length]);
+        return new int[]{maxCnt,maxSell};
+    }
+    public void saleCase(int[][] users, int[] emoticons, int start, int count, int[] selected){
+        if(count == emoticons.length){
+            int curCnt = 0;
+            int curSell = 0;
+            int[] adaption = adaptSale(emoticons,selected);
+            for(int[] user : users){
+                int userTotal = 0;
+                for(int i=0;i<count;i++){
+                    if(selected[i] >= user[0]){
+                        userTotal += adaption[i];
+                    }
+                }
+                if(userTotal >= user[1]){
+                    curCnt++;
+                }else{
+                    curSell += userTotal;
+                }
+            }
+            if(maxCnt < curCnt){
+                maxCnt = curCnt;
+                maxSell = curSell;
+            }else if(maxCnt == curCnt){
+                maxSell = Math.max(maxSell,curSell);
+            }
+            return;
+        }
+        
+        for(int i=1;i<=4;i++){
+            selected[start] = i*10;
+            saleCase(users,emoticons,start+1,count+1,selected);
+        }
+    }
+    public int[] adaptSale(int[] price, int[] rate){
+        int[] adaption = new int[price.length];
+        for(int i=0;i<adaption.length;i++){
+            adaption[i] = (price[i]*(100-rate[i]))/100;
+        }
+        return adaption;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/150368
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
이모티콘을 각각 10,20,30,40 퍼센트중에 하나로 할인 할 수 있음.
사용자들이 주어짐.
사용자들은 이모티콘을 구매할때, 자신의 기준이 있음. 이 기준보다 할인율이 낮으면 구매를 안함.
이모티콘을 적절히 할인해서 사용자들이 많이 구매하도록 유도 해야함.
사용자들은 또한 자신이 이모티콘 구매에 사용한 총 금액이 또 자신만의 기준을 넘으면 모두 환불하고 임티 플러스를 삼.
우리는 다음 두 가지를 최대한 만족하는 경우를 찾으려고 함.
1. 임티 플러스 사는 인원이 가장 많아지도록 할 것.
2. 이모티콘 판매 총액이 최대가 되도록 할 것.
1번 조건이 2번 조건보다 우선함.
이모티콘 할인율을 적절히 조정해서 위 두 조건을 만족할때, 임티 플러스를 산 인원과 이모티콘 판매 총액을 출력.
## 🔍 풀이 방법
백트래킹, 구현
할인율이 4개로 고정이고 이모티콘 수도 7개임.
사용자도 100개가 최대이니 그냥 완탐함.
백트래킹으로 4개의 할인율 각각 다 적용하고 
마지막에 결과 계산함.
## ⏳ 회고
할인율은 (1-할인율)로 금액 계산해야하는데 할인율 쳐 곱해놓고 왜 안되지 이러고 있었음 ㅡㅡ