### PR TITLE
[20251024] BOJ / P4 / 홍준이의 교집합 / 권혁준

### DIFF
--- a/khj20006/202510/24 BOJ P4 홍준이의 교집합.md
+++ b/khj20006/202510/24 BOJ P4 홍준이의 교집합.md
@@ -1,0 +1,45 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+using ll = long long;
+
+ll N, K;
+const ll MOD = 1e9 + 7;
+vector<pair<ll, int>> events;
+ll c[200001]{};
+
+ll power(ll a, ll b) {
+	if (b == 0) return 1;
+	if (b == 1) return a % MOD;
+	ll h = power(a, b >> 1);
+	h = (h * h) % MOD;
+	return (b & 1) ? h * a % MOD : h;
+}
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin >> N >> K;
+
+	c[K] = 1;
+	for (int x = 1; K + x <= N; x++) c[K + x] = c[K + x - 1] * (K + x) % MOD * power(x, MOD - 2) % MOD;
+
+	for (int i = 0, l, r; i < N; i++) {
+		cin >> l >> r;
+		events.emplace_back(l, 1);
+		events.emplace_back(r + 1, -1);
+	}
+
+	sort(events.begin(), events.end());
+	
+	ll ans = 0, prev = MOD, cnt = 0;
+	for (int i = 0; i < N * 2;) {
+		ll prevCnt = cnt, cur = events[i].first;
+		while (i < N * 2 && events[i].first == cur) cnt += events[i++].second;
+		if (prev != MOD) ans = (ans + (cur - prev) * c[prevCnt]) % MOD;
+		prev = cur;
+	}
+	cout << ans;
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/12992

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N개의 1차원 구간이 있다.
i번째 구간은 L[i]부터 R[i]까지 포함하는 구간이고, 구간의 길이는 R[i] - L[i] + 1이다.
서로 다른 구간들을 k개 골랐을 때, 가능한 모든 경우의 수에 대한 k개 구간의 교집합의 길이 합을 구해보자.

## 🔍 풀이 방법
구간을 고르는 순서는 상관 없다. -> 조합을 써야겠다.

구간의 시작과 끝을 별개의 event로 쪼개고 정렬 후 스위핑 하면서 prev, cur 좌표와 겹치는 개수 cnt를 관리했다.

이전 cnt가 k 이상이었다면?
답에 (cur-prev) * comb[cnt][k] 만큼 더해주기

C[n] = comb[n][k]라고 하면,
C[k+x] = C[k+x-1] * (k+x) / x 이고, 페르마의 소정리에 의해
C[k+x] = (C[k+x-1] * (k+x) * x^(MOD-2)) % MOD 가 되어서 O(NlogMOD)에 배열 C를 모두 채울 수 있다.

## ⏳ 회고
문제 지문이 무섭게 생겼는데 속은 그렇지 않음