### PR TITLE
[20251029] BOJ / P1 / 쉽게 제한된 메모리 / 권혁준

### DIFF
--- a/khj20006/202510/29 BOJ P1 쉽게 제한된 메모리.md
+++ b/khj20006/202510/29 BOJ P1 쉽게 제한된 메모리.md
@@ -1,0 +1,49 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+using ll = long long;
+
+const ll MOD = 1'000'000'007;
+ll N, X, A, B, Q, ans = 0, s[100]{}, e[100]{};
+vector<int> q, p;
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin >> N >> X >> A >> B >> Q;
+	q.resize(Q);
+	p.resize(Q);
+	iota(p.begin(), p.end(), 0);
+	for (int& i : q) cin >> i, i++;
+	fill(e, e + Q, MOD - 1);
+	sort(q.begin(), q.end());
+	
+	int rem = Q;
+	while (rem) {
+		vector<int> ms;
+		for (int i = 0; i < Q; i++) if (s[i] < e[i]) ms.push_back((s[i] + e[i] + 1) >> 1);
+		sort(ms.begin(), ms.end());
+		ms.erase(unique(ms.begin(), ms.end()), ms.end());
+		vector<int> cnt(ms.size());
+
+		int pos = 0;
+		for (ll x = X, j = 0; j < N - 1; j++) {
+			int d = upper_bound(ms.begin(), ms.end(), x) - ms.begin();
+			if (d != ms.size()) cnt[d]++;
+			x = (x * A + B) % MOD;
+		}
+		for (int i = 1; i < ms.size(); i++) cnt[i] += cnt[i - 1];
+		
+		for (int i = 0; i < Q; i++) if (s[i] < e[i]) {
+			int m = (s[i] + e[i] + 1) >> 1;
+			int idx = lower_bound(ms.begin(), ms.end(), m) - ms.begin();
+			if (cnt[idx] < q[i]) s[i] = m;
+			else e[i] = m - 1;
+			if (s[i] >= e[i]) ans += (s[i] + e[i] + 1) >> 1, rem--;
+		}
+	}
+
+	cout << ans;
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/12926

## 🧭 풀이 시간
90분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
배열 X는 다음과 같이 생성된다.
X[0] = 0, X[i] = (X[i-1] * a + b) % 1,000,000,007

X[0]부터 X[N-1]까지 N개의 정수로 구성된 배열 X에 다음 쿼리를 Q개 처리해보자.
- i : 배열 X에서 i번째로 작은 수를 출력 (i는 0-based index)

N <= 1,000,000
Q <= 100

## 🔍 풀이 방법
메모리 제한이 너무 작아서 배열 X를 선언할 수 없다.
`f(n) = 배열 X에서 n보다 작은 수의 개수`로 두고, 각 쿼리마다 파라메트릭 서치로 바꿔 생각했다.

매 쿼리마다 각각 파라메트릭 서치를 돌리면 O(NQlogMOD)라 시간초과가 나서 f(n)을 구할 때 n이 겹치는 쿼리들에 대해선 한 번만 돌리도록 구현했다.
X를 순회하는 작업을 총 logMOD 번만 하고, 각 순회에서 쿼리들의 mid값을 정렬 후 잘 카운팅해줘서 모든 쿼리의 범위를 한 번에 줄여줬다.

## ⏳ 회고
이걸 `병렬 이분 탐색`이라 한다고 함.
결정 문제를 한 번 푸는 과정에서 모든 쿼리에 대해 한 번 씩 해결하는 방법을 찾는 것이 핵심인 듯하다.
이걸 놓쳐서 시간초과가 났다