### PR TITLE
[20251017] BOJ / G5 / 용앱 합성하기 / 이준희

### DIFF
--- a/JHLEE325/202510/17 BOJ G5 용액 합성하기.md
+++ b/JHLEE325/202510/17 BOJ G5 용액 합성하기.md
@@ -1,0 +1,45 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+
+        int[] arr = new int[n];
+
+        st = new StringTokenizer(br.readLine());
+
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int left = 0;
+        int right = n - 1;
+        int temp = 987654321;
+        int res = 0;
+
+        while (left < right) {
+            int sum = arr[left] + arr[right];
+            if (sum < 0) {
+                left++;
+            } else if (sum > 0) {
+                right--;
+            } else {
+                res = 0;
+                break;
+            }
+            if(temp> Math.abs(sum)){
+                res = sum;
+                temp = Math.abs(sum);
+            }
+        }
+
+        System.out.println(res);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14921

## 🧭 풀이 시간
10분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
-1억 ~ 1억의 특성값을 갖는 용액들이 있을 때
두 용액을 합성했을 때 특성값의 합이 0에 가장 가까운 경우의 특성값을 구하는 문제입니다.

## 🔍 풀이 방법
투포인터를 활용하여 풀었습니다.
문제 조건에서 입력자체가 정렬되어 있기 때문에 왼쪽끝 오른쪽끝에서 시작하여 합이 양수, 음수를 분기로 하여 처리했습니다.
0에 가깝다는 것은 절대값을 활용하여 판단했습니다.

## ⏳ 회고
처음에 음수일 때도 양수(절대값)으로 출력해서 틀렸는데 예제를 잘 봐야겠습니다.
