### PR TITLE
[20251013] BOJ / P4 / 체커 / 이종환

### DIFF
--- a/0224LJH/202510/13 BOJ 체커.md
+++ b/0224LJH/202510/13 BOJ 체커.md
@@ -1,0 +1,98 @@
+```java
+
+import java.awt.Point;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+	
+	static class Node{
+		int idx;
+		int x,y;
+		public Node(int idx, int x, int y) {
+			this.idx = idx;
+			this.x = x;
+			this.y = y;
+		}
+	}
+	
+	static int nodeCnt;
+	static Node[] nodes;
+	static int[] ans;
+	static List<Point> list;
+
+	static StringBuilder sb = new StringBuilder();
+    
+    public static void main(String[] args) throws NumberFormatException, IOException {
+        init();
+        process();
+        print();
+
+    }
+    
+
+    
+    public static void init() throws NumberFormatException, IOException {
+    	BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    	nodeCnt = Integer.parseInt(br.readLine());
+    	nodes = new Node[nodeCnt];
+    	ans = new int[nodeCnt];
+    	for (int i = 0; i < nodeCnt; i++) {
+    		StringTokenizer st = new StringTokenizer(br.readLine());
+    		int x = Integer.parseInt(st.nextToken());
+    		int y = Integer.parseInt(st.nextToken());
+    		nodes[i] = new Node(i, x,y);
+    		
+    	}
+    	
+	}
+    
+    public static void process() throws IOException { 	
+    	
+    	Arrays.fill(ans, Integer.MAX_VALUE);
+    	
+    	list = new ArrayList<>(); // 모든 후보 지점 리스트
+    	for (int i = 0; i < nodeCnt; i++) {
+    		for (int j = 0; j < nodeCnt; j++) {
+    			list.add(new Point(nodes[i].x, nodes[j].y));
+    		}
+    	}
+    	calculte();
+    	
+    	
+    	for (int i = 0; i < nodeCnt; i++) {
+    		sb.append(ans[i]).append(" ");
+    	}
+    }
+    
+    private static void calculte() {
+    	for (Point p: list) {
+    		int x =p.x;
+    		int y = p.y;
+    		
+    		PriorityQueue<Node> pq = new PriorityQueue<>(
+    				(a,b) -> (Math.abs(x - a.x) + Math.abs(y - a.y)) - (Math.abs(x - b.x) + Math.abs(y - b.y)) );
+    		for (Node n: nodes) pq.add(n);
+    		
+    		int distanceSum = 0;
+    		for (int i = 0; i < nodeCnt; i++) {
+    			Node n = pq.poll();
+    			distanceSum += Math.abs(x - n.x) + Math.abs(y - n.y);
+    			
+    			ans[i] = Math.min(ans[i], distanceSum);
+    		}
+    	}
+    }
+   
+    
+
+
+
+	public static void print() {
+		System.out.println(sb.toString());
+
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1090

## 🧭 풀이 시간
100분

## 👀 체감 난이도

- [x] 상
- [ ] 중
- [ ] 하


## ✏️ 문제 설명
N개의 체커가 엄청 큰 보드 위에 있다. i번 체커는 (xi, yi)에 있다. 같은 칸에 여러 체커가 있을 수도 있다. 체커를 한 번 움직이는 것은 그 체커를 위, 왼쪽, 오른쪽, 아래 중의 한 방향으로 한 칸 움직이는 것이다.

첫째 줄에 N이 주어진다. N은 50보다 작거나 같은 자연수이다. 둘째 줄부터 N개의 줄에 각 체커의 x좌표와 y좌표가 주어진다. 이 값은 1,000,000보다 작거나 같은 자연수이다.

첫째 줄에 수 N개를 출력한다. k번째 수는 적어도 k개의 체커가 같은 칸에 모이도록 체커를 이동해야 하는 최소 횟수이다.

## 🔍 풀이 방법
처음에는 엄청 해맸다. 그러다가 힌트로 모이는 지점의 좌표가 중앙값에 가까운 값이라는 힌트를 보고, 각각의 점이 아니라 모이는 지점이 될 수 있는 후보 지점들 위주로 생각했다.

가능한 후보 지점 위치에서의 거리를 정렬 기준으로 하는 PQ를 만든 후, 모든 노드를 PQ에 넣는다.
이후 하나씩 꺼내며 후보 지점과의 거리 차이를 합한다. i번째를 꺼냈을 때의 값이, 그 지점으로 i개의 노드가 모였을 때 이동거리의 최솟값이다.

이 과정을 모든 후보 지점에서 진행하면, 알아서 답이 나온다.

## ⏳ 회고
상어시리즈처럼 무식한 구현이 아닌데 어려운 로직없이 플레인게 재밌었다.
