### PR TITLE
[20251028] BOJ / G5 / 가장 긴 짝수 연속한 수열(large)

### DIFF
--- a/0224LJH/202510/28 BOJ 가장 긴 짝수 연속한 수열(large).md
+++ b/0224LJH/202510/28 BOJ 가장 긴 짝수 연속한 수열(large).md
@@ -1,0 +1,79 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+
+	
+	static int len,totalErase,curErase,start,end,ans,curLen;
+	static int[] arr;
+	
+    public static void main(String[] args) throws IOException {
+    	init();
+    	process();
+    	print();
+    }
+
+    private static void init() throws IOException{
+    	BufferedReader br = new BufferedReader(new InputStreamReader(System.in));;
+    	StringTokenizer st = new StringTokenizer(br.readLine());
+    	len = Integer.parseInt(st.nextToken());
+    	totalErase = Integer.parseInt(st.nextToken());
+    	arr = new int[len];
+    	st = new StringTokenizer(br.readLine());
+    	for (int i = 0; i < len; i++) {
+    		arr[i] = Integer.parseInt(st.nextToken());
+    	}
+    	
+    	start = 0;
+    	end = 0;
+    	ans = 0;
+    	curErase = 0;
+    	curLen = 0;
+
+    }
+    
+    private static void process() {
+    	if (arr[0] %2 == 0) {
+    		curLen++;
+    		ans++;
+    	} else {
+    		curErase++;
+    	}
+
+    	while( end < len) {
+    		if (curErase < totalErase) {
+    			end++;
+    			if (end == len)break;
+    			if (arr[end] %2 == 0) curLen++;
+    			else curErase++;
+    			
+    		} else if (curErase == totalErase && end + 1 < len && arr[end+1]%2 ==0) {
+    			end++;
+    			curLen++;
+    		} else {
+    			if (arr[start] %2 == 0) {
+    				curLen--;
+    			} else {
+    				curErase--;
+    			}
+    			start++;
+    		}
+    		
+    		
+    		
+    		ans = Math.max(ans, curLen);
+    	}
+    }
+    
+
+    
+    private static void print() {
+    	System.out.println(ans);
+    }
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/22862

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
길이가 $N$인 수열  $S$가 있다. 
수열 $S$는 1 이상인 정수로 이루어져 있다.

수열 $S$에서 원하는 위치에 있는 수를 골라 최대 $K$번 삭제를 할 수 있다.

예를 들어, 수열 
$S$가 다음과 같이 구성되어 있다고 가정하자.

수열 S : 1 2 3 4 5 6 7 8

수열 $S$에서 4번째에 있는 4를 지운다고 하면 아래와 같다.

수열 S : 1 2 3 5 6 7 8 

수열 $S$에서 최대 $K$번 원소를 삭제한 수열에서 짝수로 이루어져 있는 연속한 부분 수열 중 가장 긴 길이를 구해보자.

## 🔍 풀이 방법
투포인터를 진행하면 간단하게 진행할 수 있다. 단 홀수인경우 길이가 아닌 지우는 횟수를 늘리는 식으로 진행하면된다.

## ⏳ 회고
