### PR TITLE
[20251014] BOJ / G5 / 개똥벌레 / 이준희

### DIFF
--- a/JHLEE325/202510/14 BOJ G5 개똥벌레.md
+++ b/JHLEE325/202510/14 BOJ G5 개똥벌레.md
@@ -1,0 +1,43 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int h = Integer.parseInt(st.nextToken());
+
+        int[] seok = new int[h + 2];
+        int[] jong = new int[h + 2];
+
+        for (int i = 0; i < n; i++) {
+            int height = Integer.parseInt(br.readLine());
+            if (i % 2 == 0) seok[height]++;
+            else jong[height]++;
+        }
+
+        for (int i = h - 1; i >= 1; i--) {
+            seok[i] += seok[i + 1];
+            jong[i] += jong[i + 1];
+        }
+
+        int min = Integer.MAX_VALUE;
+        int count = 0;
+
+        for (int i = 1; i <= h; i++) {
+            int crash = seok[i] + jong[h - i + 1];
+
+            if (crash < min) {
+                min = crash;
+                count = 1;
+            } else if (crash == min) {
+                count++;
+            }
+        }
+
+        System.out.println(min + " " + count);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/3020

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
석순과 종유석이 번갈아서 나타나는 동굴을 일직선으로 석순과 종유석을 부수면서 날아가는 개똥벌레가 있습니다.
이 때 가장 적게 석순, 종유석을 부수는 경우에 몇개를 부수는지 또 그러한 경로가 몇개인지 구하는 문제입니다.

## 🔍 풀이 방법
h(동굴 높이)가 50만으로 매우 커서 누적합을 이용했습니다.
석순과 종유석 배열을 따로 두고 각각의 누적합을 구한 후 최종 단계에서 각 높이별로 부딪히는 장애물의 갯수를 파악했습니다.

## ⏳ 회고
처음에 입력받을 때 석순, 종유석의 방향에 상관없이 다 밑에서 위로 향하는 것처럼 입력 받아놓고 누적합 계산할 때는 종유석이라고 인덱스를 거꾸로 시작해서 뻘짓했습니다.
