### PR TITLE
[20251016] BOJ / G3 / 백양로 브레이크 / 이준희

### DIFF
--- a/JHLEE325/202510/16 BOJ G3 백양로 브레이크.md
+++ b/JHLEE325/202510/16 BOJ G3 백양로 브레이크.md
@@ -1,0 +1,59 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static final int INF = 987654321;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+
+        st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        int[][] map = new int[n + 1][n + 1];
+
+        for (int i = 1; i <= n; i++) {
+            Arrays.fill(map[i], INF);
+            map[i][i] = 0;
+        }
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            map[u][v] = 0;
+
+            if (b == 1) map[v][u] = 0;
+            else map[v][u] = 1;
+        }
+
+        for (int k = 1; k <= n; k++) {
+            for (int i = 1; i <= n; i++) {
+                for (int j = 1; j <= n; j++) {
+                    if (map[i][j] > map[i][k] + map[k][j]) {
+                        map[i][j] = map[i][k] + map[k][j];
+                    }
+                }
+            }
+        }
+
+        int k = Integer.parseInt(br.readLine());
+        
+        for (int i = 0; i < k; i++) {
+            st = new StringTokenizer(br.readLine());
+            int s = Integer.parseInt(st.nextToken());
+            int e = Integer.parseInt(st.nextToken());
+            sb.append(map[s][e]).append('\n');
+        }
+
+        System.out.print(sb.toString());
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11562

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
모 대학교에서 길을 공사하게 되면서 양방향이었던 길이 일부 일방통행으로 변하여
특정 건물에서 다른 건물로 이동할 수 없는 경우가 발생했습니다.

건물과 건물을 잇는 길의 양방향 통행 가능 여부가 주어졋을 때
주어지는 각 요청에 대하여 건물과 건물을 이동하는데 양방향으로 복원이 필요한 길의 최소갯수를 구하는 문제입니다.

## 🔍 풀이 방법
이미 양방향인 길의 경우 가중치를 0, 단방향이어서 양방향으로 바꾸어야 이동이 가능한 길의 가중치를 1로 설정하여 플로이드-워셜을 돌려서 풀었습니다.

## ⏳ 회고
가중치를 0과 1로 만들어서 풀어야된다는 것만 알면 굉장히 쉬운 문제였던 것 같습니다.
