### PR TITLE
[20251029] BOJ/ G5 / 점 모으기 / 이종환

### DIFF
--- a/0224LJH/202510/29 BOJ 점 모으기.md
+++ b/0224LJH/202510/29 BOJ 점 모으기.md
@@ -1,0 +1,87 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class Main { 
+	
+	static int size, pointCnt,xIdx,yIdx;
+	static int[] xArr,yArr;
+	static long xSum, ySum,xCumul,yCumul, ansX, ansY;
+	
+	
+    public static void main(String[] args) throws IOException {
+    	init();
+    	process();
+    	print();
+    }
+
+    private static void init() throws IOException{
+    	BufferedReader br = new BufferedReader(new InputStreamReader(System.in));;
+    	StringTokenizer st = new StringTokenizer(br.readLine());
+    	size = Integer.parseInt(st.nextToken());
+    	pointCnt = Integer.parseInt(st.nextToken());
+    	xIdx = 0;
+    	yIdx = 0;
+    	xSum = 0;
+    	ySum = 0;
+    	ansX = Long.MAX_VALUE;
+    	ansY = Long.MAX_VALUE;
+    	
+    	xArr = new int[pointCnt];
+    	yArr = new int[pointCnt];
+    	
+    	xCumul = 0;
+    	yCumul = 0;
+    	for (int i = 0; i < pointCnt; i++) {
+    		st = new StringTokenizer(br.readLine());
+    		int y = Integer.parseInt(st.nextToken());
+    		int x = Integer.parseInt(st.nextToken());
+    		xSum += x;
+    		ySum += y;
+    		xArr[i] = x;
+    		yArr[i] = y;
+    	}
+
+
+    }
+    
+    private static void process() {
+    	Arrays.sort(xArr);
+    	Arrays.sort(yArr);
+    	
+    	int num = 1;
+    	while(num <= size) {
+    		long curSumX = 0;
+    		long curSumY = 0;
+    		while (xIdx < pointCnt && num >= xArr[xIdx]) {
+    			xCumul += xArr[xIdx++];
+    		}
+    		while (yIdx < pointCnt && num >= yArr[yIdx]) {
+    			yCumul += yArr[yIdx++];
+    		}
+
+    		curSumX = num*xIdx - xCumul*2 + xSum - num * (pointCnt - xIdx);
+    		curSumY = num*yIdx - yCumul*2 + ySum - num * (pointCnt - yIdx);
+    		
+    		ansX = Math.min(ansX, curSumX);
+    		ansY = Math.min(ansY, curSumY);
+    		num++;
+    	}
+    }
+    
+
+    
+    private static void print() {
+    	System.out.println(ansY + ansX);
+    }
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/7571

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
 격자공간내의 한 사각형으로 모든 점들을 모을 때 각 점이 움직인 거리의 합을 고려한다. 예를 들어, 위의 점들을 (3,2)에 있는 사각형으로 모을 때 최단거리로 점들을 이동시킨다면 (1,2)에 있는 점의 이동거리는 2이고, (3,1)과 (4,2)에 있는 점의 이동거리는 각각 1이며, (1,4) 에 있는 점의 이동거리는 4이므로 점들이 움직인 거리의 합은 8이다. 또, 위의 모든 점들을 (1,2)의 위치로 모을 때도 점들이 이동한 거리의 합이 8 임을 알 수 있다. 위의 예에서는 점들을 어떤 하나의 사각형으로 모을 때 이동거리의 합이 8보다 작게 되는 사각형은 없다.

이 문제는 주어진 격자공간에 있는 모든 점들을 하나의 사각형으로 모을 때 드는 이동거리의 합의 최솟값을 구하는 것이다. 주어진 격자공간에서는 하나의 사각형에 여러 개의 점들이 들어 있을 수도 있고, 점들을 모을 때는 어떤 점이 들어 있는 사각형으로도 모을 수 있다고 가정한다.

## 🔍 풀이 방법
우선 x,y는 완전 별개로 생각한다.
그러면 너무 간단하다.
특정값 i에 대해서 
- i보다 작거나 같은 값들의 합과 개수
- i보다 큰 값들의 합과 개수
이것만 구해서 계산하면 끝!

## ⏳ 회고
