### PR TITLE
[20251019] BOJ / P4 / 날카로운 눈 / 이종환

### DIFF
--- a/0224LJH/202510/19 BOJ 날카로운 눈
+++ b/0224LJH/202510/19 BOJ 날카로운 눈
@@ -1,0 +1,116 @@
+```java 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+	
+	static int patternCnt;
+	static Pattern[] patterns;
+	
+	static String ans;
+	
+	static class Pattern {
+		int start;
+		int end;
+		int plus;
+		int numCnt;
+		
+		public Pattern(int start, int limit, int plus) {
+			
+			this.numCnt = (limit-start)/plus + 1;
+			
+			this.start = start;
+			this.end = (numCnt-1) * plus + start; // 진짜 마지막 숫자
+			this.plus = plus;
+		}
+	}
+	
+
+	
+
+    public static void main(String[] args) throws IOException {
+    	init();
+    	process();
+    	print();
+    }
+    
+    private static void init() throws IOException{
+    	BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    	patternCnt = Integer.parseInt(br.readLine());
+    	patterns = new Pattern[patternCnt];
+    	
+    	for (int i = 0; i < patternCnt; i++) {
+    		StringTokenizer st = new StringTokenizer(br.readLine());
+    		int start = Integer.parseInt(st.nextToken());
+    		int limit = Integer.parseInt(st.nextToken());
+    		int plus = Integer.parseInt(st.nextToken());
+    		patterns[i] = new Pattern(start,limit,plus);
+    	}
+    }
+    
+    private static void process() {
+    	long totalCnt = 0;
+    	for (Pattern p: patterns) totalCnt += p.numCnt;
+    	if (totalCnt %2 == 0) {
+    		ans = "NOTHING";
+    		return;
+    	}
+    	
+    	// 홀수개라면, 기준이 되는 지점을 찾으면 된다!!
+    	// 예를들어 num을 확인할 경우, num이하의 숫자의 개수를 찾는다.
+    	// num이하의 숫자가 나온 총 횟수를 f(num)이라 하자.
+    	// 1.f(num)이 짝수인 경우 -> 정답이 되는 숫자는 num보다 크다.
+    	// 2-1. f(num)이 홀수이고, num자체가 짝수개 or 존재 x -> 정답이 되는 숫자가 num보다 작다
+    	// 2-2. f(num)이 홀수이고, num자체가 홀수개 존재 -> 정답!!
+    	
+    	long start = 0;
+    	long end = Integer.MAX_VALUE;
+    	long mid = (start + end)/2;
+    	
+    	while (start <= mid) {
+    		long belowNumCnt = 0;
+    		long numCnt = 0;
+    		
+    		
+    		for (Pattern p: patterns) {
+    			if (p.end < mid) {
+    				belowNumCnt += p.numCnt;
+    				continue;
+    			} else if (p.start > mid) continue;
+    			
+    			//mid가 start 이상 end이하임
+    			belowNumCnt += (mid - p.start)/p.plus + 1;
+    			if ((mid-p.start)%p.plus == 0) numCnt++;
+    			
+    		}
+//    		System.out.println(mid +": " + numCnt +", 이하 총 개수:" + belowNumCnt);
+    		
+    		if (numCnt % 2 != 0) { // numCnt가 홀수 -> 정답임
+    			StringBuilder sb = new StringBuilder();
+    			sb.append(mid).append(" ").append(numCnt);
+    			ans = sb.toString();
+    			return;
+    		}
+    		
+    		
+    		if (belowNumCnt % 2 == 0) {
+    			start = mid+1;
+    		} else {
+    			end = mid;
+    		}
+    		mid = (start + end)/2;
+    	}
+    	
+    	
+    	
+    }
+    
+    private static void print() {
+    	System.out.println(ans);
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1637

## 🧭 풀이 시간
70분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명

정수가 여러 개 모여 있는 정수더미가 있다. 그 안에 어떤 특정한 정수 하나만 홀수개 존재하고 나머지 정수는 모두 짝수개 존재한다. 정수더미 속에서 날카로운 눈을 이용해 홀수개 존재하는 정수를 찾아야 하는 문제이다.

첫째 줄에 입력의 개수 N이 주어진다. N은 1이상 20,000이하인 수이다. 그 다음 줄부터 N줄에 걸쳐 세 개의 정수 A, C, B가 주어지는데, 이것은 A, A+B, A+2B, ..., A+kB (단, A+kB ≦ C) 의 정수들이 정수더미 안에 있다는 것을 나타낸다. A, B, C는 1보다 크거나 같고 2,147,483,647보다 작거나 같은 정수이다. 정수더미는 N개의 입력이 나타내는 정수들을 모두 포함한다.



## 🔍 풀이 방법
단순히 배열을 만들고 저장하기에는 너무나도 많은 수가 만들어지기에 무조건 메모리가 터진다.
고민하다가 힌트를 보니 이분탐색을 하라고 했다.

그래서 곰고히 생각해보니, 정답이 없는 경우를 제외하면 항상 총 갯수는 항상 홀수이다.
그렇기에 특정 숫자를 검사할 때, 그 숫자가 몇번 나오는지, 그리고 그 숫자 이하의 숫자는 총 몇번 나오는지를 계산하면된다.

예를들어 num을 확인할 경우, num이하의 숫자의 개수를 찾는다. num이하의 숫자가 나온 총 횟수를 f(num)이라 하자.

 	1.f(num)이 짝수인 경우 -> 정답이 되는 숫자는 num보다 크다.
	2-1. f(num)이 홀수이고, num자체가 짝수개 or 존재 x -> 정답이 되는 숫자가 num보다 작다
	2-2. f(num)이 홀수이고, num자체가 홀수개 존재 -> 정답!!

이를 통해 이분탐색으로 풀며된다. 이러면 20000 * log(21억) 이기에 시간복잡도도 문제 없다!


## ⏳ 회고
맨날 하던 방식을 벗어나서 신기한 방식의 이분탐색이었다.