### PR TITLE
[20251023] BOJ / G5 / 센서 / 이준희

### DIFF
--- a/JHLEE325/202510/23 BOJ G5 센서.md
+++ b/JHLEE325/202510/23 BOJ G5 센서.md
@@ -1,0 +1,40 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = Integer.parseInt(br.readLine());
+        int k = Integer.parseInt(br.readLine());
+
+        int[] sensors = new int[n];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            sensors[i] = Integer.parseInt(st.nextToken());
+        }
+
+        if (k >= n) {
+            System.out.println(0);
+            return;
+        }
+
+        Arrays.sort(sensors);
+
+        int[] diff = new int[n - 1];
+        for (int i = 0; i < n - 1; i++) {
+            diff[i] = sensors[i + 1] - sensors[i];
+        }
+
+        Arrays.sort(diff);
+
+        int sum = 0;
+        for (int i = 0; i < n - k; i++) {
+            sum += diff[i];
+        }
+
+        System.out.println(sum);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2212

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
센서의 거리가 주어지고 센서와 통신하는 K개의 집중국으로 모든 센서를 커버해야 할 때 집중국의 수신가능 영역 길이의 합의 최소값을 구하는 문제입니다.

## 🔍 풀이 방법
각 센서의 좌표를 오름차순으로 정렬한 후 센서간의 거리 차이 배열을 만들었습니다.
이후 거리 차이 배열도 오름차순으로 정렬한 후
N-K개의 거리차이들을 더한 값을 출력했습니다.

## ⏳ 회고
처음에 집중국을 어디에 둘지 고민했었는데 거리차이를 이용하는 아이디어를 떠올리기가 쉽지 않았던 것 같습니다.
