### PR TITLE
[20251026] BOJ / G4 / 카드 섞기 / 설진영

### DIFF
--- a/Seol-JY/202510/26 BOJ G4 카드 섞기.md‎
+++ b/Seol-JY/202510/26 BOJ G4 카드 섞기.md‎
@@ -1,0 +1,82 @@
+```java
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        
+        int N = Integer.parseInt(br.readLine());
+        
+        int[] P = new int[N];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            P[i] = Integer.parseInt(st.nextToken());
+        }
+        
+        int[] S = new int[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            S[i] = Integer.parseInt(st.nextToken());
+        }
+        
+        int[] current = new int[N];
+        for (int i = 0; i < N; i++) {
+            current[i] = i;
+        }
+        
+        boolean isGoal = true;
+        for (int i = 0; i < N; i++) {
+            if (current[i] % 3 != P[i]) {
+                isGoal = false;
+                break;
+            }
+        }
+        
+        if (isGoal) {
+            System.out.println(0);
+            return;
+        }
+        
+        int maxAttempts = 500000;
+        
+        for (int shuffle = 1; shuffle <= maxAttempts; shuffle++) {
+            int[] next = new int[N];
+            for (int i = 0; i < N; i++) {
+                next[i] = current[S[i]];
+            }
+            current = next;
+            
+            boolean success = true;
+            for (int i = 0; i < N; i++) {
+                if (current[i] % 3 != P[i]) {
+                    success = false;
+                    break;
+                }
+            }
+            
+            if (success) {
+                System.out.println(shuffle);
+                return;
+            }
+            
+            if (shuffle > 1) {
+                boolean backToStart = true;
+                for (int i = 0; i < N; i++) {
+                    if (current[i] != i) {
+                        backToStart = false;
+                        break;
+                    }
+                }
+                if (backToStart) {
+                    System.out.println(-1);
+                    return;
+                }
+            }
+        }
+        
+        System.out.println(-1);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1091

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
N개의 카드를 3명의 플레이어에게 나눠주는데, 특정 섞기 방법을 반복 적용해서 각 카드가 원하는 플레이어에게 가도록 하는 최소 섞기 횟수를 구하는 문제


## 🔍 풀이 방법
- `current[i]` 배열로 초기 위치 i의 카드가 현재 어느 위치에 있는지 추적
- 매 섞기마다 `next[i] = current[S[i]]`로 카드 위치 업데이트
- 순열의 사이클 특성상 원점으로 돌아오면 불가능 판정

## ⏳ 회고
음 귀찮네