### PR TITLE
[20251030] BOJ / G3 / 내리막 길 / 이준희

### DIFF
--- a/JHLEE325/202510/30 BOJ G3 내리막 길.md
+++ b/JHLEE325/202510/30 BOJ G3 내리막 길.md
@@ -1,0 +1,55 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int M, N;
+    static int[][] map;
+    static int[][] dp;
+    static int[] dy = {-1, 1, 0, 0};
+    static int[] dx = {0, 0, -1, 1};
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        M = Integer.parseInt(st.nextToken());
+        N = Integer.parseInt(st.nextToken());
+
+        map = new int[M][N];
+        dp = new int[M][N];
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+                dp[i][j] = -1;
+            }
+        }
+
+        System.out.println(dfs(0, 0));
+    }
+
+    static int dfs(int y, int x) {
+        if (y == M - 1 && x == N - 1) {
+            return 1;
+        }
+
+        if (dp[y][x] != -1) return dp[y][x];
+
+        dp[y][x] = 0;
+
+        for (int dir = 0; dir < 4; dir++) {
+            int ny = y + dy[dir];
+            int nx = x + dx[dir];
+
+            if (ny < 0 || nx < 0 || ny >= M || nx >= N) continue;
+            if (map[ny][nx] < map[y][x]) {
+                dp[y][x] += dfs(ny, nx);
+            }
+        }
+
+        return dp[y][x];
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1520

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
높이가 쓰여있는 N*M 크기의 맵이 주어졌을 때
0,0 에서 N-1,M-1 까지 내리막길로만 내려갈 수 있는 경우의 수의 갯수를 구하는 문제입니다.

## 🔍 풀이 방법
처음에는 그냥 0,0에서 목적지까지 dfs로 돌리면서 순회하려고 했는데 시간초과가 났습니다.
그래서 dp를 더하여 dp[y][x] = dp[y][x]에서 목적지까지 가는 경우의 수 갯수 로 하여 풀었습니다.

## ⏳ 회고
문제 사이즈와 케이스를 잘 확인합시다 
