### PR TITLE
[20251019] BOJ / G5 / 전깃줄 / 강신지

### DIFF
--- a/ksinji/202510/19 BOJ 전깃줄.md
+++ b/ksinji/202510/19 BOJ 전깃줄.md
@@ -1,0 +1,47 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static class Wire implements Comparable<Wire> {
+        int a, b;
+        Wire(int a, int b) { 
+            this.a = a; 
+            this.b = b; 
+        }
+
+        @Override
+        public int compareTo(Wire o) {
+            return this.a - o.a;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+
+        Wire[] arr = new Wire[N];
+        int[] dp = new int[N];
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            arr[i] = new Wire(a, b);
+        }
+
+        Arrays.sort(arr);
+
+        int max = 1;
+        for (int i = 0; i < N; i++) {
+            dp[i] = 1;
+            for (int j = 0; j < i; j++) {
+                if (arr[i].b > arr[j].b) {
+                    dp[i] = Math.max(dp[i], dp[j] + 1);
+                }
+            }
+            max = Math.max(max, dp[i]);
+        }
+```
+        System.out.println(N - max);
+    }
+}


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2565
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
두 전봇대 사이 전깃줄 여러개. 교차하는 전깃줄이 없도록 하려면 최소 몇 개의 전깃줄을 없애야 하는가?
## 🔍 풀이 방법
교차하지 않게 최대한 많은 전깃줄을 배치한 다음 그 수를 전체 전깃줄의 수에서 빼면 됨.
왼쪽 전봇대 기준으로 오름차순 정렬한 뒤, 오른쪽 전봇대 번호로 최장 증가 부분 수열(LIS) 길이를 구한다.
## ⏳ 회고
전형적인 LIS 문제였다.