### PR TITLE
[20251015] BOJ / G3 / 수열과 쿼리 15 / 김민진

### DIFF
--- a/zinnnn37/202510/15_BOJ_G3_수열과_쿼리_15.md
+++ b/zinnnn37/202510/15_BOJ_G3_수열과_쿼리_15.md
@@ -1,0 +1,87 @@
+```java
+import java.io.*;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class BJ_14427_수열과_쿼리_15 {
+
+	private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+	private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	private static final StringBuilder   sb = new StringBuilder();
+	private static       StringTokenizer st;
+
+	private static int N, M;
+	private static Node[]      nodes;
+	private static Queue<Node> pq;
+
+	private static class Node implements Comparable<Node> {
+		int idx;
+		int val;
+
+		Node(int idx, int val) {
+			this.idx = idx;
+			this.val = val;
+		}
+
+		@Override
+		public int compareTo(Node o) {
+			if (this.val == o.val) {
+				return Integer.compare(this.idx, o.idx);
+			}
+			return Integer.compare(this.val, o.val);
+		}
+
+		@Override
+		public String toString() {
+			return "[" + idx + " " + val + "]";
+		}
+	}
+
+	public static void main(String[] args) throws IOException {
+		init();
+		sol();
+	}
+
+	private static void init() throws IOException {
+		N = Integer.parseInt(br.readLine());
+
+		nodes = new Node[N + 1];
+		pq    = new PriorityQueue<>();
+		st    = new StringTokenizer(br.readLine());
+		for (int i = 1; i <= N; i++) {
+			nodes[i] = new Node(i, Integer.parseInt(st.nextToken()));
+			pq.offer(nodes[i]);
+		}
+
+		M = Integer.parseInt(br.readLine());
+	}
+
+	private static void sol() throws IOException {
+		while (M-- > 0) {
+			st = new StringTokenizer(br.readLine());
+
+			int cmd = Integer.parseInt(st.nextToken());
+
+			if (cmd == 1) {
+				int a = Integer.parseInt(st.nextToken());
+				int b = Integer.parseInt(st.nextToken());
+
+				nodes[a] = new Node(a, b); // 객체 참조 변경 시 pq 순서 꼬일 수 있음,,
+				pq.offer(nodes[a]); // priority queue는 내부 객체가 변경되어도 재정렬 되지 않음
+			} else if (cmd == 2) {
+				// 업데이트 되기 이전 값은 poll()
+				while (!pq.isEmpty() && pq.peek().val != nodes[pq.peek().idx].val) {
+					pq.poll();
+				}
+				sb.append(pq.peek().idx).append("\n");
+			}
+		}
+		bw.write(sb.toString());
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[수열과 쿼리 15](https://www.acmicpc.net/problem/14427)

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
`update` 연산과 최솟값의 인덱스를 출력(최솟값이 두개 이상이면 더 작은 인덱스)하는 쿼리의 값 구하기

## 🔍 풀이 방법
우선순위 큐
큐 안에 들어있는 객체의 값 바꿔도 재정렬이 일어나지 않으므로 교체 필요
`udpate`때는 새 객체 넣고 최솟값 출력 때 이전 버전 객체들은 무시하면 됨

## ⏳ 회고
우선순위 큐 써도 돼서 골3일까