### PR TITLE
[20251016] BOJ / G5 / 사과나무 / 설진영

### DIFF
--- a/Seol-JY/202510/16 BOJ G5 사과나무.md‎
+++ b/Seol-JY/202510/16 BOJ G5 사과나무.md‎
@@ -1,0 +1,40 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        
+        int N = Integer.parseInt(br.readLine());
+        int[][] orchard = new int[N + 1][N + 1];
+        
+        for (int i = 1; i <= N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 1; j <= N; j++) {
+                orchard[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+        
+        int[][] prefixSum = new int[N + 1][N + 1];
+        for (int i = 1; i <= N; i++) {
+            for (int j = 1; j <= N; j++) {
+                prefixSum[i][j] = orchard[i][j] + prefixSum[i-1][j] + prefixSum[i][j-1] - prefixSum[i-1][j-1];
+            }
+        }
+        
+        int maxProfit = Integer.MIN_VALUE;
+        
+        for (int K = 1; K <= N; K++) {
+            for (int i = K; i <= N; i++) {
+                for (int j = K; j <= N; j++) {
+                    int sum = prefixSum[i][j] - prefixSum[i-K][j] - prefixSum[i][j-K] + prefixSum[i-K][j-K];
+                    maxProfit = Math.max(maxProfit, sum);
+                }
+            }
+        }
+        
+        System.out.println(maxProfit);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2079

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
N×N 과수원에서 K×K 크기의 정사각형 영역을 선택하여 최대 이익을 구하기
모든 가능한 K(1≤K≤N)에 대해 최대값 찾기

## 🔍 풀이 방법
누적 합 + 브루트포스
sum = prefixSum[i][j] - prefixSum[i-K][j] - prefixSum[i][j-K] + prefixSum[i-K][j-K]
최댓값 갱신

## ⏳ 회고
쉬움
