### PR TITLE
[20251028] BOJ / G5 / 주사위 / 이준희

### DIFF
--- a/JHLEE325/202510/28 BOJ G5 주사위.md
+++ b/JHLEE325/202510/28 BOJ G5 주사위.md
@@ -1,0 +1,55 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        long N = Long.parseLong(br.readLine());
+        long[] d = new long[6];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < 6; i++) {
+            d[i] = Long.parseLong(st.nextToken());
+        }
+
+        if (N == 1) {
+            long sum = 0, maxv = 0;
+            for (int i = 0; i < 6; i++) {
+                sum += d[i];
+                if (d[i] > maxv) maxv = d[i];
+            }
+            System.out.println(sum - maxv);
+            return;
+        }
+
+        long min1 = Long.MAX_VALUE;
+        for (int i = 0; i < 6; i++) min1 = Math.min(min1, d[i]);
+
+        long min2 = Long.MAX_VALUE;
+        for (int i = 0; i < 6; i++) {
+            for (int j = i + 1; j < 6; j++) {
+                if (i + j == 5) continue;
+                min2 = Math.min(min2, d[i] + d[j]);
+            }
+        }
+        int[][] corners = {
+                {0, 1, 2}, {0, 1, 3}, {0, 4, 2}, {0, 4, 3},
+                {5, 1, 2}, {5, 1, 3}, {5, 4, 2}, {5, 4, 3}
+        };
+        long min3 = Long.MAX_VALUE;
+        for (int[] c : corners) {
+            long sum = d[c[0]] + d[c[1]] + d[c[2]];
+            if (sum < min3) min3 = sum;
+        }
+
+        long res = 0;
+        res += 4 * min3;
+        res += (8 * N - 12) * min2;
+        res += (5 * N * N - 16 * N + 12) * min1;
+
+        System.out.println(res);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1041

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
주사위 N^3개를 이용해 N*N*N 크기의 정육면체를 만들었을 때
아랫면을 제외한 면에 보이는 숫자들의 합이 최소인 경우를 구하는 문제입니다.

## 🔍 풀이 방법
각각 1면만 보이는 주사위의 갯수, 2면이 보이는 주사위의 갯수, 3면이 보이는 주사위의 갯수를 구해서, 각 경우의 최솟값을 곱해서 구했습니다.

## ⏳ 회고
머리로 풀려다가 3면만 보이는 경우 쌍을 잘 못찾아서 삽질했습니다
