### PR TITLE
[20251029] BOJ / G1 / 최종 순위 / 이준희

### DIFF
--- a/JHLEE325/202510/29 BOJ G1 최종 순위.md
+++ b/JHLEE325/202510/29 BOJ G1 최종 순위.md
@@ -1,0 +1,104 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int T = Integer.parseInt(br.readLine().trim());
+        StringBuilder sb = new StringBuilder();
+
+        for (int t = 0; t < T; t++) {
+            int n = Integer.parseInt(br.readLine().trim());
+
+            st = new StringTokenizer(br.readLine());
+            int[] lastYear = new int[n];
+            for (int i = 0; i < n; i++) {
+                lastYear[i] = Integer.parseInt(st.nextToken());
+            }
+
+            boolean[][] graph = new boolean[n + 1][n + 1];
+            int[] indegree = new int[n + 1];
+
+            for (int i = 0; i < n; i++) {
+                for (int j = i + 1; j < n; j++) {
+                    int higher = lastYear[i];
+                    int lower = lastYear[j];
+                    if (!graph[higher][lower]) {
+                        graph[higher][lower] = true;
+                        indegree[lower]++;
+                    }
+                }
+            }
+
+            int m = Integer.parseInt(br.readLine().trim());
+            for (int i = 0; i < m; i++) {
+                st = new StringTokenizer(br.readLine());
+                int a = Integer.parseInt(st.nextToken());
+                int b = Integer.parseInt(st.nextToken());
+
+                if (graph[a][b]) {
+                    graph[a][b] = false;
+                    indegree[b]--;
+                    graph[b][a] = true;
+                    indegree[a]++;
+                } else if (graph[b][a]) {
+                    graph[b][a] = false;
+                    indegree[a]--;
+                    graph[a][b] = true;
+                    indegree[b]++;
+                } else {
+                    graph[a][b] = true;
+                    indegree[b]++;
+                }
+            }
+
+            Queue<Integer> q = new LinkedList<>();
+            for (int i = 1; i <= n; i++) {
+                if (indegree[i] == 0) {
+                    q.offer(i);
+                }
+            }
+
+            boolean ispossible = false;
+            List<Integer> result = new ArrayList<>();
+
+            for (int cnt = 0; cnt < n; cnt++) {
+                if (q.isEmpty()) {
+                    result = null;
+                    break;
+                }
+                if (q.size() > 1) {
+                    ispossible = true;
+                }
+                int cur = q.poll();
+                result.add(cur);
+
+                for (int next = 1; next <= n; next++) {
+                    if (graph[cur][next]) {
+                        indegree[next]--;
+                        if (indegree[next] == 0) {
+                            q.offer(next);
+                        }
+                    }
+                }
+            }
+
+            if (result == null) {
+                sb.append("IMPOSSIBLE\n");
+            } else if (ispossible) {
+                sb.append("?\n");
+            } else {
+                for (int x : result) {
+                    sb.append(x).append(" ");
+                }
+                sb.append("\n");
+            }
+        }
+
+        System.out.print(sb.toString());
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/3665

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
어떤 시합에서 작년에는 순위를 공지했으나 올해는 안한다고 합니다.
그러나 작년과 비교해서 상대순위가 바뀐 경우에 그 쌍을 공지한다고 합니다.
이 때 올해의 순위를 알 수 있는 경우 순위를, 확실하지 않은 경우 ? 를 찾는게 불가능한 경우 IMPOSSIBLE을 출력하는 문제입니다.

## 🔍 풀이 방법
일단 작년 순위를 기준으로 방향이 있는 간선을 만들어놓고
다음 해의 상대 순위 쌍을 받아서 그 방향을 반대로 만들어서 저장합니다.

이를 이용해서 위상정렬하여 찾았습니다.

## ⏳ 회고
위상정렬 문제를 오랜만에 봐서 좀 어려웠던 것 같습니다.
