### PR TITLE
[20251019] BOJ / G1 / 굉장한 모비스터디 / 한종욱

### DIFF
--- a/Ukj0ng/202510/19 BOJ G1 굉장한 모비스터디.md
+++ b/Ukj0ng/202510/19 BOJ G1 굉장한 모비스터디.md
@@ -1,0 +1,120 @@
+```
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static Map<Integer, Set<Integer>> map;
+    private static List<List<Integer>> temp;
+    private static int[][] uf, size;
+    private static int N, M1, M2, M3;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        findAmazedMobi();
+
+        bw.write(temp.size() + "\n");
+        for (List<Integer> group : temp) {
+            for (int i = 0; i < group.size(); i++) {
+                if (i > 0) bw.write(" ");
+                bw.write(group.get(i) + "");
+            }
+            bw.write("\n");
+        }
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        M1 = Integer.parseInt(st.nextToken());
+        M2 = Integer.parseInt(st.nextToken());
+        M3 = Integer.parseInt(st.nextToken());
+
+        uf = new int[3][N+1];
+        size = new int[3][N+1];
+        map = new HashMap<>();
+        temp = new ArrayList<>();
+
+        for (int i = 0; i < 3; i++) {
+            for (int j = 1; j <= N; j++) {
+                uf[i][j] = j;
+                size[i][j] = 1;
+            }
+        }
+
+        for (int i = 0; i < M1; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            union(a, b, 0);
+        }
+
+        for (int i = 0; i < M2; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            union(a, b, 1);
+        }
+
+        for (int i = 0; i < M3; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            union(a, b, 2);
+        }
+    }
+
+    private static void findAmazedMobi() {
+        Map<String, List<Integer>> groups = new HashMap<>();
+
+        for (int node = 1; node <= N; node++) {
+            String key = find(node, 0) + "," + find(node, 1) + "," + find(node, 2);
+
+            groups.putIfAbsent(key, new ArrayList<>());
+            groups.get(key).add(node);
+        }
+
+        for (List<Integer> group : groups.values()) {
+            if (group.size() >= 2) {
+                Collections.sort(group);
+                temp.add(group);
+            }
+        }
+
+        temp.sort((a, b) -> Integer.compare(a.get(0), b.get(0)));
+    }
+
+    private static void union(int x, int y, int index) {
+        int X = find(x, index);
+        int Y = find(y, index);
+
+        if (size[index][X] < size[index][Y]) {
+            uf[index][X] = Y;
+            size[index][Y] += size[index][X];
+        } else {
+            uf[index][Y] = X;
+            size[index][X] += size[index][Y];
+        }
+    }
+
+    private static int find(int x, int index) {
+        if (uf[index][x] == x) return x;
+
+        return uf[index][x] = find(uf[index][x], index);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/27726

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
세 개의 수업이 끝나고 스터디를 맺는데, 세 개의 수업의 스터디를 모두 같은 스터디를 하는 스터디를 굉장한 모비스터디라고 한다. 
존재하는 굉장한 모비스터디의 개수와 거기 멤버들을 오름차순으로 출력하시오.
## 🔍 풀이 방법
서로 분리집합을 통해 관계를 맺은 후
1. 메모리초과 발생
처음엔 map에 각 노드를 하나씩 대조하면서 넣었다. map에는 노드들이 중복으로 저장되어 최악의 경우 공간복잡도가 $O(N^{2})$가 발생했다. 
2. 성공
BFS에서 visited를 Set<String>으로 선언하듯, 세 스터디의 root를 `String key = find(node, 0) + "," + find(node, 1) + "," + find(node, 2);`로 선언했다. 이렇게 하면 각 노드를 1번씩만 탐색해 공간복잡도가 $O(N)$다.
그 다음 각 그룹의 크기가 2이상인 것만 정렬해 저장하고, 각 그룹의 최소값을 기준으로 오름차순 정렬을 했다.
## ⏳ 회고
visited를 Set<String>으로 선언하는 걸 map에서도 할 수 있다는 생각을 하지 못했다. 