### PR TITLE
[20251021] BOJ / G4 / 단어 수학 / 설진영

### DIFF
--- a/Seol-JY/202510/21 BOJ G4 단어 수학.md
+++ b/Seol-JY/202510/21 BOJ G4 단어 수학.md
@@ -1,0 +1,35 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        
+        Map<Character, Integer> weights = new HashMap<>();
+        
+        for (int i = 0; i < n; i++) {
+            String word = br.readLine();
+            int len = word.length();
+            for (int j = 0; j < len; j++) {
+                char c = word.charAt(j);
+                int weight = (int) Math.pow(10, len - 1 - j);
+                weights.put(c, weights.getOrDefault(c, 0) + weight);
+            }
+        }
+        
+        List<Integer> weightList = new ArrayList<>(weights.values());
+        weightList.sort((a, b) -> b - a);
+        
+        int result = 0;
+        int digit = 9;
+        for (int weight : weightList) {
+            result += weight * digit;
+            digit--;
+        }
+        
+        System.out.println(result);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
각 알파벳을 0-9 숫자로 매핑하여 주어진 단어들의 합을 최대화하는 문제

## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
각 알파벳을 0-9 숫자로 매핑하여 주어진 단어들의 합을 최대화하는 문제

## 🔍 풀이 방법 
그리디, 어짜피 정렬할거니까 그냥 신경쓰지말고 큰거부터 차례대로 할당하고 모두 합하면됨
자릿수별 가중치 계산하고 큰순서대로 9부터 할당하기

## ⏳ 회고
개꿀잼문제