### PR TITLE
[20251012] BOJ / G2 / 두 섬간의 이동 / 한종욱

### DIFF
--- a/Ukj0ng/202510/12 BOJ G2 두 섬간의 이동.md
+++ b/Ukj0ng/202510/12 BOJ G2 두 섬간의 이동.md
@@ -1,0 +1,72 @@
+```
+import java.io.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static int[] uf, size;
+    private static int N;
+    private static long d, bridge;
+
+    public static void main(String[] args) throws IOException {
+        init();
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+        d = 0;
+        bridge = 0;
+
+        uf = new int[N+1];
+        size = new int[N+1];
+
+        for (int i = 1; i <= N; i++) {
+            uf[i] = i;
+            size[i] = 1;
+        }
+
+        for (int i = 0; i < N-1; i++) {
+            int a = Integer.parseInt(br.readLine());
+            int b = a+1;
+
+            int A = find(a);
+            int B = find(b);
+
+            long sizeA = size[A];
+            long sizeB = size[B];
+
+            d -= ((sizeA*(sizeA-1)/2) + (sizeB*(sizeB-1)/2));
+            bridge -= ((sizeA*(sizeA*sizeA-1))/6 + (sizeB*(sizeB*sizeB-1))/6);
+            union(A, B);
+
+            long newSize = sizeA + sizeB;
+
+            d += newSize*(newSize-1)/2;
+            bridge += newSize*(newSize*newSize-1)/6;
+
+            bw.write(d + " " + bridge + "\n");
+        }
+    }
+
+    private static void union(int X, int Y) {
+        if (X == Y) return;
+
+        if (size[X] < size[Y]) {
+            uf[X] = Y;
+            size[Y] += size[X];
+        } else {
+            uf[Y] = X;
+            size[X] += size[Y];
+        }
+    }
+
+    private static int find(int x) {
+        if (uf[x] == x) return x;
+
+        return uf[x] = find(uf[x]);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/10888
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
두 섬간의 다리를 연결할 때, 그 당시의 이동할 수 있는 섬의 쌍 개수와 그때마다 쓰이는 다리의 개수의 합은?
## 🔍 풀이 방법
문제에서 (i, i+1)의 섬을 연결한다. 쌍의 개수와 다리의 합을 변수로 놓고 상태관리를 진행한다. 

각 섬의 root의 size를 기준으로 쌍의 개수와 다리의 합을 빼고, 더한 거의 개수를 더한다.

제일 중요한 것은 점화식이다. (i, i+1)의 섬을 연결하기 때문에, 점화식으로 개수 관리가 가능했다. 
섬의 쌍 개수: $size(size-1)/2$
다리의 합: $size(size^{2}-1)/6$

## ⏳ 회고
섬의 쌍 개수는 아는 점화식인데, 다리의 합은 $1*(n-1) + 2*(n-2) + ... + (n-1)*1$인 걸 아는데 점화식을 못 구해서 클선생에게 점화식을 작성해달라고 했다. 
또, size를 관리할 때 범위 때문에 long으로 했어야 했는데, int로 해서 틀렸다. 