### PR TITLE
[20251104] BOJ / G5 / 김밥천국의 계단 / 김민진

### DIFF
--- a/zinnnn37/202511/4 BOJ G5 김밥천국의 계단.md
+++ b/zinnnn37/202511/4 BOJ G5 김밥천국의 계단.md
@@ -1,0 +1,79 @@
+```java
+import java.io.*;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class BJ_28069_김밥천국의_계단 {
+
+	private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+	private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	private static       StringTokenizer st;
+
+	private static int N, K, nxt;
+	private static int[]       minCnt;
+	private static Queue<Node> q;
+
+	private static class Node {
+		int step;
+		int cnt;
+
+		Node(int step, int cnt) {
+			this.step = step;
+			this.cnt = cnt;
+		}
+	}
+
+	public static void main(String[] args) throws IOException {
+		init();
+		sol();
+
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+
+	private static void init() throws IOException {
+		st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		K = Integer.parseInt(st.nextToken());
+
+		minCnt = new int[N + 1];
+		Arrays.fill(minCnt, Integer.MAX_VALUE);
+
+		q = new ArrayDeque<>();
+		q.offer(new Node(0, 0));
+		minCnt[0] = 0;
+	}
+
+	private static void sol() throws IOException {
+		while (!q.isEmpty()) {
+			Node cur = q.poll();
+
+			if (cur.step == N) {
+				bw.write("minigimbob");
+				return;
+			}
+
+			if (cur.cnt >= K) {
+				continue;
+			}
+
+			nxt = cur.step + 1;
+			if (nxt <= N && minCnt[nxt] > cur.cnt + 1) {
+				minCnt[nxt] = cur.cnt + 1;
+				q.offer(new Node(nxt, cur.cnt + 1));
+			}
+
+			nxt = cur.step + cur.step / 2;
+			if (nxt <= N && minCnt[nxt] > cur.cnt + 1) {
+				minCnt[nxt] = cur.cnt + 1;
+				q.offer(new Node(nxt, cur.cnt + 1));
+			}
+		}
+		bw.write("water");
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[김밥천국의 계단](https://www.acmicpc.net/problem/28069)

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
`i`번째 칸에서 `i + 1`, `i + i / 2` 칸으로 이동할 수 있을 때 `N`번째 칸에 `K`번 만에 도달 가능?

## 🔍 풀이 방법
일단 bfs로 풀긴 함
방문 배열 2차원으로 하면 메모리 터져서 int 배열에 cnt 횟수 저장함
근데 이거 dp잖아

## ⏳ 회고
그냥 처음부터 얌전히 dp로 풀 걸