### PR TITLE
[20251022] BOJ / G3 / 난개발 / 한종욱

### DIFF
--- a/Ukj0ng/202510/22 BOJ G3 난개발.md
+++ b/Ukj0ng/202510/22 BOJ G3 난개발.md
@@ -1,0 +1,75 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static List<int[]> events;
+    private static int[][] points, traffic;
+    private static int N, M;
+    public static void main(String[] args) throws IOException {
+        init();
+        long answer = sweep();
+
+        bw.write(answer + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        events = new ArrayList<>();
+        points = new int[N+1][2];
+        traffic = new int[M][3];
+
+        for (int i = 1; i <= N; i++) {
+            st = new StringTokenizer(br.readLine());
+            points[i][0] = Integer.parseInt(st.nextToken());
+            points[i][1] = Integer.parseInt(st.nextToken());
+        }
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+            int c = Integer.parseInt(st.nextToken());
+
+            traffic[i][0] = Math.min(points[u][1], points[v][1]);
+            traffic[i][1] = Math.max(points[u][1], points[v][1]);
+            traffic[i][2] = c;
+        }
+
+        Arrays.sort(traffic, (o1, o2) -> {
+            if (o1[0] == o2[0]) return Integer.compare(o1[1], o2[1]);
+            return Integer.compare(o1[0], o2[0]);
+        });
+
+        for (int[] t : traffic) {
+            events.add(new int[]{t[0], t[2], 1});
+            events.add(new int[]{t[1]+1, t[2], -1});
+        }
+
+        events.sort((o1, o2) -> {
+            if (o1[0] != o2[0]) return Integer.compare(o1[0], o2[0]);
+            return Integer.compare(o1[2], o2[2]);
+        });
+    }
+
+    private static long sweep() {
+        long result = 0;
+        long current= 0;
+
+        for (int[] e : events) {
+            current += (long)e[1]*e[2];
+            result = Math.max(result, current);
+        }
+
+        return result;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/19584

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
도로의 통행량이 주어진다. 도로를 철거할 때, 통행량을 최대한 많이 막았다고 한다면 최대로 많이 막은 통행량을 출력하라.
## 🔍 풀이 방법
도로를 y기준으로 정렬하고 이벤트로 바꿔서 스위핑해 푼다. 

## ⏳ 회고
스위핑은 투포인터와 다른 점이 있다. 어려운 스위핑은 '추가', '삭제' 처럼 각 행위를 이벤트로 처리해 해당 이벤트가 들어올 때마다 처리하는 방식을 사용한다. 