### PR TITLE
[20251014] BOJ / G4 / 테트로미노 / 김민진

### DIFF
--- a/zinnnn37/202510/14 BOJ G4 테트로미노.md
+++ b/zinnnn37/202510/14 BOJ G4 테트로미노.md
@@ -1,0 +1,84 @@
+```java
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class BJ_14500_테트로미노 {
+
+	private static final int[] dx = { 0, 1, 0, -1 };
+	private static final int[] dy = { 1, 0, -1, 0 };
+
+	private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+	private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	private static       StringTokenizer st;
+
+	private static int N, M, ans;
+	private static int[][]     matrix;
+	private static boolean[][] visited;
+
+	public static void main(String[] args) throws IOException {
+		init();
+		sol();
+	}
+
+	private static void init() throws IOException {
+		st  = new StringTokenizer(br.readLine());
+		N   = Integer.parseInt(st.nextToken());
+		M   = Integer.parseInt(st.nextToken());
+		ans = 0;
+
+		matrix = new int[N][M];
+		for (int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine());
+			for (int j = 0; j < M; j++) {
+				matrix[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+
+		visited = new boolean[N][M];
+	}
+
+	private static void sol() throws IOException {
+		for (int i = 0; i < N; i++) {
+			for (int j = 0; j < M; j++) {
+				visited[i][j] = true;
+				dfs(1, i, j, matrix[i][j]);
+				visited[i][j] = false;
+			}
+		}
+		bw.write(ans + "");
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+
+	private static void dfs(int depth, int cx, int cy, int tmp) throws IOException {
+		if (depth == 4) {
+			ans = Math.max(ans, tmp);
+			return;
+		}
+
+		if (tmp + (4 - depth) * 1000 <= ans) {
+			return;
+		}
+
+		for (int d = 0; d < 4; d++) {
+			int nx = cx + dx[d];
+			int ny = cy + dy[d];
+
+			if (nx < 0 || N <= nx || ny < 0 || M <= ny || visited[nx][ny]) continue;
+
+			// 凸 처리 - 다음칸으로 이동하지 않음으로써 중간 칸에서 분기 가능하도록 함
+			if (depth == 2) {
+				visited[nx][ny] = true;
+				dfs(depth + 1, cx, cy, tmp + matrix[nx][ny]);
+				visited[nx][ny] = false;
+			}
+
+			visited[nx][ny] = true;
+			dfs(depth + 1, nx, ny, tmp + matrix[nx][ny]);
+			visited[nx][ny] = false;
+		}
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[테트로미노](https://www.acmicpc.net/problem/14500)

## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
이차원 격자에 테트로미노를 놓았을 때 테트로미노가 놓인 칸의 수의 합의 최대값은

## 🔍 풀이 방법
dfs..
근데 `凸` 얘는 일반적인 dfs로 확인이 불가능해서 `depth == 2`일 때 분기해야함
이 때 `nx` `ny`로 이동하지 않고 dfs 계속 진행하면 저 모양 확인 가능

## ⏳ 회고
크악