### PR TITLE
[20251024] BOJ / G2 / 트리의 지름 / 김민진

### DIFF
--- a/zinnnn37/202510/24 BOJ G2 트리의 지름.md
+++ b/zinnnn37/202510/24 BOJ G2 트리의 지름.md
@@ -1,0 +1,98 @@
+```java
+package etc;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class BJ_1167_트리의_지름 {
+
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static StringTokenizer st;
+
+    private static int V, ans, max, maxNode;
+    private static int[] dist;
+    private static List<Node>[] graph;
+
+    private static class Node {
+        int to;
+        int weight;
+
+        Node(int to, int weight) {
+            this.to = to;
+            this.weight = weight;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        V = Integer.parseInt(br.readLine());
+        ans = 0;
+        max = 0;
+        maxNode = 0;
+
+        dist = new int[V + 1];
+        Arrays.fill(dist, -1);
+        dist[1] = 0;
+
+        graph = new List[V + 1];
+        for (int i = 1; i <= V; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < V; i++) {
+            st = new StringTokenizer(br.readLine());
+
+            int v = Integer.parseInt(st.nextToken());
+
+            int u;
+            while ((u = Integer.parseInt(st.nextToken())) != -1) {
+                int w = Integer.parseInt(st.nextToken());
+                graph[v].add(new Node(u, w));
+            }
+        }
+    }
+
+    private static void sol() throws IOException {
+        dfs(1, 0);
+        findMax();
+
+        max = 0;
+        Arrays.fill(dist, -1);
+        dist[maxNode] = 0;
+        dfs(maxNode, 0);
+        findMax();
+
+        bw.write(max + "");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void dfs(int v, int w) throws IOException {
+        for (Node u : graph[v]) {
+            if (dist[u.to] != -1) continue;
+
+            dist[u.to] = u.weight + w;
+            dfs(u.to, dist[u.to]);
+        }
+    }
+
+    private static void findMax() {
+        for (int i = 1; i <= V; i++) {
+            if (max < dist[i]) {
+                max = Math.max(max, dist[i]);
+                maxNode = i;
+            }
+        }
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[트리의 지름](https://www.acmicpc.net/problem/1167)

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
트리의 지름 구하기

## 🔍 풀이 방법
트리의 특성상 임의의 한 노드에서 가장 먼 노드는 트리 지름의 한쪽 끝임이 보장됨
1부터 시작해서 가장 먼 노드를 찾고 그 노드와 가장 먼 노드를 찾으면 트리의 지름을 구할 수 있음

## ⏳ 회고
알쏭달쏭 디지털세계