### PR TITLE
[20251028] BOJ / G4 / 주사위 굴리기 / 이강현

### DIFF
--- a/lkhyun/202510/28 BOJ G4 주사위 굴리기.md
+++ b/lkhyun/202510/28 BOJ G4 주사위 굴리기.md
@@ -1,0 +1,101 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main{
+    static class State{
+        int x,y;
+        int[] row = new int[3];
+        int[] col = new int[3];
+        State(int x, int y){
+            this.x = x;
+            this.y = y;
+        }
+        public void rolling(int direction, int[][] map) throws Exception{
+            if(direction == 1){ //동쪽
+                if(y == map[0].length-1) return;
+                int temp = col[2];
+                col[2] = row[2];
+                row[2] = row[1];
+                row[1] = row[0];
+                row[0] = temp;
+                y++;
+                check();
+                return;
+            }
+            if(direction == 2){ //서쪽
+                if(y == 0) return;
+                int temp = col[2];
+                col[2] = row[0];
+                row[0] = row[1];
+                row[1] = row[2];
+                row[2] = temp;
+                y--;
+                check();
+                return;
+            }
+            if(direction == 3){ //북쪽
+                if(x == 0) return;
+                int temp = col[2];
+                col[2] = col[0];
+                col[0] = row[1];
+                row[1] = col[1];
+                col[1] = temp;
+                x--;
+                check();
+                return;
+            }
+            if(direction == 4){ //남쪽
+                if(x == map.length-1) return;
+                int temp = col[2];
+                col[2] = col[1];
+                col[1] = row[1];
+                row[1] = col[0];
+                col[0] = temp;
+                x++;
+                check();
+                return;
+            }
+        }
+        public void check() throws Exception{
+            if(map[x][y] == 0){
+                    map[x][y] = col[2];
+                }else{
+                    col[2] = map[x][y];
+                    map[x][y] = 0;
+                }
+                bw.write(row[1]+"\n");
+        }
+    }
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringBuilder sb = new StringBuilder();
+    static StringTokenizer st;
+    static int N,M,X,Y,K;
+    static int[][] map;
+    public static void main(String[] args) throws Exception {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        X = Integer.parseInt(st.nextToken());
+        Y = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+        map = new int[N][M];
+        for(int i = 0; i<N; i++){
+            st = new StringTokenizer(br.readLine());
+            for(int j = 0; j<M; j++){
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+        State dice = new State(X,Y);
+        
+        st = new StringTokenizer(br.readLine());
+        for(int i = 0; i<K; i++){
+            int cmd = Integer.parseInt(st.nextToken());
+            dice.rolling(cmd, map);
+        }
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14499
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
NxM 지도 위 특정 지점에 주사위 한개가 있음.
주사위를 상하좌우로 한칸씩 굴릴거임. 처음엔 주사위의 모든 면이 다 0임
굴린 후, 주사위의 위치에 해당하는 지도의 값이 0이면 주사위 바닥 부분의 값을 복사함.
아니라면 주사위의 바닥의 값이 지도의 값이 되고 지도의 값은 0이됨.
여러번 굴릴때마다 주사위의 윗면의 값을 출력.
지도를 벗어나는 경우에는 굴리는 행위도 출력도 하면 안됨.

## 🔍 풀이 방법
시뮬레이션
문제에 전개도가 주어져서 가로를 row, 세로를 col로 설정하여 state를 정의했다.
굴리는 방향에 따라 배열값을 직접 수정했다.
## ⏳ 회고
구현이 요즘 메타래