### PR TITLE
[20251015] BOJ / G5 / 꿀 따기 / 설진영

### DIFF
--- a/Seol-JY/202510/15 BOJ G5 꿀 따기.md‎
+++ b/Seol-JY/202510/15 BOJ G5 꿀 따기.md‎
@@ -1,0 +1,40 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        
+        int N = Integer.parseInt(br.readLine());
+        int[] H = new int[N];
+        
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            H[i] = Integer.parseInt(st.nextToken());
+        }
+        
+        int[] S = new int[N];
+        S[0] = H[0];
+        for (int i = 1; i < N; i++) {
+            S[i] = S[i - 1] + H[i];
+        }
+        
+        int answer = 0;
+        
+        for (int mid = 1; mid < N - 1; mid++) {
+            answer = Math.max(answer, 2 * S[N - 1] - H[0] - H[mid] - S[mid]);
+        }
+        
+        for (int mid = 1; mid < N - 1; mid++) {
+            answer = Math.max(answer, S[N - 2] + S[mid] - 2 * H[mid]);
+        }
+        
+        for (int mid = 1; mid < N - 1; mid++) {
+            answer = Math.max(answer, S[N - 2] - H[0] + H[mid]);
+        }
+        
+        System.out.println(answer);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/21758

<img width="590" height="492" alt="image" src="https://github.com/user-attachments/assets/1928e69a-fb39-4d4c-8aea-e4af7a8834b3" />


## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
N개의 장소가 일렬로 배치되어 있고, 각 장소마다 꿀의 양이 정해져 있음
두 마리의 벌과 벌통 하나를 배치하여 벌들이 수집할 수 있는 꿀의 양을 최대화


## 🔍 풀이 방법

두 벌이 왼쪽에서 출발 → 오른쪽 벌통
두 벌이 오른쪽에서 출발 → 왼쪽 벌통 
양쪽 끝에 벌, 중간에 벌통
세개중에 잴 큰거

누적합 미리 구해둬서 불필요한 추가 연산 막기

## ⏳ 회고
누적합 잘쓰면 쉬울듯 