### PR TITLE
[20251017] PGM / LV2 / 두 큐 합 같게 만들기 / 강신지

### DIFF
--- a/ksinji/202510/17 PGM 두 큐 합 같게 만들기.md
+++ b/ksinji/202510/17 PGM 두 큐 합 같게 만들기.md
@@ -1,0 +1,46 @@
+```java
+import java.util.*;
+
+class Solution {
+    public int solution(int[] queue1, int[] queue2) {
+        int n = queue1.length;
+        int totalSize = n*2;
+
+        long queueValue = 0, totalValue = 0;
+        int[] nums = new int[totalSize];
+
+        for (int i = 0; i < n; i++) {
+            nums[i] = queue1[i];
+            queueValue += queue1[i];
+            totalValue  += queue1[i];
+        }
+        for (int i = 0; i < n; i++) {
+            nums[n + i] = queue2[i];
+            totalValue += queue2[i];
+        }
+
+        // 전체 합이 홀수면 불가능
+        if (totalValue % 2 == 1) return -1;
+        long half = totalValue / 2;
+
+        if (queueValue == half) return 0;
+
+        int i = 0;      // q1 시작 위치
+        int j = n;      // q2 시작 위치
+        int moves = 0;
+
+        // 각 포인터는 최대 L까지 갈 수 있음
+        while (i < totalSize && j < totalSize) {
+            if (queueValue == half) return moves;
+
+            if (queueValue > half) {
+                queueValue -= nums[i++];
+            } else {
+                queueValue += nums[j++];
+            }
+            moves++;
+        }
+        return -1;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/118667
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
두 큐가 있음. 한 번에 한 큐의 맨 앞 원소를 꺼내 다른 큐 뒤에 붙일 수 있음. 두 큐의 합을 같게 만드는 최소 연산횟수 구하기. 불가능하면 -1.
## 🔍 풀이 방법
두 큐를 이어붙여 하나의 배열 생성 후 각 큐의 시작 인덱스를 이동시키며 계산
q1 내 값의 합이 원하는 값(모든 값을 더한 것의 절반)이 되도록 적절히 이동

## ⏳ 회고
뭔가 무지성으로 큐에서 옮기면서 풀면 시간초과가 날 것 같아서 힌트를 봄.
두 큐를 이어 붙여 투포인터로 푸는 방법은 생각하지 못했는데 좋은 방법인 것 같음.
근데 다시 직접 옮기는 방식으로 풀어보니 시간초과 나지 않는다...