### PR TITLE
[20251013] BOJ / G5 / 괄호의 값 / 설진영

### DIFF
--- a/Seol-JY/202510/13 BOJ G5 괄호의 값.md
+++ b/Seol-JY/202510/13 BOJ G5 괄호의 값.md
@@ -1,0 +1,58 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String s = br.readLine();
+        
+        System.out.println(solution(s));
+    }
+    
+    static int solution(String s) {
+        Deque<Character> deque = new ArrayDeque<>();
+        int result = 0;
+        int temp = 1;
+        
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            
+            if (c == '(') {
+                deque.push(c);
+                temp *= 2;
+            } 
+            else if (c == '[') {
+                deque.push(c);
+                temp *= 3;
+            } 
+            else if (c == ')') {
+                if (deque.isEmpty() || deque.peek() != '(') {
+                    return 0;
+                }
+                
+                if (s.charAt(i - 1) == '(') {
+                    result += temp;
+                }
+                
+                deque.pop();
+                temp /= 2;
+            } 
+            else if (c == ']') {
+                if (deque.isEmpty() || deque.peek() != '[') {
+                    return 0;
+                }
+                
+                if (s.charAt(i - 1) == '[') {
+                    result += temp;
+                }
+                
+                deque.pop();
+                temp /= 3;
+            }
+        }
+        
+        return deque.isEmpty() ? result : 0;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2504

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
괄호열의 값을 계산하는 문제 () = 2, [] = 3이고, (X) = 2×X, [X] = 3×X로 계산함. 연속된 괄호는 덧셈, 올바르지 않은 괄호열은 0 출력

## 🔍 풀이 방법
ArrayDeque로 괄호 검증하면서 동시에 값 계산
여는 괄호 만나면 temp에 곱셈, 닫는 괄호 만나면 직전이 여는 괄호인 경우에만 temp를 result에 누적하고 temp를 나눔
스택으로 괄호 쌍 검증

## ⏳ 회고
스택 + 곱셈 누적 방식으로 풀이함 ez 