### PR TITLE
[20251006] BOJ / P5 / 비숍 / 한종욱

### DIFF
--- a/Ukj0ng/202510/06 BOJ P5 비숍.md
+++ b/Ukj0ng/202510/06 BOJ P5 비숍.md
@@ -1,0 +1,77 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static boolean[][] board, visited;
+    private static int N, answer;
+
+    public static void main(String[] args) throws IOException {
+        init();
+
+        DFS(0, 0, true);
+        int blackMax = answer;
+        answer = 0;
+
+        visited = new boolean[N][N];
+        DFS(0, 0, false);
+        int whiteMax = answer;
+        answer = blackMax + whiteMax;
+
+        bw.write(answer + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+        answer = 0;
+
+        board = new boolean[N][N];
+        visited = new boolean[N][N];
+
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                if ("1".equals(st.nextToken())) board[i][j] = true;
+            }
+        }
+    }
+
+    private static void DFS(int index, int count, boolean isBlack) {
+        answer = Math.max(answer, count);
+
+        for (int i = index; i < N * N; i++) {
+            int x = i / N;
+            int y = i % N;
+
+            if ((x + y) % 2 == (isBlack ? 0 : 1)) continue;
+
+            if (board[x][y] && canPlace(x, y)) {
+                visited[x][y] = true;
+                DFS(i + 1, count + 1, isBlack);
+                visited[x][y] = false;
+            }
+        }
+    }
+
+    private static boolean canPlace(int x, int y) {
+        for (int i = 1; x+i < N && y+i < N; i++) {
+            if (visited[x+i][y+i]) return false;
+        }
+        for (int i = 1; x+i < N && y-i >= 0; i++) {
+            if (visited[x+i][y-i]) return false;
+        }
+        for (int i = 1; x-i >= 0 && y+i < N; i++) {
+            if (visited[x-i][y+i]) return false;
+        }
+        for (int i = 1; x-i >= 0 && y-i >= 0; i++) {
+            if (visited[x-i][y-i]) return false;
+        }
+        return true;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1799

## 🧭 풀이 시간
90분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
체스판에 제일 많은 비숍을 안 겹치고 둘 수 있는 개수는?

## 🔍 풀이 방법
1. 그냥 생 DFS로 돌리니까 시간초과 발생
2. 백칸과 흑칸으로 나눠 각 칸에서 나올 수 있는 비숍의 최대 개수를 계산하고 더하는 방식의 DFS 사용

## ⏳ 회고
2번 방식은 진짜 생각도 못했다. 또, DFS의 visited를 체크할 땐 모든 걸 다 계산해서 체크하자. 