### PR TITLE
[20251012] BOJ / G5 / 수 고르기 / 이준희

### DIFF
--- a/JHLEE325/202510/12 BOJ G5 수 고르기.md
+++ b/JHLEE325/202510/12 BOJ G5 수 고르기.md
@@ -1,0 +1,44 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        int[] arr = new int[n];
+
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(br.readLine());
+        }
+
+        Arrays.sort(arr);
+
+        int left = 0;
+        int right = 0;
+        int ans = Integer.MAX_VALUE;
+
+        while (right < n) {
+            int diff = arr[right] - arr[left];
+
+            if (diff < m) {
+                right++;
+                continue;
+            }
+            if (diff == m) {
+                ans = m;
+                break;
+            }
+            ans = Math.min(ans, diff);
+            left++;
+
+        }
+
+        System.out.println(ans);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2230

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
주어진 수열에서 두 수를 골랐을 때 차이가 m 이상인 것 중 가장 작은 것을 구하는 문제입니다.

## 🔍 풀이 방법
배열을 정렬한 후 포인터 2개를 이용해서 풀었습니다.

## ⏳ 회고
적당한 큰 수를 항상 987654321 로 설정했었는데 m값이 최대 20억이었어서 헛짓거리를 했습니다.
