### PR TITLE
[20251029] BOJ/ G5 / 점 모으기 / 설진영

### DIFF
--- a/Seol-JY/202510/29 BOJ 점 모으기.md‎
+++ b/Seol-JY/202510/29 BOJ 점 모으기.md‎
@@ -1,0 +1,37 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        
+        int[] rows = new int[M];
+        int[] cols = new int[M];
+        
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            rows[i] = Integer.parseInt(st.nextToken());
+            cols[i] = Integer.parseInt(st.nextToken());
+        }
+        
+        Arrays.sort(rows);
+        Arrays.sort(cols);
+        
+        int medianRow = rows[M / 2];
+        int medianCol = cols[M / 2];
+        
+        long sum = 0;
+        for (int i = 0; i < M; i++) {
+            sum += Math.abs(rows[i] - medianRow);
+            sum += Math.abs(cols[i] - medianCol);
+        }
+        
+        System.out.println(sum);
+    }
+}
+```


### PR DESCRIPTION

## 🧷 문제 링크
https://www.acmicpc.net/problem/2616

## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
N×N 격자판에 M개의 점이 있을 때, 모든 점을 하나의 칸으로 모으는 최소 이동거리 합을 구하는 문제
맨해튼 거리

## 🔍 풀이 방법
행과 열을 독립적으로 생각
여러 점을 한 곳으로 모을 때 거리 합을 최소화하는 위치는 중앙값임

## ⏳ 회고
굳