### PR TITLE
[20251006] BOJ / G5 / 종이 접기

### DIFF
--- a/LiiNi-coder/202510/06 BOJ 종이 접기.md
+++ b/LiiNi-coder/202510/06 BOJ 종이 접기.md
@@ -1,0 +1,30 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main{
+    static boolean check(String s){
+        if(s.length() == 1)
+            return true;
+        int mid=s.length() / 2;
+        for(int i=0; i < mid; i++){
+            if(s.charAt(i) == s.charAt(s.length()- 1 - i))
+                return false;
+        }
+        return check(s.substring(0, mid)) && check(s.substring(mid+ 1));
+    }
+
+    public static void main(String[] args)throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int t = Integer.parseInt(br.readLine());
+        StringBuilder sb=new StringBuilder();
+        while(t-->0){
+            sb.append(check(br.readLine() ) ? "YES\n" : "NO\n");
+        }
+
+        System.out.print(sb.toString());
+        br.close();
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1802
## 🧭 풀이 시간
35 분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
- 반갈 종이접기를 여러번 하는것이 가능할때, 종이접기가 된 후보 종이들이 인풋으로 오면 그것마다 반갈 종이접기가 가능한것인지 판ㄷ나
## 🔍 풀이 방법
- 분할정복 + 양옆이 서로 반전되는지 판단
## ⏳ 회고
- 오랜만의 분할정복이라 신선한 문제.