### PR TITLE
[20251024] PGM / LV3 / 입국심사 / 강신지

### DIFF
--- a/ksinji/202510/24 PGM 입국심사.md
+++ b/ksinji/202510/24 PGM 입국심사.md
@@ -1,0 +1,33 @@
+```java
+import java.util.*;
+
+class Solution {
+    public long solution(int n, int[] times) {
+        Arrays.sort(times);
+        long min = 1;
+
+    	long max = (long) times[times.length-1]*n;
+    	long mid = 0;
+    	long sum;
+    	long answer = max;
+
+    	while(min <= max) {
+    		sum = 0;
+    		mid = (min + max) / 2;
+
+    		for(int time : times) {
+    			sum += mid / time;
+    		}
+
+    		if(sum >= n) {
+				answer = mid;
+				max = mid - 1;
+    		}
+    		else {
+    			min = mid + 1;
+    		}
+    	}
+```
+        return answer;
+    }
+}


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/43238
## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
입국심사를 기다리는 사람 n명, 입국심사관들이 한 명을 심사할 때 걸리는 시간이 배열로 주어짐. 모든 사람이 심사를 받는 데 걸리는 최소 시간을 return하라.
## 🔍 풀이 방법
입국 심사를 기다리는 사람 수가 최대 10억명으로 매우 크므로 브루트포스로는 답을 구할 수 없으므로 이분탐색을 이용해 풀었다.
초기 max를 제일 오래 걸리는 심사 시간으로 n명을 심사할 때 걸리는 시간으로 해두고, mid 시간 내에 각 심사관이 몇 명을 심사할 수 있는지 계산한 뒤 그 값에 따라 min과 max를 조절해가며 적절한 mid값을 찾아 반환했다.
## ⏳ 회고
백준 1114 통나무 자르기 풀려다가 화가 나서 프로그래머스에서 이분탐색 문제를 풀었다. 통나무 문제는 다음에 다시 풀어봐야.