### PR TITLE
[20251006] BOJ / G4 / 운동 / 이준희

### DIFF
--- a/JHLEE325/202510/06 BOJ G4 운동.md
+++ b/JHLEE325/202510/06 BOJ G4 운동.md
@@ -1,0 +1,52 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static final int INF = 987654321;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int v = Integer.parseInt(st.nextToken());
+        int e = Integer.parseInt(st.nextToken());
+
+        int[][] map = new int[v][v];
+
+        for (int i = 0; i < v; i++) {
+            Arrays.fill(map[i], INF);
+        }
+
+        for (int i = 0; i < e; i++) {
+            st = new StringTokenizer(br.readLine());
+            int s = Integer.parseInt(st.nextToken()) - 1;
+            int d = Integer.parseInt(st.nextToken()) - 1;
+            int c = Integer.parseInt(st.nextToken());
+
+            map[s][d] = c;
+        }
+
+        for (int k = 0; k < v; k++) {
+            for (int i = 0; i < v; i++) {
+                for (int j = 0; j < v; j++) {
+                    map[i][j] = Math.min(map[i][j], map[i][k] + map[k][j]);
+                }
+            }
+        }
+        int res = INF;
+        for (int i = 0; i < v; i++) {
+            for (int j = 0; j < v; j++) {
+                res = Math.min(res, map[i][j] + map[j][i]);
+            }
+        }
+
+        if (res == INF) {
+            System.out.println(-1);
+        } else {
+            System.out.println(res);
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1956

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
각 마을을 잇는 일방통행 도로를 따라서 운동을 하는데
운동을 하고 돌아오는 사이클 중 도로길이의 합이 가장 작은 경우를 구하는 문제입니다.

## 🔍 풀이 방법
플로이드-워셜을 이용하여 모든 마을에 대해 모든 경로를 구해놓고 map[i][j] + map[j][i] 가 존재하는 것 중 최소를 구했습니다.

## ⏳ 회고
골드 4답지 않은 문제였습니다.
