### PR TITLE
[20251007] BOJ / G3 / 게리멘더링 / 이준희

### DIFF
--- a/JHLEE325/202510/07 BOJ G3 게리멘더링.md
+++ b/JHLEE325/202510/07 BOJ G3 게리멘더링.md
@@ -1,0 +1,101 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int n;
+    static int[] people;
+    static List<Integer>[] graph;
+    static boolean[] selected;
+    static int res;
+    static int INF = 987654321;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        n = Integer.parseInt(br.readLine());
+        people = new int[n + 1];
+        graph = new ArrayList[n + 1];
+        selected = new boolean[n + 1];
+
+        res = INF;
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= n; i++) {
+            people[i] = Integer.parseInt(st.nextToken());
+            graph[i] = new ArrayList<>();
+        }
+
+        for (int i = 1; i <= n; i++) {
+            st = new StringTokenizer(br.readLine());
+            int cnt = Integer.parseInt(st.nextToken());
+            for (int j = 0; j < cnt; j++) {
+                graph[i].add(Integer.parseInt(st.nextToken()));
+            }
+        }
+
+        dfs(1);
+        if(res==INF){
+            System.out.println(-1);
+        }
+        else{
+            System.out.println(res);
+        }
+    }
+
+    static void dfs(int idx) {
+        if (idx == n + 1) {
+            List<Integer> a = new ArrayList<>();
+            List<Integer> b = new ArrayList<>();
+
+            for (int i = 1; i <= n; i++) {
+                if (selected[i]) a.add(i);
+                else b.add(i);
+            }
+
+            if (a.isEmpty() || b.isEmpty()) return;
+
+            if (checked(a) && checked(b)) {
+                int diff = Math.abs(sum(a) - sum(b));
+                res = Math.min(res, diff);
+            }
+            return;
+        }
+
+        selected[idx] = true;
+        dfs(idx + 1);
+
+        selected[idx] = false;
+        dfs(idx + 1);
+    }
+
+    static boolean checked(List<Integer> area) {
+        if (area.isEmpty()) return false;
+
+        Queue<Integer> q = new LinkedList<>();
+        boolean[] visited = new boolean[n + 1];
+        q.add(area.get(0));
+        visited[area.get(0)] = true;
+        int cnt = 1;
+
+        while (!q.isEmpty()) {
+            int now = q.poll();
+            for (int next : graph[now]) {
+                if (!visited[next] && area.contains(next)) {
+                    visited[next] = true;
+                    q.add(next);
+                    cnt++;
+                }
+            }
+        }
+
+        return cnt == area.size();
+    }
+
+    static int sum(List<Integer> area) {
+        int s = 0;
+        for (int x : area) s += people[x];
+        return s;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17471

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
2개이상 10개 이하의 마을이 있는 나라에서 2개의 당이 선거구를 나눠먹으려고 합니다.
선거구를 나눠먹을 때는 각 당이 최소 1개의 선거구를 갖고 있어야 하고
각 당의 선거구끼리는 연결되어 있어야 합니다.
마을, 마을을 연결하는 길의 정보, 각 마을의 인원수가 주어졌을 때
두 당의 선거구의 인원의 차이가 가장 적은 경우의 인구차이를 구하는 문제입니다.

## 🔍 풀이 방법
조합을 이용해서 각 당의 선거구 리스트를 뽑고
BFS를 이용하여 각 선거구들이 연결되어 있는지 확인한 후
다 통과하는 경우에 인구수를 계산했습니다.

## ⏳ 회고
뭔가 여러가지를 짬뽕해서 풀었는데 크게 어렵지는 않았습니다.
N이 10 이하의 작은 수여서 브루트포스 식으로 모든 조합을 다 찾아도 통과 가능해서 그랬던 것 같기도 합니다.
