### PR TITLE
[20251020] BOJ / G5 / 감소하는 수 / 김민진

### DIFF
--- a/zinnnn37/202510/20 BOJ G5 감소하는 수.md
+++ b/zinnnn37/202510/20 BOJ G5 감소하는 수.md
@@ -1,0 +1,55 @@
+```java
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class BJ_1038_감소하는_수 {
+
+	private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+	private static int        N;
+	private static List<Long> nums;
+
+	public static void main(String[] args) throws IOException {
+		if (init()) {
+			for (int i = 0; i <= 9; i++) {
+				sol(i);
+			}
+			Collections.sort(nums);
+			bw.write(nums.get(N) + "");
+		}
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+
+	private static boolean init() throws IOException {
+		N = Integer.parseInt(br.readLine());
+
+		if (N <= 10) {
+			bw.write(N + "");
+			return false;
+		} else if (N >= 1023) {
+			bw.write("-1");
+			return false;
+		}
+		nums = new ArrayList<>();
+
+		return true;
+	}
+
+	private static void sol(long num) throws IOException {
+		nums.add(num);
+
+		long mod = num % 10;
+		if (mod == 0) return;
+
+		for (int i = 0; i < mod; i++) {
+			sol(num * 10 + i);
+		}
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[감소하는 수](https://www.acmicpc.net/problem/1038)

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
가장 큰 자릿수부터 가장 작은 자릿수까지 해당 자릿수의 숫자가 점점 작아지는 수이면 감소하는 수
`N`번째 감소하는 수 구하기

## 🔍 풀이 방법
`0`부터 `num % 10` 값을 확인하면서 `num * 10 + i` 하기..
마지막에 감소하는 수가 들어있는 리스트를 정렬해서 `N`번째 수 출력하기

0부터 9까지의 숫자로 만들 수 있는 경우의 수는 `2^10 = 1024`인데 공집합 포함이니까 숫자는 1023개
→ `N ≥ 1023`이면 `-1`

## ⏳ 회고
브루트포스가 싫다