### PR TITLE
[20251012] BOJ / G5 / 다이어트 / 이강현

### DIFF
--- a/lkhyun/202510/12 BOJ G5 다이어트.md
+++ b/lkhyun/202510/12 BOJ G5 다이어트.md
@@ -1,0 +1,41 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main{
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringBuilder sb = new StringBuilder();
+    static int G;
+
+    public static void main(String[] args) throws Exception {
+        G = Integer.parseInt(br.readLine());
+        List<Integer> results = new ArrayList<>();
+        for (int b = 1; b * b <= G; b++) {
+            if (G % b == 0) {
+                int a = G / b;
+                
+                if ((a + b) % 2 == 0) {
+                    int c = (a + b) / 2;
+                    int p = (a - b) / 2;
+                    
+                    if (p >= 1) {
+                        results.add(c);
+                    }
+                }
+            }
+        }
+        
+        if (results.isEmpty()) {
+            bw.write("-1");
+        } else {
+            Collections.sort(results);
+            for (int weight : results) {
+                bw.write(weight + "\n");
+            }
+        }
+        
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1484
## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
G가 주어짐.
G는 성원이의 현재 몸무게의 제곱에서 기억하고 있는 몸무게의 제곱을 뺀것임.
이때 가능한 현재 몸무게를 모두 출력.
## 🔍 풀이 방법
수학
(x-y)(x+y) = G라는 공식인데
G의 약수를 구하기
이때 x와 y각각이 자연수가 되려면 x-y와 x+y가 짝수가 되어야 한다.
## ⏳ 회고
x와 y각각이 자연수가 되려면 x-y와 x+y가 짝수여야 한다는것을 몰라서 못풀었다.