### PR TITLE
[20251026] PGM / LV2 / 피로도 / 강신지

### DIFF
--- a/ksinji/202510/26 PGM 피로도.md
+++ b/ksinji/202510/26 PGM 피로도.md
@@ -1,0 +1,29 @@
+```java
+class Solution {
+    static boolean[] visited;
+    static int answer = 0;
+
+    public int solution(int k, int[][] dungeons) {
+        visited = new boolean[dungeons.length];
+        dfs(k, dungeons, 0);
+        return answer;
+    }
+
+    static void dfs(int now, int[][] dungeons, int count) {
+        if (count > answer) answer = count;
+
+        for (int i = 0; i < dungeons.length; i++) {
+            if (visited[i]) continue;
+
+            int need = dungeons[i][0];
+            int cost = dungeons[i][1];
+
+            if (now >= need) {
+                visited[i] = true;
+                dfs(now - cost, dungeons, count + 1);
+                visited[i] = false;
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/87946
## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
각 던전마다 최소 입장 피로도와 소모 피로도가 있음. 2차원 배열로 주어짐.
각 던전은 하루에 한 번 탐험할 수 있음
현재 피로도 기준으로 최대 몇 개의 던전을 탐험할 수 있는지 구하라
## 🔍 풀이 방법
던전의 수가 최대 8개로 적기 때문에 완탐으로 가능한 모든 탐험 순서를 시도했다.
dfs를 써서 현재 피로도에서 입장 가능한 던전만 선택해 탐험하고, 방문 여부를 기록하며 최대 탐험 개수를 갱신했다.
## ⏳ 회고
