### PR TITLE
[20251021] BOJ / G4 / 주사위 굴리기 / 이준희

### DIFF
--- a/JHLEE325/202510/21 BOJ G4 주사위 굴리기.md
+++ b/JHLEE325/202510/21 BOJ G4 주사위 굴리기.md
@@ -1,0 +1,112 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static int n, m, x, y, k;
+    static int[][] map;
+    static int[] dx = {0, 0, 0, -1, 1}; // 동 서 북 남
+    static int[] dy = {0, 1, -1, 0, 0};
+    static int[] dice = {0, 0, 0, 0, 0, 0}; // 상 하 동 서 북 남
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        x = Integer.parseInt(st.nextToken());
+        y = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+
+        map = new int[n][m];
+
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < m; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        st = new StringTokenizer(br.readLine());
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < k; i++) {
+            int op = Integer.parseInt(st.nextToken());
+            int nx = x + dx[op];
+            int ny = y + dy[op];
+
+            if (nx >= n || nx < 0 || ny >= m || ny < 0)
+                continue;
+
+            x = nx;
+            y = ny;
+
+            switch (op) {
+                case 1:
+                    move_1();
+                    copy(nx, ny);
+                    sb.append(dice[0]).append("\n");
+                    break;
+                case 2:
+                    move_2();
+                    copy(nx, ny);
+                    sb.append(dice[0]).append("\n");
+                    break;
+                case 3:
+                    move_3();
+                    copy(nx, ny);
+                    sb.append(dice[0]).append("\n");
+                    break;
+                case 4:
+                    move_4();
+                    copy(nx, ny);
+                    sb.append(dice[0]).append("\n");
+                    break;
+            }
+        }
+        System.out.println(sb.toString());
+    }
+
+    static void move_1() {
+        int temp = dice[0];
+        dice[0] = dice[3];
+        dice[3] = dice[1];
+        dice[1] = dice[2];
+        dice[2] = temp;
+    }
+
+    static void move_2() {
+        int temp = dice[0];
+        dice[0] = dice[2];
+        dice[2] = dice[1];
+        dice[1] = dice[3];
+        dice[3] = temp;
+    }
+
+    static void move_3() {
+        int temp = dice[0];
+        dice[0] = dice[5];
+        dice[5] = dice[1];
+        dice[1] = dice[4];
+        dice[4] = temp;
+    }
+
+    static void move_4() {
+        int temp = dice[0];
+        dice[0] = dice[4];
+        dice[4] = dice[1];
+        dice[1] = dice[5];
+        dice[5] = temp;
+    }
+
+    static void copy(int cx, int cy) {
+        if (map[cx][cy] == 0) {
+            map[cx][cy] = dice[1];
+        } else {
+            dice[1] = map[cx][cy];
+            map[cx][cy] = 0;
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14499

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
N*M 지도에서 주사위를 굴리면서 아래의 규칙을 따릅니다.
1. 주사위를 굴렸을 때 이동한 칸에 쓰여있는 수가 0이면 주사위의 값을 칸에 복사한다.
2. 0이 아니면 칸의 값을 주사위의 아래칸에 복사하고 칸의 값을 0으로 만든다.

이 때 각 돌리기 마다 주사위의 상단에 쓰여진 숫자를 출력하는 문제입니다.
단, 지도를 벗어나는 돌리기 요청의 경우에는 그냥 무시됩니다.

## 🔍 풀이 방법
빡구현 문제였습니다.
주사위는 상 하 동 서 북 남 순의 6자리 1차원 배열을 사용하여 유지하였고
동 서 북 남 으로 주사위를 굴리는 경우의 메소드를 구현했습니다.

## ⏳ 회고
처음에 주사위에서 바닥칸으로 복사할 때 주사위 칸을 0으로 만들어서 틀렸었는데 문제를 다시 읽고 고쳤습니다.
