### PR TITLE
[20251030] BOJ / G4 / 빠른 무작위 메시지 전달 / 김민진

### DIFF
--- a/zinnnn37/202510/30 BOJ G4 빠른 무작위 메시지 전달.md
+++ b/zinnnn37/202510/30 BOJ G4 빠른 무작위 메시지 전달.md
@@ -8,7 +8,7 @@ public class BJ_25835_빠른_무작위_메시지_전달 {
     private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
     private static StringTokenizer st;
 
-    private static long ans;
+    private static int ans;
     private static int[][] friends;
     private static boolean[] visited;
 
@@ -23,7 +23,7 @@ public class BJ_25835_빠른_무작위_메시지_전달 {
     }
 
     private static void init() throws IOException {
-        ans = Long.MAX_VALUE;
+        ans = Integer.MAX_VALUE;
 
         friends = new int[12][12];
         for (int i = 0; i < 12; i++) {
@@ -46,7 +46,7 @@ public class BJ_25835_빠른_무작위_메시지_전달 {
         }
     }
 
-    private static void dfs(int depth, int cur, long sum) throws IOException {
+    private static void dfs(int depth, int cur, int sum) throws IOException {
         if (depth == 6) {
             ans = Math.min(ans, sum);
             return;


### PR DESCRIPTION
## 🧷 문제 링크
[빠른 무작위 메시지 전달](https://www.acmicpc.net/problem/25825)

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
12명의 사람이 있고 친구 그룹 `(i, i+1)`으로 구성됨
한 그룹에서 다른 그룹으로 메시지를 전달하는데 한 그룹 내에서 메시지를 전달 받은 사람은 그룹의 다른 사람에게 전달하고 메시지를 전달 받은 사람이 다른 그룹에 메시지를 전달함
메시지를 전달할 수 있는 최소 비용

## 🔍 풀이 방법
백트래킹

## ⏳ 회고
그룹 내에서도 메시지 전달 비용이 든다.. 문제를 잘 읽자
그리고 `next → next + 1`을 했으면 다음 시작점은 `next + 1`인데 `next`로 해놔서 계속 틀렸음