### PR TITLE
[20251006] BOJ / G5 / 내려가기 / 김민진

### DIFF
--- a/zinnnn37/202510/6 BOJ G5 내려가기.md
+++ b/zinnnn37/202510/6 BOJ G5 내려가기.md
@@ -1,0 +1,72 @@
+```java
+import java.io.*;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BJ_2096_내려가기 {
+
+	private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+	private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	private static       StringTokenizer st;
+
+	private static int N, minAns, maxAns;
+	private static int[][] nums, min, max;
+
+	public static void main(String[] args) throws IOException {
+		init();
+		sol();
+	}
+
+	private static void init() throws IOException {
+		N = Integer.parseInt(br.readLine());
+
+		minAns = Integer.MAX_VALUE;
+		maxAns = 0;
+
+		nums = new int[N][3];
+		min  = new int[N][3];
+		max  = new int[N][3];
+
+		for (int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine());
+			for (int j = 0; j < 3; j++) {
+				nums[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+
+		for (int i = 0; i < N; i++) {
+			Arrays.fill(min[i], Integer.MAX_VALUE);
+		}
+
+		for (int i = 0; i < 3; i++) {
+			min[0][i] = nums[0][i];
+			max[0][i] = nums[0][i];
+		}
+
+	}
+
+	private static void sol() throws IOException {
+		for (int i = 1; i < N; i++) {
+			for (int j = 0; j < 3; j++) {
+				for (int k = j - 1; k <= j + 1; k++) {
+					if (k < 0 || k == 3) continue;
+
+					min[i][j] = Math.min(min[i][j], nums[i][j] + min[i - 1][k]);
+					max[i][j] = Math.max(max[i][j], nums[i][j] + max[i - 1][k]);
+				}
+			}
+		}
+
+		for (int i = 0; i < 3; i++) {
+			minAns = Math.min(minAns, min[N - 1][i]);
+			maxAns = Math.max(maxAns, max[N - 1][i]);
+		}
+
+		bw.write(maxAns + " " + minAns);
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[내려가기](https://www.acmicpc.net/problem/2096)

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
수직 + 대각선으로만 이동 가능할 때 얻을 수 있는 최대값과 최소값

## 🔍 풀이 방법
dp..

## ⏳ 회고
메모리 보면 이렇게 푸는 거 아닌 것 같긴 해..
Java 8은 256이라 이렇게 풀긴 했지만..