### PR TITLE
[20251015] BOJ / G1 / 택배 / 이준희

### DIFF
--- a/JHLEE325/202510/15 BOJ G1 택배.md
+++ b/JHLEE325/202510/15 BOJ G1 택배.md
@@ -1,0 +1,55 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int c = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(br.readLine());
+        int[][] express = new int[m][3];
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+            int box = Integer.parseInt(st.nextToken());
+            express[i][0] = from;
+            express[i][1] = to;
+            express[i][2] = box;
+        }
+
+        Arrays.sort(express, (a, b) -> {
+            if (a[1] == b[1]) return a[0] - b[0];
+            return a[1] - b[1];
+        });
+
+        int[] load = new int[n + 1];
+        int result = 0;
+
+        for (int i = 0; i < m; i++) {
+            int from = express[i][0];
+            int to = express[i][1];
+            int box = express[i][2];
+
+            int maxbox = 0;
+            for (int j = from; j < to; j++) {
+                maxbox = Math.max(maxbox, load[j]);
+            }
+
+            int canbox = Math.min(c - maxbox, box);
+            if (canbox <= 0) continue;
+
+            for (int j = from; j < to; j++) {
+                load[j] += canbox;
+            }
+
+            result += canbox;
+        }
+
+        System.out.println(result);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/8980

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
트럭의 C 가 정해져 있고 택배는 보내는 마을, 받는 마을, 박스 개수가 존재합니다.
이 때 트럭이 일직선으로 놓은 마을들을 지나가면서 택배를 싣거나 배송할 때
가장 많은 택배를 배송할 수 있는 경우를 구하는 문제입니다.

## 🔍 풀이 방법
2차원 배열을 받는 마을을 기준으로 정렬한 후
그리디를 이용해서 풀었습니다.

## ⏳ 회고
처음에 정렬하는 column을 잘못 설정해서 이상한 짓을 했습니다.
