### PR TITLE
[20251029] BOJ / G5 / 캠프 준비 / 김민진

### DIFF
--- a/zinnnn37/202510/29 BOJ G5 캠프 준비.md
+++ b/zinnnn37/202510/29 BOJ G5 캠프 준비.md
@@ -1,0 +1,76 @@
+```java
+import java.io.*;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BJ_16938_캠프_준비 {
+
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static StringTokenizer st;
+
+    private static int N, L, R, X, ans;
+    private static int[] questions, selected;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        L = Integer.parseInt(st.nextToken());
+        R = Integer.parseInt(st.nextToken());
+        X = Integer.parseInt(st.nextToken());
+        ans = 0;
+
+        st = new StringTokenizer(br.readLine());
+        questions = new int[N];
+        for (int i = 0; i < N; i++) {
+            questions[i] = Integer.parseInt(st.nextToken());
+        }
+        Arrays.sort(questions);
+
+        selected = new int[N];
+    }
+
+    private static void sol() throws IOException {
+        dfs(0, 0);
+
+        bw.write(ans + "");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void dfs(int depth, int start) throws IOException {
+        if (2 <= depth && depth <= N) {
+            if (checkValid(depth)) {
+                ans++;
+            }
+        }
+
+        if (depth == N) {
+            return;
+        }
+
+        for (int i = start; i < N; i++) {
+            selected[depth] = i;
+            dfs(depth + 1, i + 1);
+        }
+    }
+
+    private static boolean checkValid(int depth) throws IOException {
+        int sum = 0;
+
+        for (int i = 0; i < depth; i++) {
+            sum += questions[selected[i]];
+        }
+
+        return L <= sum && sum <= R && questions[selected[depth - 1]] - questions[selected[0]] >= X;
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[캠프 준비](https://www.acmicpc.net/problem/16938)

## 🧭 풀이 시간
15분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
주어진 문제를 2개 이상 뽑아서 전체 난이도 합이 `L` 이상 `R` 이하이며 가장 어려운 문제와 가장 쉬운 문제의 난이도 차가 `X` 이상인 경우의 수

## 🔍 풀이 방법
정렬 + 조합
문제들을 먼저 정렬해두면 값 확인할 때 `depth - 1`과 `0`끼리만 비교하면 됨

※ 일일이 조합 구할 필요 없이 `dfs` 진행하면서 바로바로 값 확인할 수 있음

## ⏳ 회고
`questions`의 인덱스는 `selected`의 값임을 유념하자