### PR TITLE
[20251008] BOJ / G5 / 배열 돌리기 1 / 이준희

### DIFF
--- a/JHLEE325/202510/08 BOJ G5 배열 돌리기 1.md
+++ b/JHLEE325/202510/08 BOJ G5 배열 돌리기 1.md
@@ -1,0 +1,66 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static int n, m, r;
+    static int[][] arr;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        r = Integer.parseInt(st.nextToken());
+
+        arr = new int[n][m];
+
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < m; j++) {
+                arr[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        rotate();
+
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < m; j++) {
+                System.out.print(arr[i][j]+" ");
+            }
+            System.out.println();
+        }
+    }
+
+    static void rotate() {
+        int layers = Math.min(n, m) / 2;
+
+        for (int layer = 0; layer < layers; layer++) {
+            int top = layer;
+            int left = layer;
+            int bottom = n - 1 - layer;
+            int right = m - 1 - layer;
+
+            for (int i = 0; i < r; i++) {
+                int temp = arr[top][left];
+
+                for (int j = left; j < right; j++)
+                    arr[top][j] = arr[top][j + 1];
+
+                for (int j = top; j < bottom; j++)
+                    arr[j][right] = arr[j + 1][right];
+
+                for (int j = right; j > left; j--)
+                    arr[bottom][j] = arr[bottom][j - 1];
+
+                for (int j = bottom; j > top + 1; j--)
+                    arr[j][left] = arr[j - 1][left];
+
+                arr[top + 1][left] = temp;
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16926

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
2차원 배열을 반시계 방향으로 R 번 돌린 결과를 출력하는 문제입니다.

## 🔍 풀이 방법
깡으로 구현했습니다.
레이어의 갯수를 파악한 후 각 레이어 마다
위, 아래, 왼쪽, 오른쪽을 각각 반시계 방향으로 돌렸습니다.

## ⏳ 회고
일단 깡으로 구현하고 시간초과 나면 처리하려 그랬는데 바로 통과했습니다.
