### PR TITLE
[20251016] BOJ / P1 / 수열과 쿼리 23 / 권혁준

### DIFF
--- a/khj20006/202510/16 BOJ P1 수열과 쿼리 23.md
+++ b/khj20006/202510/16 BOJ P1 수열과 쿼리 23.md
@@ -1,0 +1,65 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+using ll = long long;
+
+int N, Q, a[100000]{}, sq;
+ll fen[100001]{}, ans[100000]{};
+map<int, int> m;
+vector<tuple<int, int, int>> qs;
+
+void upt(int i, int v) {
+    for(;i<100001;i+=i&-i) fen[i] += v;
+}
+
+ll f(int i) {
+    ll ret = 0;
+    for(;i>0;i-=i&-i) ret += fen[i];
+    return ret;
+}
+
+int main(){
+    cin.tie(0)->sync_with_stdio(0);
+    
+    cin>>N>>Q;
+    sq = sqrt(N);
+    for(int i=0;i<N;i++) cin>>a[i], m[a[i]] = 0;
+    int c = 0;
+    for(auto &[x,y]:m) y = ++c;
+    for(int i=0;i<N;i++) a[i] = m[a[i]];
+
+    int t = 0;
+    qs.resize(Q);
+    for(auto &[a,b,x]:qs) cin>>a>>b, a--, b--, x = t++;
+    sort(qs.begin(), qs.end(), [](auto a, auto b) -> bool {
+        auto [al, ar, ax] = a;
+        auto [bl, br, bx] = b;
+        if(al/sq == bl/sq) return ar < br;
+        return al/sq < bl/sq;
+    });
+
+    int l = 0, r = -1;
+    ll res = 0;
+    for(auto [pl,pr,x]:qs) {
+        while(r < pr) {
+            res += f(c) - f(a[++r]);
+            upt(a[r],1);
+        }
+        while(pr < r) {
+            res -= f(c) - f(a[r]);
+            upt(a[r--],-1);
+        }
+        while(l < pl) {
+            res -= f(a[l]-1);
+            upt(a[l++],-1);
+        }
+        while(pl < l) {
+            res += f(a[--l]-1);
+            upt(a[l],1);
+        }
+        ans[x] = res;
+    }
+    for(int i=0;i<Q;i++) cout<<ans[i]<<'\n';
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16979

## 🧭 풀이 시간
80분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
길이 N인 수열 A에 아래 쿼리를 수행해보자.
- s e : s <= i < j <= e이면서 A[i] > A[j]인 (i,j) 쌍의 개수를 출력

## 🔍 풀이 방법
- mo's
- 펜윅 트리
---
mo's로 쿼리 정렬하고 처리는 아래와 같이 ㄱㄱ
1. r이 늘어날 때 -> 답에 a[r]보다 큰 수의 개수만큼 +
2. r이 줄어들 때 -> 답에 a[r]보다 큰 수의 개수만큼 -
3. l이 늘어날 때 -> 답에 a[l]보다 작은 수의 개수만큼 -
4. l이 줄어들 때 -> 답에 a[l]보다 작은 수의 개수만큼 +

수열의 값을 압축해서 O(N)범위로 떨군 후에, 특정 수보다 큰/작은 수의 개수를 펜윅 트리로 구했다.

## ⏳ 회고
세그먼트 트리 -> 시간 초과
펜윅 트리 써야 맞음. 세그로 뚫어보려다 시간만 날림.