### PR TITLE
[20251101] BOJ / G1 / 할 일 정하기 1 / 설진영

### DIFF
--- a/Seol-JY/202511/1 BOJ G1 할 일 정하기 1.md
+++ b/Seol-JY/202511/1 BOJ G1 할 일 정하기 1.md
@@ -1,0 +1,53 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int N;
+    static int[][] cost;
+    static int[][] dp;
+    static final int INF = 987654321;
+    
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        
+        N = Integer.parseInt(br.readLine());
+        cost = new int[N][N];
+        
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                cost[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+        
+        dp = new int[N][1 << N];
+        for (int i = 0; i < N; i++) {
+            Arrays.fill(dp[i], -1);
+        }
+        
+        System.out.println(solve(0, 0));
+    }
+    
+    static int solve(int person, int mask) {
+        if (person == N) {
+            return 0;
+        }
+        
+        if (dp[person][mask] != -1) {
+            return dp[person][mask];
+        }
+        
+        int result = INF;
+        
+        for (int job = 0; job < N; job++) {
+            if ((mask & (1 << job)) == 0) {
+                int nextMask = mask | (1 << job);
+                result = Math.min(result, cost[person][job] + solve(person + 1, nextMask));
+            }
+        }
+        
+        return dp[person][mask] = result;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[백준 1311번 - 할 일 정하기 1](https://www.acmicpc.net/problem/1311)

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
N명의 사람에게 N개의 일을 1:1로 배정하는 문제.
각 사람이 각 일을 할 때의 비용이 주어지며, 총 비용의 최솟값을 구해야 한다.


## 🔍 풀이 방법
dp[person][mask]: person번째 사람까지 배정했을 때, mask 상태(배정된 일들)에서의 최소 비용
- 비트마스크로 어떤 일이 배정되었는지 표현, 각 사람마다 아직 배정되지 않은 모든 일을 시도하며 최솟값 선택하기 

## ⏳ 회고
혁준이가 추천해줬다
혁준이가  N (1 ≤ N ≤ 20) 조건 있으면 비트 DP 라고 힌트도 줬다
