### PR TITLE
[20251021] BOJ / P5 / 카드 게임 / 한종욱

### DIFF
--- a/Ukj0ng/202510/21 BOJ P5 카드 게임.md
+++ b/Ukj0ng/202510/21 BOJ P5 카드 게임.md
@@ -1,0 +1,70 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static int[] uf, cards;
+    private static int N, M, K;
+    public static void main(String[] args) throws IOException {
+        init();
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+        cards = new int[M];
+        uf = new int[M];
+
+        st = new StringTokenizer(br.readLine());
+
+        for (int i = 0; i < M; i++) {
+            cards[i] = Integer.parseInt(st.nextToken());
+            uf[i] = i;
+        }
+
+        Arrays.sort(cards);
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < K; i++) {
+            int input = Integer.parseInt(st.nextToken());
+            int temp = binarySearch(input);
+            int index = find(temp);
+
+            bw.write(cards[index] + "\n");
+            uf[index] = index + 1;
+        }
+    }
+
+    private static int binarySearch(int target) {
+        int left = 0;
+        int right = M-1;
+
+        while (left < right) {
+            int mid = left + (right - left) / 2;
+
+            if (target < cards[mid]) {
+                right = mid;
+            } else {
+                left = mid + 1;
+            }
+        }
+
+        return left;
+    }
+
+    private static int find(int x) {
+        if (uf[x] == x) return x;
+
+        return uf[x] = find(uf[x]);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크

https://www.acmicpc.net/problem/16566

## 🧭 풀이 시간

45분

## 👀 체감 난이도

- [ ]  상
- [x]  중
- [ ]  하

## ✏️ 문제 설명

제시된 카드보다 큰 값 중 제일 작은 값을 제시하라.

## 🔍 풀이 방법

1. 이분탐색만 사용
이분탐색을 통해 제시된 카드 중 제일 큰 값의 인덱스를 찾고, `used[]` 배열을 사용해 찾은 인덱스부터 M-1까지 탐색해 사용되지 않은 카드를 찾아서 출력
2. 이분탐색 + 분리집합
분리집합을 통해, 사용한 카드는 다음 사용 가능한 카드로 연결한다. 이분탐색을 통해 제일 큰 값의 인덱스를 찾고 해당 카드와 연결된 사용할 수 있는 카드를 `find()`함수로 찾아서 출력 

## ⏳ 회고

Union은 일반적으로 양방향 연결인데, 이 문제에선 일방향 연결이 필요했다. 따라서, `uf[x] = y` ’x를 사용했으니 다음엔 y로 가라’가 맞다. 이분 탐색을 너무 오랜만에 해서, 헷갈렸다. `result`가 필수가 아니라 `left`를 반환하는 것만으로도 충분했다.