### PR TITLE
[20251025] BOJ / G5 / 트리 / 설진영

### DIFF
--- a/Seol-JY/202510/25 BOJ G5 트리.md‎
+++ b/Seol-JY/202510/25 BOJ G5 트리.md‎
@@ -1,0 +1,69 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int N;
+    static List<Integer>[] tree;
+    static boolean[] removed;
+    static int deleteNode;
+    
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        
+        N = Integer.parseInt(br.readLine());
+        tree = new ArrayList[N];
+        removed = new boolean[N];
+        
+        for (int i = 0; i < N; i++) {
+            tree[i] = new ArrayList<>();
+        }
+        
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int root = -1;
+        
+        for (int i = 0; i < N; i++) {
+            int parent = Integer.parseInt(st.nextToken());
+            if (parent == -1) {
+                root = i;
+            } else {
+                tree[parent].add(i);
+            }
+        }
+        
+        deleteNode = Integer.parseInt(br.readLine());
+        
+        removeNode(deleteNode);
+        
+        if (removed[root]) {
+            System.out.println(0);
+            return;
+        }
+        
+        System.out.println(countLeaf(root));
+    }
+    
+    static void removeNode(int node) {
+        removed[node] = true;
+        for (int child : tree[node]) {
+            removeNode(child);
+        }
+    }
+    
+    static int countLeaf(int node) {
+        if (removed[node]) return 0;
+        
+        int childCount = 0;
+        int leafCount = 0;
+        
+        for (int child : tree[node]) {
+            if (!removed[child]) {
+                childCount++;
+                leafCount += countLeaf(child);
+            }
+        }
+        
+        return childCount == 0 ? 1 : leafCount;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1068

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
트리에서 특정 노드를 삭제했을 때 리프 노드의 개수를 구하는 문제
노드를 삭제하면 그 노드의 모든 자손도 함께 삭제


## 🔍 풀이 방법
부모자식관계를 인접리스트로 저장하
dfs로 삭제할 노드의 모든 자손을 removed 배열에 표시함

각 노드에서 살아있는 자식이 0개면 리프로 보고, 재귀적으로 개수 합하기

## ⏳ 회고
ez 루트처리 신경써야할듯