### PR TITLE
[20251008] BOJ / P5 / 전투기 출격 / 권혁준

### DIFF
--- a/khj20006/202510/08 BOJ P5 전투기 출격.md
+++ b/khj20006/202510/08 BOJ P5 전투기 출격.md
@@ -1,0 +1,43 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+using ll = long long;
+
+ll N, M, R, d[101][101]{}, e[101]{}, v[100001]{}, s[100001]{};
+
+int main(){
+    cin.tie(0)->sync_with_stdio(0);
+    
+    cin>>N>>M>>R;
+    for(int i=1;i<=M;i++) for(int j=1;j<=M;j++) cin>>d[i][j];
+    for(int i=1;i<=M;i++) for(int j=1;j<=M;j++) for(int k=1;k<=M;k++) d[j][k] = min(d[j][k], d[j][i] + d[i][k]);
+
+    for(int i=1;i<=M;i++) cin>>e[i];
+
+    for(int p=1,i=1;i<=N;i++) {
+        cin>>v[i];
+        s[i] = s[i-1] + d[p][v[i]];
+        p = v[i];
+    }
+
+    ll mn = 1e18, ans = 1e18;
+    for(int i=1;i<=N;i++) {
+        int l = i, r = N, m = (l+r)>>1;
+        ll f = s[i] + e[v[i]];
+        while(l<r) {
+            ll z = 0;
+            if(m < N) z += d[v[i]][v[m+1]] + s[N]-s[m+1];
+            if(f+z <= R) r = m;
+            else l = m+1;
+            m = (l+r)>>1;
+        }
+        ll cnt = m-i, res = f;
+        if(m < N) res += d[v[i]][v[m+1]] + s[N]-s[m+1];
+        if(res > R) continue;
+        if(cnt < mn || (cnt == mn && res < ans)) mn = cnt, ans = res;
+    }
+    if(mn == 1e18) cout<<-1;
+    else cout<<mn<<' '<<ans;
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/27116

## 🧭 풀이 시간
45분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
M개의 구역이 존재하고, i번 구역에서 j번 구역으로 가는 거리는 d[i][j]이고, 이동할 때는 이만큼의 연료를 소모한다.
i번 구역에 착륙할 때는 f[i]만큼의 연료를 소모한다.
1번 구역에서 출발하여 길이 N인 비행경로를 순서대로 순회하되, **하나의 구역에 착륙**한 뒤 다시 이륙해서 순회해야 한다.
착륙한 구역의 다음 구역부터 연속한 몇 개의 구역을 동료에게 대신 순회하게 할 수 있다.

동료가 순회하는 구역의 최소 개수와 그때 사용하는 연료의 최솟값을 구해주자.

## 🔍 풀이 방법
- 플로이드-워셜
- 누적 합
- 매개 변수 탐색
---
1. 플로이드-워셜 돌리기
2. 비행 경로의 누적 합 구하기

비행 경로의 어떤 지점 i에서 착륙할 때,
동료 조종사가 순회하는 구역 수를 x로 두고 그 때 소모하는 연료를 f(x)로 두면
f(x)는 **감소함수**임.
-> 이분 탐색으로 x를 찾을 수 있음.
한 스텝에 드는 시간복잡도가 상수면 전체는 O(NlogN)으로 가능

## ⏳ 회고
구현이 좀 힘들었다