### PR TITLE
[20251103] BOJ / G5 / 콘센트 / 이준희

### DIFF
--- a/JHLEE325/202511/03 BOJ G5 콘센트.md
+++ b/JHLEE325/202511/03 BOJ G5 콘센트.md
@@ -1,0 +1,41 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        st = new StringTokenizer(br.readLine());
+        Integer[] times = new Integer[N];
+        for (int i = 0; i < N; i++) {
+            times[i] = Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.sort(times, Collections.reverseOrder());
+
+        PriorityQueue<Integer> pq = new PriorityQueue<>();
+
+        int initial = Math.min(M, N);
+        for (int i = 0; i < initial; i++) {
+            pq.offer(times[i]);
+        }
+
+        for (int i = initial; i < N; i++) {
+            int current = pq.poll();
+            current += times[i];
+            pq.offer(current);
+        }
+
+        int answer = 0;
+        while (!pq.isEmpty()) {
+            answer = Math.max(answer, pq.poll());
+        }
+
+        System.out.println(answer);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/23843

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
충전해야되는 전자기기 N 과 충전 가능한 콘센트 개수 M이 주어지고 각 전자기기 완충에 필요한시간이 주어질 때
모든 전자기기을 충전할 수 있는 최소시간을 구하는 문제입니다.

## 🔍 풀이 방법
우선순위 큐를 활용해서 풀었습니다.
충전에 필요한 시간을 내림차순으로 정렬하고 처음에 M개를 우선순위 큐에 넣습니다.
그 다음부터는 그 값이 작은 것을 꺼내어 필요시간을 계속 더해서 갱신해가면서 풀었습니다.

## ⏳ 회고
쉽운 문제입니다.
