### PR TITLE
[20251013] BOJ / G5 / 계란으로 계란치기 / 김수연

### DIFF
--- a/suyeun84/202510/13 BOJ G5 계란으로 계란치기.md
+++ b/suyeun84/202510/13 BOJ G5 계란으로 계란치기.md
@@ -1,0 +1,59 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class boj16987 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static void nextLine() throws Exception { st = new StringTokenizer(br.readLine()); }
+    static int nextInt() { return Integer.parseInt(st.nextToken()); }
+    
+    static int N, answer = 0;
+	public static void main(String[] args) throws Exception {
+		nextLine();
+		N = nextInt();
+		Egg[] eggs = new Egg[N];
+		for (int i = 0; i < N; i++) {
+			nextLine();
+			eggs[i] = new Egg(nextInt(), nextInt());
+		}
+		
+		dfs(0, eggs);
+		System.out.println(answer);
+	}
+	
+	public static void dfs(int idx, Egg[] eggs) {
+		if (idx == N) {
+			int cnt = 0;
+			for (int i = 0; i < N; i++) {
+				if (eggs[i].s <= 0) cnt++;
+			}
+			answer = Math.max(answer, cnt);
+			return;
+		}
+		if (eggs[idx].s < 0) dfs(idx+1, eggs);
+		else {
+			boolean flag = true;
+			for (int i = 0; i < N; i++) {
+				if (eggs[i].s <= 0 || idx == i) continue;
+				flag = false;
+				eggs[i].s -= eggs[idx].w;
+				eggs[idx].s -= eggs[i].w;
+				dfs(idx+1, eggs);
+				eggs[i].s += eggs[idx].w;
+				eggs[idx].s += eggs[i].w;
+			}
+			if (flag) dfs(idx+1, eggs);
+		}
+	}
+	
+	static class Egg {
+		int s, w;
+		public Egg(int s, int w) {
+			this.s = s;
+			this.w = w;
+		}
+	}
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16987
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
계란으로 계란을 치는데, 각 계란의 내구성에서 무게만큼 줄어들고 0이하가 되면 깨진다.
이때, 최대 몇 개의 계란을 깰 수 있는지 구하기
## 🔍 풀이 방법
dfs 이용
모든 경우 돌리면서 깨진 갯수가 가장 많은거 찾음
근데 계란 하나도 못깻을 때 다음으로 넘어가는 로직 작성을 해줘야됐음..
## ⏳ 회고
아옹..꼼꼼히 풀자..