### PR TITLE
[20251103] BOJ / P3 / 도시 정비 / 권혁준

### DIFF
--- a/khj20006/202511/03 BOJ P3 도시 정비.md
+++ b/khj20006/202511/03 BOJ P3 도시 정비.md
@@ -1,0 +1,49 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+using ll = long long;
+
+int N;
+vector<vector<int>> v(1000001);
+ll inmx[1000001]{}, outmx[1000001]{}, ex[1000001]{}, val[1000001]{}, a[1000001]{};
+ll ans = 0;
+
+void dfs1(int n, int p) {
+	inmx[n] = a[n];
+	ll mx1 = 0, mx2 = 0;
+	for (int i : v[n]) if (i != p) {
+		dfs1(i, n);
+		if (inmx[i] > mx1) mx2 = mx1, mx1 = inmx[i];
+		else if (inmx[i] > mx2) mx2 = inmx[i];
+		inmx[n] = max(inmx[n], inmx[i]);
+	}
+	for (int i : v[n]) if (i != p) {
+		if (inmx[i] == mx1) ex[i] = mx2;
+		else ex[i] = mx1;
+		val[n] += inmx[i];
+	}
+}
+
+void dfs2(int n, int p) {
+	outmx[n] = max({ outmx[p], (ll)a[p], ex[n] });
+	ans = max(ans, val[n] + outmx[n]);
+	for (int i : v[n]) if (i != p) dfs2(i, n);
+}
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin >> N;
+	for (int i = 1; i <= N; i++) cin >> a[i];
+	for (int i = 1, c, d; i < N; i++) {
+		cin >> c >> d;
+		v[c].push_back(d);
+		v[d].push_back(c);
+	}
+	dfs1(1, 0);
+	dfs2(1, 0);
+
+	cout << ans;
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/15491

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N개의 도시가 트리 형태로 구성되어 있다.
각 도시들은 정비가 필요하고, 정비에는 정비 기기가 필요하다.
어떤 도시에 필요한 정비 기기의 최소 가격이 x면, 가격이 x 이상인 정비 기기를 사용해야 그 도시를 정비할 수 있다.

어떤 도시를 하나 골라서 그 도시를 없애고 그와 직접 연결된 간선도 제거할 때, 모든 도시를 정비하는 최소 비용 중 최댓값을 구해보자.

## 🔍 풀이 방법
도시를 없앴을 때 나뉘어지는 각 컴포넌트 S1, S2, ...에 대하여,

max(S1) + max(S2) + ... 를 최대화

inmx[n] = n의 서브트리 내의 최댓값
outmx[n] = n의 서브트리 외의 최댓값
ex[n] = p의 자식들 들 중 n을 제외한 c1, c2, ...에 대하여, max(inmx[c1], inmx[c2], ...)

-> outmx[n] = max(outmx[p], a[p], ex[n])

n의 서브트리 중 n을 제외한 최댓값은 n의 자식들의 inmx 최댓값임.
그래서 n의 자식들 i에 대해, inmx[i]들의 최댓값을 mx1, 두 번째 최댓값을 mx2라고 했을 때
inmx[i] = mx1이면 ex[i] = mx2이고 아니면 ex[i] = mx1

## ⏳ 회고
ez