### PR TITLE
[20251010] PGM / Lv3 / 산 모양 타일링 / 이종환

### DIFF
--- a/0224LJH/202510/10 PGM 산 모양 타일링.md
+++ b/0224LJH/202510/10 PGM 산 모양 타일링.md
@@ -1,0 +1,52 @@
+```java
+import java.io.*;
+import java.util.*;
+
+class Solution {
+    static int size;
+    static boolean[] hasTop;
+    static int[][] dp;
+    
+    static final int EMPTY = 0;
+    static final int LEFT = 1;
+    static final int TOP = 2;
+    static final int RIGHT = 3;
+    static final int REMAINDER = 10007;
+    
+    public int solution(int n, int[] tops) {
+        size = n;
+        hasTop = new boolean[n];
+        dp = new int[size][4];
+
+        for (int i = 0; i < n; i++) hasTop[i] = tops[i] == 1;
+        
+        process();
+        
+        
+        int answer = dp[size-1][EMPTY] + dp[size-1][LEFT] +  dp[size-1][TOP] +  dp[size-1][RIGHT] ;
+        answer %= REMAINDER;
+        return answer;
+    }
+    
+    private void process(){
+        // i번칸의 경우의 수
+        // dp[i][아무것도 안함]=  dp[i-1][모든 경우]
+        // dp[i][왼쪽으로 뻗음] = dp[i-1][왼쪽으로 뻗음] + dp[i-1][위로뻗음] + dp[i-1][아무것도 안함]
+        // dp[i][위로 뻗음] = (top이 있음)? dp[i-1][모든 경우]: 0;
+        // dp[i][오른쪽으로 뻗음] = dp[i-1]모든 경우
+        
+        dp[0][EMPTY] = 1;
+        dp[0][LEFT] = 1;
+        dp[0][RIGHT] = 1;
+        if (hasTop[0]) dp[0][TOP] = 1;
+        
+        for (int i = 1; i < size; i++){
+            int sum = dp[i-1][EMPTY] + dp[i-1][TOP] + dp[i-1][LEFT] + dp[i-1][RIGHT];
+            dp[i][EMPTY] = sum%REMAINDER;
+            dp[i][LEFT] = (sum-dp[i-1][RIGHT])%REMAINDER;
+            dp[i][RIGHT] = sum%REMAINDER;
+            if(hasTop[i]) dp[i][TOP] = sum%REMAINDER;
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/258705

## 🧭 풀이 시간
38분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
사다리꼴의 윗변의 길이를 나타내는 정수 n과 사다리꼴 윗변에 붙인 정삼각형을 나타내는 1차원 정수 배열 tops가 매개변수로 주어집니다. 이때 문제 설명에 따라 만든 모양을 정삼각형 또는 마름모 타일로 빈 곳이 없도록 채우는 경우의 수를 10007로 나눈 나머지를 return 하도록 solution 함수를 완성해 주세요.


## 🔍 풀이 방법
결국 dp이다.

dp[i][j]를 만들어서  i는 몇번 째 뒤집어진 삼각형인지, j는 어느방향으로 마름모를 만들었는 지 (혹은 아예 비웠는 지)에 따라 계산하였다.


## ⏳ 회고
Lv3 중 제일 쉬운듯.