### PR TITLE
[20251007] BOJ / G4 / 우유 도시 / 한종욱

### DIFF
--- a/Ukj0ng/202510/07 BOJ G4 우유 도시.md
+++ b/Ukj0ng/202510/07 BOJ G4 우유 도시.md
@@ -1,0 +1,84 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static final int[] dx = {1, 0};
+    private static final int[] dy = {0, 1};
+    private static int[][] map;
+    private static int[][][] dp;
+    private static int N;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        DP();
+
+        int answer = 0;
+        for (int i = 0; i < 3; i++) {
+            answer = Math.max(answer, dp[N-1][N-1][i]);
+        }
+        bw.write(answer + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+
+        map = new int[N][N];
+        dp = new int[N][N][3];
+
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+                Arrays.fill(dp[i][j], -1);
+            }
+        }
+    }
+
+    private static void DP() {
+        if (map[0][0] == 0) dp[0][0][0] = 1;
+        dp[0][0][2] = 0;
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                for (int k = 0; k < 3; k++) {
+                    if (dp[i][j][k] == -1) continue;
+
+                    for (int l = 0; l < 2; l++) {
+                        int nx = i + dx[l];
+                        int ny = j + dy[l];
+
+                        if (OOB(nx, ny)) continue;
+
+                        dp[nx][ny][k] = Math.max(dp[nx][ny][k], dp[i][j][k]);
+                        
+                        int next = (k+1)%3;
+                        if (map[nx][ny] == next) {
+                            dp[nx][ny][next] = Math.max(dp[nx][ny][next], dp[i][j][k]+1);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static boolean OOB(int nx, int ny) {
+        return nx < 0 || nx > N-1 || ny < 0 || ny > N-1;
+    }
+
+    private static boolean canDrink(int current, int next) {
+        if (current == 0 && next == 1) return true;
+
+        if (current == 1 && next == 2) return true;
+
+        if (current == 2 && next == 0) return true;
+
+        return false;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14722

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
오른쪽 또는 아래로만 이동가능하고, 정해진 순서대로 우유를 먹을 때 제일 많은 우유를 먹을 수 있는 개수는?

## 🔍 풀이 방법
`dp[i][j][k] = (i, j)에 도착했을 때, 마지막으로 마신 우유가 k인 경우의 최대 우유 개수`로 상태정의를 한다.

1. 우유 안 마시고 이동
2. 우유 마시고 이동
으로 경우의 수를 나눈 뒤, 갱신

이 때, 초기화도 잘해줘야 한다. 
```
if (map[0][0] == 0) dp[0][0][0] = 1;  // 딸기 마심
dp[0][0][2] = 0;  // 아무것도 안 마심 (다음은 0을 마셔야 함)
```

## ⏳ 회고
내가 틀린 이유는 상태정의를 마지막으로 마신 우유가 아닌 현재 위치의 우유로 생각하고 풀었기 때문이다. 상태정의를 잘못했기 때문에 이후 로직이 맞았어도 틀린 로직이었다. 