### PR TITLE
[20251020] BOJ / P5 / AB / 권혁준

### DIFF
--- a/khj20006/202510/20 BOJ P5 AB.md
+++ b/khj20006/202510/20 BOJ P5 AB.md
@@ -1,0 +1,48 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+using ll = long long;
+
+int Q;
+multiset<string> a, b;
+
+int main() {
+    cin.tie(0)->sync_with_stdio(0);
+    
+    cin>>Q;
+    for(string o, s;Q--;) {
+        cin>>o>>s;
+        if(o == "find") {
+            ll ans = 0;
+            string tmp = "";
+            int acnt[1000]{};
+            for(int i=0;i<s.size()-1;i++) {
+                tmp += s[i];
+                acnt[i] = a.count(tmp);
+            }
+            tmp = "";
+            reverse(s.begin(), s.end());
+            for(int i=0;i<s.size()-1;i++) {
+                tmp += s[i];
+                ans += acnt[s.size()-2-i] * b.count(tmp);
+            }
+            cout<<ans<<'\n';
+        }
+        else {
+            bool rev = s == "B";
+            bool add = o == "add";
+            auto &c = rev ? b : a;
+            cin>>s;
+            if(rev) reverse(s.begin(), s.end());
+            
+            string tmp = "";
+            for(char j:s) {
+                tmp += j;
+                if(add) c.insert(tmp);
+                else c.erase(c.find(tmp));
+            }
+        }
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/27652

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
집합 A, B에 대해 다음 쿼리를 수행해보자.
- add A S : A에 문자열 S를 추가
- delete A S : A에서 문자열 S를 제거
- add B S : B에 문자열 S를 추가
- delete B S : B에서 문자열 S를 제거
- find S : A의 원소의 접두사와 B의 원소의 접미사를 이어 붙여 S가 되는 경우의 수를 출력

## 🔍 풀이 방법
A에는 S의 모든 접두사를 다 넣어놓고, B에는 S의 모든 접미사를 다 넣어놓는다.
제거 연산 시에도 각각에서 모든 접두/접미사를 제거한다.
이때, 중복 원소가 생길 수 있으니까 multiset을 사용했다.
find 연산에서는 S의 모든 접두사와 접미사에 대해 A, B에서 존재하는 개수를 세서 계산했다.

## ⏳ 회고
C++만세