### PR TITLE
[20251015] BOJ / P3 / Game on Plane / 권혁준

### DIFF
--- a/khj20006/202510/15 BOJ P3 Game on Plane.md
+++ b/khj20006/202510/15 BOJ P3 Game on Plane.md
@@ -1,0 +1,19 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+
+int T, N, a, d[5001]{};
+
+int main(){
+    cin.tie(0)->sync_with_stdio(0);
+    
+    for(int i=2;i<=5000;i++) {
+        bitset<5000> v;
+        for(int j=0;j<=i-j-2;j++) v[d[j]^d[i-j-2]]=1;
+        while(v[d[i]]) d[i]++;
+    }
+
+    for(cin>>T;T--;cout<<(d[a] ? "First\n" : "Second\n")) cin>>a;
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16187

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
2차원 공간에 N개의 점이 정N각형 형태로 배치되어 있다.
두 사람이 게임을 진행한다.
각 사람은 자신의 차례가 되면 두 점을 골라서 선분으로 연결한다.
어떤 사람이 선분을 이었을 때 볼록 다각형이 완성된다면 그 사람의 승리로 게임이 끝난다.
N이 주어지면 선공이 이기는지 후공이 이기는지 구해보자.

## 🔍 풀이 방법
- DP
- 스프라그-그런디 정리
---
`dp[n] = 공간에 n개의 점이 있을 때의 그런디 수` 로 정의했다.
두 사람이 최적 전략으로 게임을 해서 볼록 다각형이 완성된다면, 반드시 삼각형이 된다.
삼각형에는 선분이 세 개 필요하니까, 두 사람은 선분을 그을 때 최대한 기존 선분들과 만나지 않도록 그리게 된다. 그렇지 않으면 상대방이 바로 삼각형을 만들 수 있기 때문이다.

따라서 어떤 두 선분을 이으면, 그 선분의 양 옆으로 남은 점의 수에 따라 승패가 결정된다.
한 쪽에 x개의 점이 남았다면, 반대쪽에는 n-x-2개의 점이 남게 되고, 스프라그-그런디 정리에 의해 이 경우의 그런디 수는 dp[x] ^ dp[n-x-2]가 된다.

따라서 dp[n] = mex(dp[x]^dp[n-x-2]) (0 <= x <= n-2) 가 된다.

## ⏳ 회고
ez