### PR TITLE
[20251013] BOJ / G5 / 계란으로 계란치기 / 이준희

### DIFF
--- a/JHLEE325/202510/13 BOJ G5 계란으로 계란치기.md
+++ b/JHLEE325/202510/13 BOJ G5 계란으로 계란치기.md
@@ -1,0 +1,60 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int n;
+    static int[] str, weight;
+    static int answer = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        str = new int[n];
+        weight = new int[n];
+
+        for (int i = 0; i < n; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            str[i] = Integer.parseInt(st.nextToken());
+            weight[i] = Integer.parseInt(st.nextToken());
+        }
+
+        dfs(0);
+        System.out.println(answer);
+    }
+
+    static void dfs(int idx) {
+        if (idx == n) {
+            int broken = 0;
+            for (int i = 0; i < n; i++) {
+                if (str[i] <= 0) broken++;
+            }
+            answer = Math.max(answer, broken);
+            return;
+        }
+
+        if (str[idx] <= 0) {
+            dfs(idx + 1);
+            return;
+        }
+
+        boolean hit = false;
+
+        for (int i = 0; i < n; i++) {
+            if (i == idx || str[i] <= 0) continue;
+
+            hit = true;
+
+            str[idx] -= weight[i];
+            str[i] -= weight[idx];
+
+            dfs(idx + 1);
+
+            str[idx] += weight[i];
+            str[i] += weight[idx];
+        }
+
+        if (!hit) dfs(idx + 1);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16987

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
계란으로 계란을 깰 때 계란은 각 계란의 무게만큼 내구도가 깎이고 내구도가 0이하가 되면 깨집니다.
이 때 최대한 많은 계란을 쳐서 깨는 경우를 구하는 문제입니다.

## 🔍 풀이 방법
dfs로 모든 경우의 수를 다 돌아서 계산했습니다.

## ⏳ 회고
뭔가 좀 노가다인 것 같았는데 2초라 여유 있었던 것 같습니다.
