### PR TITLE
[20251025] BOJ / G4 / 가장 긴 증가하는 부분 수열 4 / 김민진

### DIFF
--- a/zinnnn37/202510/25 BOJ G4 가장 긴 증가하는 부분 수열 4.md
+++ b/zinnnn37/202510/25 BOJ G4 가장 긴 증가하는 부분 수열 4.md
@@ -1,0 +1,75 @@
+```java
+import java.io.*;
+import java.util.Stack;
+import java.util.StringTokenizer;
+
+public class BJ_14002_가장_긴_증가하는_부분_수열_4 {
+
+	private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+	private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	private static final StringBuilder   sb = new StringBuilder();
+	private static       StringTokenizer st;
+
+	private static int N, lis;
+	private static int[] nums, dp;
+	private static Stack<Integer> stack;
+
+	public static void main(String[] args) throws IOException {
+		init();
+		sol();
+	}
+
+	private static void init() throws IOException {
+		N = Integer.parseInt(br.readLine());
+
+		nums = new int[N];
+		st = new StringTokenizer(br.readLine());
+		for (int i = 0; i < N; i++) {
+			nums[i] = Integer.parseInt(st.nextToken());
+		}
+
+		dp = new int[N];
+		dp[0] = 1;
+		stack = new Stack<>();
+	}
+
+	private static void sol() throws IOException {
+		getLis();
+		getArr();
+
+		sb.append(lis).append("\n");
+		while (!stack.isEmpty()) {
+			sb.append(stack.pop()).append(" ");
+		}
+
+		bw.write(sb.toString());
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+
+	private static void getLis() {
+		lis = 1;
+		for (int i = 1; i < N; i++) {
+			dp[i] = 1;
+			for (int j = 0; j < i; j++) {
+				if (nums[i] > nums[j]) {
+					dp[i] = Math.max(dp[i], dp[j] + 1);
+					lis = Math.max(lis, dp[i]);
+				}
+			}
+		}
+	}
+
+	private static void getArr() {
+		int targetLen = lis;
+
+		for (int i = N - 1; i >= 0; i--) {
+			if (dp[i] == targetLen) {
+				stack.push(nums[i]);
+				targetLen--;
+			}
+		}
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[가장 긴 증가하는 부분 수열 4](https://www.acmicpc.net/problem/14002)

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
수열이 주어졌을 때 가장 긴 증가하는 부분 수열의 길이와 값 출력하기

## 🔍 풀이 방법
dp + 역추적
dp로 `i`가 가장 마지막 요소라고 가정했을 때의 부분 수열 길이 저장하여 `lis` 값을 구함
`dp`배열 역순으로 확인
만약 `dp[i]`에 `lis`와 동일한 값이 들어있으면 해당 값을 스택에 넣고 `lis--`
탐색 끝나면 스택 `pop()` 하면서 값 출력

## ⏳ 회고
🙂🙃🙂🙃