### PR TITLE
[20251009] BOJ / G5 / 한글 LCS / 이준희

### DIFF
--- a/JHLEE325/202510/09 BOJ G5 한글 LCS.md
+++ b/JHLEE325/202510/09 BOJ G5 한글 LCS.md
@@ -1,0 +1,31 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        
+        String A = br.readLine();
+        String B = br.readLine();
+
+        char[] a = A.toCharArray();
+        char[] b = B.toCharArray();
+
+        int n = a.length;
+        int m = b.length;
+
+        int[][] dp = new int[n + 1][m + 1];
+
+        for (int i = 1; i <= n; i++) {
+            for (int j = 1; j <= m; j++) {
+                if (a[i - 1] == b[j - 1]) dp[i][j] = dp[i - 1][j - 1] + 1;
+                else dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+            }
+        }
+
+        System.out.println(dp[n][m]);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/15482

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
한글 문자열 2개의 LCS를 구하는 문제입니다.

## 🔍 풀이 방법
DP를 이용해서 풀었습니다.

## ⏳ 회고
한글날이라고 한글 이라고 검색해서 나온 문제를 풀었는데
영문 LCS 처럼 그대로 풀었는데도 풀렸습니다.
다 풀고 나서 분류를 봤더니 UTF-8 입력처리 어쩌구가 써있어서 찾아봤더니 자바는 자동으로 처리해준다 합니다
