### PR TITLE
[20251020] BOJ / G5 / Ezreal 여눈부터 가네 ㅈㅈ / 이준희

### DIFF
--- a/JHLEE325/202510/20 BOJ G5 Ezreal 여눈부터 가네 ㅈㅈ.md
+++ b/JHLEE325/202510/20 BOJ G5 Ezreal 여눈부터 가네 ㅈㅈ.md
@@ -1,0 +1,30 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static final int MOD = 1000000007;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int N = Integer.parseInt(br.readLine());
+
+        long[][] dp = new long[N + 1][3];
+
+        dp[1][1] = 1;
+        dp[1][2] = 1;
+
+        for (int i = 2; i <= N; i++) {
+            dp[i][0] = (dp[i-1][1] + dp[i-1][2]) % MOD;
+            dp[i][1] = (dp[i-1][0] + dp[i-1][2]) % MOD;
+            dp[i][2] = (dp[i-1][0] + dp[i-1][1]) % MOD;
+        }
+
+        System.out.println(dp[N-1][1]);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/20500

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
1과 5로만 이루어진 N자리 양의 정수 중 15의 배수가 몇 개인지 구하는 문제입니다.

## 🔍 풀이 방법
DP를 이용해서 풀었습니다.
어떤 숫자가 15의 배수이려면 마지막자리 수는 0 또는 5여야 하는데 1과 5만 사용 가능하기 때문에 마지막자리 수는 무조건 5여야 합니다.
또 15는 3과 5의 공배수이므로 3의 배수 이면서 5의 배수인 경우를 찾아야 하는데 이 때 마지막자리 수가 5이면 5의 배수이기 때문에 3의 배수인지만 판단하면 됩니다.
그래서 모든 자리 숫자의 합이 3의 배수인 경우 3의 배수라는 규칙을 활용하여 나머지를 이용하여 점화식을 세웠습니다.
```
dp[i][0] = (dp[i-1][1] + dp[i-1][2]) % MOD;
dp[i][1] = (dp[i-1][0] + dp[i-1][2]) % MOD;
dp[i][2] = (dp[i-1][0] + dp[i-1][1]) % MOD;
```

## ⏳ 회고
처음에 DP 점화식 구하는 것 자체를 손도 못댔습니다.
3의 배수 규칙에 대해서 찾아보고 겨우 풀 수 있었습니다.
