### PR TITLE
[20251029] PGM / LV2 / 전력망을 둘로 나누기 / 강신지

### DIFF
--- a/ksinji/202510/29 PGM 전력망을 둘로 나누기.md
+++ b/ksinji/202510/29 PGM 전력망을 둘로 나누기.md
@@ -1,0 +1,58 @@
+```java
+import java.util.*;
+
+class Solution {
+    public int solution(int n, int[][] wires) {
+        List<List<Integer>> g = new ArrayList<>();
+        for (int i = 0; i <= n; i++) g.add(new ArrayList<>());
+
+        for (int[] w : wires) {
+            g.get(w[0]).add(w[1]);
+            g.get(w[1]).add(w[0]);
+        }
+
+        int answer = Integer.MAX_VALUE;
+
+        for (int[] cut : wires) {
+            int a = cut[0];
+            int b = cut[1];
+
+            int sizeA = bfsCount(n, g, a, b);
+            int sizeB = n - sizeA;
+            int diff = Math.abs(sizeA - sizeB);
+
+            if (diff < answer) answer = diff;
+        }
+
+        return answer;
+    }
+
+    private int bfsCount(int n, List<List<Integer>> g, int a, int b) {
+        boolean[] visited = new boolean[n + 1];
+        Queue<Integer> q = new LinkedList<>();
+        q.add(a);
+        visited[a] = true;
+
+        int cnt = 0;
+
+        while (!q.isEmpty()) {
+            int cur = q.poll();
+            cnt++;
+
+            for (int nxt : g.get(cur)) {
+                if (isCutEdge(cur, nxt, a, b)) continue;
+                if (!visited[nxt]) {
+                    visited[nxt] = true;
+                    q.add(nxt);
+                }
+            }
+        }
+        return cnt;
+    }
+
+    private boolean isCutEdge(int u, int v, int a, int b) {
+        return (u == a && v == b) || (u == b && v == a);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/86971
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
n개의 송전탑이 트리 형태로 연결되어 있다. 전선을 하나 끊어 두 전력망으로 나뉘었을 때, 두 송전탑 개수의 차이가 최소가 되도록 하는 값을 구하라.
## 🔍 풀이 방법
모든 전선을 하나씩 끊어보며, 끊은 상태에서 BFS로 한쪽 네트워크의 송전탑 개수를 센다.
다른 쪽은 전체에서 그 개수를 빼서 구하고, 두 개수의 차이를 계산한다.
이 과정을 반복해 최소 차이를 갱신한다.
## ⏳ 회고
그냥 하면 된다