### PR TITLE
[20251021] BOJ / P4 / 경로 수정하기 / 권혁준

### DIFF
--- a/khj20006/202510/21 BOJ P4 경로 수정하기.md
+++ b/khj20006/202510/21 BOJ P4 경로 수정하기.md
@@ -1,0 +1,32 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+
+int N, Q;
+int U = 0, D = 0, L = 0, R = 0, X = 0, Y = 0;
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin >> N >> Q;
+	for (int i = 0; i < N; i++) {
+		char a;
+		cin >> a;
+		if (a == 'U') U++, Y++;
+		if (a == 'D') D++, Y--;
+		if (a == 'L') L++, X--;
+		if (a == 'R') R++, X++;
+	}
+
+	for (int x, y; Q--;) {
+		cin >> x >> y;
+		int xDiff = abs(x - X), yDiff = abs(y - Y);
+		if (abs(x) + abs(y) > N || (x + y) % 2 != (X + Y) % 2) {
+			cout << "-1\n";
+			continue;
+		}
+		cout << (xDiff + yDiff) / 2 << '\n';
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/20554

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
(0,0)에서 출발하여 상하좌우 중 하나로 구성된 길이 N의 이동 명령을 따라 이동한다.
도착점이 (x,y)가 되기 위해 수정해야 하는 이동 명령의 최솟값을 Q번 구해보자.

## 🔍 풀이 방법
새로운 도착점 (x,y)는 원래의 도착점 (X,Y)와 체스판 상에서 다른 색 칸에 위치한다면 절대 이동할 수 없다.
또, |x| + |y|가 N보다 크면 어떻게 수정해도 이동할 수 없다.
위 두 경우를 배제하면 답은 (|x-X| + |y-Y|) / 2라고 생각했다.

## ⏳ 회고
근데 답이 저게 아닌가보다. 왜 아니지? 반례도 못 찾겠음