### PR TITLE
[20251031] PGM / Lv2 / 전력망을 둘로 나누기 / 이강현

### DIFF
--- a/lkhyun/202510/31 PGM Lv2 전력망을 둘로 나누기.md
+++ b/lkhyun/202510/31 PGM Lv2 전력망을 둘로 나누기.md
@@ -1,0 +1,42 @@
+```java
+import java.util.*;
+class Solution {
+    static List<Integer>[] adjList;
+    public int solution(int n, int[][] wires) {
+        int answer = n;
+        adjList = new List[n+1];
+        for(int i = 0; i<=n; i++){
+            adjList[i] = new ArrayList<>();
+        }
+        for(int[] wire : wires){
+            adjList[wire[0]].add(wire[1]);
+            adjList[wire[1]].add(wire[0]);
+        }
+        for(int[] wire : wires){
+            answer = Math.min(answer,Math.abs(n-(2*BFS(n, wire[0],wire[1]))));    
+        }
+        
+        return answer;
+    }
+    public int BFS(int n, int start, int except){
+        int count = 0;
+        ArrayDeque<Integer> q = new ArrayDeque<>();
+        boolean[] visited = new boolean[n+1];
+        q.offer(start);
+        visited[start] = true;
+        count++;
+        
+        while(!q.isEmpty()){
+            int cur = q.poll();
+            
+            for(int next : adjList[cur]){
+                if(visited[next] || next == except) continue;
+                q.offer(next);
+                visited[next] = true;
+                count++;
+            }
+        }
+        return count;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/86971
## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
전력망이 트리 구조로 존재함.
특정 전선을 끊어서 전력망을 둘로 나눌때, 두 전력망 속 노드 수의 차이가 가장 적을때 그 값을 구하기.
## 🔍 풀이 방법
완전탐색, bfs
한번만 나누면 되고 전선이 100개미만이라
n번 자르는데 한번 자를때, 자른 지점에서 원래 연결되어있던 애를 제외하고 bfs를 돌린 후 개수를 구함.
그리고 그 개수가 최적인지 판단하는 것을 반복.
## ⏳ 회고
ez