### PR TITLE
[20251023] BOJ / D4 / 수열과 쿼리 0 / 권혁준

### DIFF
--- a/khj20006/202510/23 BOJ D4 수열과 쿼리 0.md
+++ b/khj20006/202510/23 BOJ D4 수열과 쿼리 0.md
@@ -1,0 +1,93 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+
+int N, Q, sq, s[100001]{};
+deque<int> v[200001]{};
+int c[200001]{}, cc[801]{}, ans[100000]{};
+tuple<int, int, int> qs[100000]{};
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin >> N;
+	sq = sqrt(N);
+	for (int i = 1; i <= N; i++) {
+		cin >> s[i];
+		s[i] += s[i - 1];
+	}
+
+	cin >> Q;
+	for (int i = 0; i < Q; i++) {
+		auto& [l, r, x] = qs[i];
+		cin >> l >> r;
+		x = i;
+		l--;
+	}
+	
+	sort(qs, qs + Q, [](auto a, auto b) -> bool {
+		auto [al, ar, ax] = a;
+		auto [bl, br, bx] = b;
+		if (al / sq == bl / sq) return ar < br;
+		return al / sq < bl / sq;
+	});
+
+	int l = 0, r = 0;
+	v[100000].push_back(0);
+	c[100000]++, cc[100000 / sq]++;
+	for (int i = 0; i < Q; i++) {
+		auto [pl, pr, x] = qs[i];
+		while (r < pr) {
+			int z = s[++r] + 100000;
+			if (!v[z].empty()) {
+				c[v[z].back() - v[z].front()]--;
+				cc[(v[z].back() - v[z].front()) / sq]--;
+			}
+			v[z].push_back(r);
+			c[v[z].back() - v[z].front()]++;
+			cc[(v[z].back() - v[z].front()) / sq]++;
+		}
+		while (pr < r) {
+			int z = s[r--] + 100000;
+			c[v[z].back() - v[z].front()]--;
+			cc[(v[z].back() - v[z].front()) / sq]--;
+			v[z].pop_back();
+			if (!v[z].empty()) {
+				c[v[z].back() - v[z].front()]++;
+				cc[(v[z].back() - v[z].front()) / sq]++;
+			}
+		}
+		while (l < pl) {
+			int z = s[l++] + 100000;
+			c[v[z].back() - v[z].front()]--;
+			cc[(v[z].back() - v[z].front()) / sq]--;
+			v[z].pop_front();
+			if (!v[z].empty()) {
+				c[v[z].back() - v[z].front()]++;
+				cc[(v[z].back() - v[z].front()) / sq]++;
+			}
+		}
+		while (pl < l) {
+			int z = s[--l] + 100000;
+			if (!v[z].empty()) {
+				c[v[z].back() - v[z].front()]--;
+				cc[(v[z].back() - v[z].front()) / sq]--;
+			}
+			v[z].push_front(l);
+			c[v[z].back() - v[z].front()]++;
+			cc[(v[z].back() - v[z].front()) / sq]++;
+		}
+
+		for (int i = 800; i >= 0; i--) if (cc[i]) {
+			for (int j = sq * (i + 1) - 1; j >= sq * i; j--) if (c[j]) {
+				ans[x] = j;
+				break;
+			}
+			break;
+		}
+	}
+
+	for (int i = 0; i < Q; i++) cout << ans[i] << '\n';
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/13545

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
1과 -1로만 이루어져 있는 길이 N인 수열 A에 아래 쿼리들을 처리해보자.
- i j : 부분 수열 A[i,,j]에서 **합이 0이면서 가장 긴 연속 부분 수열의 길이**를 출력

## 🔍 풀이 방법
어떤 부분 수열 A[i..j]가 합이 0이라는 것은, A의 누적 합 배열 s에서 s[j] - s[i-1] = 0이라는 것과 똑같다.
-> 쿼리에서 현재 구간을 관리할 때 어떤 원소 s[i]에 대해, 이 값을 가지는 인덱스들을 모두 덱 v[s[i]]에 저장해둔다.

일단 mo's로 쿼리를 정렬한다.
인덱스 i가 현재 구간에 추가된다면, 기존의 v[s[i]]에 i를 추가해서 해당 원소를 마지막으로 갖는 최대 길이를 높여준다.
인덱스 i가 현재 구간에서 빠지게 되면, 기존의 v[s[i]]에서 i를 빼서 해당 원소를 마지막으로 가지던 최대 길이를 낮춰준다.

최대 길이를 효율적으로 구하기 위해서 각 누적 합 원소에 대한 인덱스를 저장하는 덱을 썼고, 
각 쿼리에 대한 답을 구할 때는 길이에 대한 카운트 배열 + 제곱근 분할 카운트 배열로 쿼리 당 O(sqrt(N))에 구해줬다.

## ⏳ 회고
덱이 비어있는지 확인을 안 해서 `AccessEmptyContainer` 에러가 떴다 조심하자