### PR TITLE
[20251017] BOJ / G2 / 구간 자르기 / 김수연

### DIFF
--- a/suyeun84/202510/17 BOJ G2 구간 자르기.md
+++ b/suyeun84/202510/17 BOJ G2 구간 자르기.md
@@ -1,0 +1,53 @@
+```java
+package boj;
+
+import java.io.*;
+import java.util.*;
+
+public class boj2283 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static void nextLine() throws Exception { st = new StringTokenizer(br.readLine()); }
+    static int nextInt() { return Integer.parseInt(st.nextToken()); }
+    
+	public static void main(String[] args) throws Exception {
+		nextLine();
+		int N = nextInt();
+		int K = nextInt();
+		int start= 1000001;
+		int end = 0;
+		int[] num = new int[1000001];
+		// 누적합 생성
+		for (int i = 0; i < N; i++) {
+			nextLine();
+			int a = nextInt();
+			int b = nextInt();
+			num[a]++;
+			num[b]--;
+			start = Math.min(start, a);
+			end = Math.max(end, b);
+		}
+		for (int i = start+1; i <= end; i++) {
+			num[i] += num[i-1];
+		}
+		
+		// 투 포인터
+		int sum = 0;
+		int s = 0;
+		int e = start;
+		while (e <= end) {
+			if (sum < K) {
+				sum += num[e];
+				e++;
+			} else if (sum == K) {
+				System.out.println(s+" "+e);
+				return;
+			} else {
+				sum -= num[s];
+				s++;
+			}
+		}
+		System.out.println(0+" "+0);
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2283
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
각 구간에서 A와 B 사이에 포함되지 않은 부분을 모두 잘라냈을 때 남는 부분들의 길이 총합이 K가 되는 구간 A, B의 최솟값 구하기
## 🔍 풀이 방법
누적합 + 투포인터 사용
누적합으로 각 지점에 몇개의 구간이 포함되어 있는지 미리 계산해두고,
투 포인터로 start랑 end 옮기면서 길이 총합이 K가 되는 지점 찾음
## ⏳ 회고
어렵다..