### PR TITLE
[20251017] BOJ / G4 / 수도배관공사 / 권혁준

### DIFF
--- a/khj20006/202510/17 BOJ G4 수도배관공사.md
+++ b/khj20006/202510/17 BOJ G4 수도배관공사.md
@@ -1,0 +1,25 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+
+const int INF = 1e9+7;
+
+int main(){
+    cin.tie(0)->sync_with_stdio(0);
+    
+    int D, P;
+    cin>>D>>P;
+    vector<int> dp(100001, INF);
+    for(int l, c;P--;) {
+        cin>>l>>c;
+        for(int j=100000;j>l;j--) if(dp[j-l] != INF) {
+            if(dp[j] == INF) dp[j] = min(dp[j-l], c);
+            else dp[j] = max(dp[j], min(dp[j-l], c));
+        }
+        if(dp[l] == INF) dp[l] = c;
+        else dp[l] = max(dp[l], c);
+    }
+    
+    cout<<dp[D];
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2073

## 🧭 풀이 시간
15분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
아기염소들이 언덕에서 풀을 뜯고 놀다 보면 항상 도중에 목이 마르곤 했다. 그들은 불편함을 참지 못하고 수도관을 설치하여 거리 D(7 ≤ D ≤ 100,000)만큼 떨어진 곳의 강에서 물을 끌어오기로 했다. 근처의 인간 마을에서 P개(1 ≤ P ≤ 350)의 파이프를 매입했는데, 각각은 길이 Li와 용량 Ci로 나타낼 수 있다. (Li와 Ci는 모두 223보다 작거나 같은 양의 정수이다)

파이프들은 일렬로 이어서 수도관 하나로 만들 수 있으며, 이때 수도관의 용량은 그것을 이루는 파이프들의 용량 중 최솟값이 되고, 수도관의 길이는 파이프들 길이의 총합이다.

수도관을 한 개 만들어 총 길이가 정확히 D와 같게 할 때, 가능한 최대 수도관 용량을 구하는 프로그램을 작성하시오.

## 🔍 풀이 방법
- DP
---
배낭인데 그냥 초기값 지정이랑 min연산만 신경써주면 끝

## ⏳ 회고
ez