### PR TITLE
[20251008] BOJ / G4 / 백룸 / 한종욱

### DIFF
--- a/Ukj0ng/202510/08 BOJ G4 백룸.md
+++ b/Ukj0ng/202510/08 BOJ G4 백룸.md
@@ -1,0 +1,81 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static int[][] map, dp;
+    private static int[] wall;
+    private static boolean vertical;
+    private static int N, M;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        DP();
+
+        if (dp[N-1][M-1] == -1000000001) bw.write("Entity");
+        else bw.write(dp[N-1][M-1] + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        map = new int[N][M];
+        dp = new int[N][M];
+        wall = new int[4];
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+                dp[i][j] = -1000000001;
+            }
+        }
+
+        st = new StringTokenizer(br.readLine());
+        wall[0] = Integer.parseInt(st.nextToken());
+        wall[1] = Integer.parseInt(st.nextToken());
+        wall[2] = Integer.parseInt(st.nextToken());
+        wall[3] = Integer.parseInt(st.nextToken());
+
+        vertical = wall[1] == wall[3];
+    }
+
+    private static void DP() {
+        dp[0][0] = map[0][0];
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                if (i == 0 && j == 0) continue;
+
+                if (i > 0 && dp[i-1][j] != -1000000001 && canMove(i-1, j, 0)) {
+                    dp[i][j] = Math.max(dp[i][j], dp[i-1][j] + map[i][j]);
+                }
+
+                if (j > 0 && dp[i][j-1] != -1000000001 && canMove(i, j-1, 1)) {
+                    dp[i][j] = Math.max(dp[i][j], dp[i][j-1] + map[i][j]);
+                }
+            }
+        }
+    }
+
+    private static boolean canMove(int x, int y, int dir) {
+        if (vertical && dir == 1) {
+            int x_min = Math.min(wall[0], wall[2]);
+            int x_max = Math.max(wall[0], wall[2]);
+            if ((x_min <= x && x < x_max) && y+1 == wall[1]) return false;
+        } else if (!vertical && dir == 0) {
+            int y_min = Math.min(wall[1], wall[3]);
+            int y_max = Math.max(wall[1], wall[3]);
+            if (x+1 == wall[0] && (y_min <= y && y < y_max)) return false;
+        }
+        return true;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/26259

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
2차원 좌표를 지나갈 때마다, 값을 더하는데 벽은 통과하지 못한다. 최대값은?

## 🔍 풀이 방법
DP다. 간단한 DP인데, 벽을 나타내는 좌표의 순서가 오름차순으로 보장되어 있지 않다.
그것만 조심하면 된다. 

## ⏳ 회고
처음엔 BFS로 접근했다. 방향이 두 개이기 때문에, 방문처리를 안해도 된다고 생각했다. 그렇지만, 방향이 두 개여도 같은 좌표들이 중복으로 들어가면 $2^{n}$으로 개수가 늘어난다. 그래프로 시도했으면 차라리 다익스트라로 했어야 한다고 생각한다. 이제, 최대값을 찾는 다익스트라로. 
-> 그치만 다익스트라도 안되네. 가중치에 음수가 있어서 안되고 벨만-포드도 시간복잡도 때매 안될꺼 같다. 그냥 DP가 최선인듯

다음엔 벽을 나타내는 좌표의 순서가 오름차순으로 보장되어 있는 줄 알고 벽을 기준으로 이동하는 valid 함수를 잘못 작성했다. 