### PR TITLE
[20251027] BOJ / P5 / 버스 노선 / 한종욱

### DIFF
--- a/Ukj0ng/202510/27 BOJ P5 버스 노선.md
+++ b/Ukj0ng/202510/27 BOJ P5 버스 노선.md
@@ -1,0 +1,61 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static List<int[]> busLines;
+    private static boolean[] contains;
+    private static int N, M;
+    public static void main(String[] args) throws IOException {
+        init();
+        sweep();
+
+        for (int i = 1; i <= M; i++) {
+            if (!contains[i]) bw.write(i + " ");
+        }
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+        M = Integer.parseInt(br.readLine());
+
+        busLines = new ArrayList<>();
+        contains = new boolean[M+1];
+
+        for (int i = 1; i <= M; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            if (a < b) {
+                busLines.add(new int[]{a, b, i});
+                busLines.add(new int[]{a+N, b+N, i});
+            } else {
+                busLines.add(new int[]{a, b+N, i});
+            }
+        }
+
+        busLines.sort((o1, o2) -> {
+            if (o1[0] == o2[0]) return Integer.compare(o2[1], o1[1]);
+            return Integer.compare(o1[0], o2[0]);
+        });
+    }
+
+    private static void sweep() {
+        int end = -1;
+
+        for (int[] busLine : busLines) {
+            if (busLine[1] <= end) {
+                contains[busLine[2]] = true;
+            } else {
+                end = busLine[1];
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/10165
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
원형의 버스 노선이 있는데, 비용 절감을 위해 일부 버스 노선을 취소하려고 한다. 취소되는 노선은 다른 노선에 포함되어 있는 노선이다. 계속 운행될 버스 노선을 오름차순으로 출력하라. 
## 🔍 풀이 방법
버스 노선과 index를 배열에 저장하고
1. 시작을 기준으로 오름차순
2. 시작이 같으면 끝에서 내림차순
으로 정렬한다. 이렇게 정렬하는 이유는 포함되는 버스 노선을 생략하기 위함이다. 

원형을 계산하기 위해 
1. a<b인 경우엔, [a, b], [a+N, b+N]의 노선 포함
2. a>b인 경우엔, [a, b+N]의 노선 포함

끝점을 기준으로 포함되면 삭제하고, 아니면 끝점을 갱신한다. 
## ⏳ 회고
이 문제를 맨 처음 Event로 들어가고 나가고를 분리했다. 근데 너무 복잡해지며 풀기 어려웠다. 
Event로 나누는 경우와 구간 전체를 쓰는 경우를 잘 판단해야 한다. 
- Event로 나누는 경우 : 동시에 활성화된 개수가 중요할 경우
    - 활성 구간들의 교집합 찾기
    - 특정 시점에 겹치는 개수 세기
    - 구간들이 "동시에 진행 중"인 상태가 중요 
- 구간 전체로 쓰는 경우 : 구간끼리 비교/포함관계가 중요한 경우
    - 구간 A가 구간 B를 완전히 포함
    - 최소 개수의 구간으로 덮기
    - 구간 병합/제거