### PR TITLE
[20251103] PGM / Lv2 / [1차] 뉴스 클러스터링 / 이강현

### DIFF
--- a/lkhyun/202511/03 PGM Lv2 [1차] 뉴스 클러스터링.md
+++ b/lkhyun/202511/03 PGM Lv2 [1차] 뉴스 클러스터링.md
@@ -1,0 +1,53 @@
+```java
+import java.util.*;
+
+class Solution {
+    public int solution(String str1, String str2) {
+        List<String> A = new ArrayList<>();
+        List<String> B = new ArrayList<>();
+        
+        for(int i = 0; i + 1 < str1.length(); i++){
+            String temp = str1.substring(i, i + 2);
+            if(!validation(temp.charAt(0)) || !validation(temp.charAt(1))) continue;
+            A.add(temp.toLowerCase());
+        }
+
+        for(int i = 0; i + 1 < str2.length(); i++){
+            String temp = str2.substring(i, i + 2);
+            if(!validation(temp.charAt(0)) || !validation(temp.charAt(1))) continue;
+            B.add(temp.toLowerCase());
+        }
+        
+        if(A.isEmpty() && B.isEmpty()) {
+            return 65536;
+        }
+        
+        Collections.sort(A);
+        Collections.sort(B);
+        
+        int intersection = 0;
+        int a = 0;
+        int b = 0;
+        while(a < A.size() && b < B.size()){
+            int compare = A.get(a).compareTo(B.get(b));
+            if(compare == 0){
+                intersection++;
+                a++;
+                b++;
+            } else if(compare < 0){
+                a++;
+            } else {
+                b++;
+            }
+        }
+        
+        int union = A.size() + B.size() - intersection;
+        
+        return (int)((double)intersection / union * 65536);
+    }
+    
+    public boolean validation(char c){
+        return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/17677
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
문자열 두개를 비교하는데 두글자씩 잘라서 자카드 유사도를 측정
france면 {fr,ra,an,nc,ce} 이렇게 집합을 생성하게 됨.
이때, 영어 대소문자는 비교하지 않고 그외 문자들은 모두 무시함.
예를 들어, ab+c라는 문자열이 있다면 집합은 {ab,bc}임.
이때 교집합을 합집합으로 나눈 값이 자카드 유사도임.
중복도 포함임. 그래서 {1,1,1}과 {1,1,1,1,1}은 교집합이 {1,1,1}이고 합집합이 {1,1,1,1,1}임.
자카드 유사도에 65536를 곱하고 소수점을 버린 형태로 출력.
## 🔍 풀이 방법
문자열
그냥 구현하라는대로 했다. substring으로 두 글자씩 뽑아서 리스트에 저장하고 정렬해서 앞에서부터 하나씩 비교함.
합집합은 두 집합의 크기를 더하고 교집합을 빼는 방식으로 구현함. 다중집합을 허용하기에
## ⏳ 회고
문자열 처리는 까다롭다.