### PR TITLE
[20251011] BOJ / G4 / 램프 / 한종욱

### DIFF
--- a/Ukj0ng/202510/11 BOJ G4 램프.md
+++ b/Ukj0ng/202510/11 BOJ G4 램프.md
@@ -1,0 +1,45 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static Map<String, Integer> map;
+    private static int N, M, K, max;
+
+    public static void main(String[] args) throws IOException {
+        init();
+
+        for (String key : map.keySet()) {
+            char[] chars = key.toCharArray();
+            int count = 0;
+            for (char c : chars) {
+                if (c == '0') count++;
+            }
+
+            if (count <= K && (count%2 == K%2)) max = Math.max(max, map.get(key));
+        }
+
+        bw.write(max+"\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        max = 0;
+
+        map = new HashMap<>();
+
+        for (int i = 0; i < N; i++) {
+            String input = br.readLine();
+            map.put(input, map.getOrDefault(input, 0)+1);
+        }
+        K = Integer.parseInt(br.readLine());
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1034
## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
램프를 킬껀데, 중복으로 가능하다. 행의 최댓값은?
## 🔍 풀이 방법
열을 통째로 움직이기 때문에, 각 행의 램프 패턴을 map에 넣고 각자 확인한다. 

0의 개수를 확인해서, K번 이하로 행을 켤 수 있는지 확인하고 해당 숫자와 K의 홀짝성을 확인해 타당하면 최댓값을 갱신한다. 

## ⏳ 회고
행별로 패턴을 묶을 수 있다는 걸 생각하지 못했다.....