### PR TITLE
[20251010] BOJ / G5 / 감소하는 수 / 이준희

### DIFF
--- a/JHLEE325/202510/10 BOJ G5 감소하는 수.md
+++ b/JHLEE325/202510/10 BOJ G5 감소하는 수.md
@@ -1,0 +1,39 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static ArrayList<Long> list = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i <= 9; i++) {
+            dfs(i, 1);
+        }
+
+        Collections.sort(list);
+
+        if (n >= list.size()) {
+            System.out.println(-1);
+        } else {
+            System.out.println(list.get(n));
+        }
+    }
+
+    static void dfs(long num, int depth) {
+        list.add(num);
+
+        long lastDigit = num % 10;
+        if (lastDigit == 0) return;
+        
+        for (int next = 0; next < lastDigit; next++) {
+            dfs(num * 10 + next, depth + 1);
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1038

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
큰 자릿수 부터 작은 자릿수까지의 수가 전부 감소한다면 그 수를 감소하는 수라고 합니다.
ex) 321, 9876543210 등
N이 주어졌을 때 N번째 감소하는 수를 출력하는 문제입니다.

## 🔍 풀이 방법
DFS를 이용하여 풀었습니다.
0 ~ 9 까지 중의 숫자 하나가 가장 큰 자릿수인 경우로 시작하는 방식으로 구현했습니다.
예를들면 dfs(5,1) 인 경우 5, 50, 51, 52, 53, 54, 510, 520, 521 ... 이런식으로 구할 수 있도록 dfs를 구현했습니다.

## ⏳ 회고
처음에는 숫자가 말도안된다고 생각해서 손을 못대고 있다가 감소하는 수가 한계가 있다는 것을 생각해내는데 시간이 좀 걸렸던 것 같습니다.
