### PR TITLE
[20251105] BOJ / P4 / 방어선 / 권혁준

### DIFF
--- a/khj20006/202511/05 BOJ P4 방어선.md
+++ b/khj20006/202511/05 BOJ P4 방어선.md
@@ -1,0 +1,60 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+
+int T, N;
+vector<int> seg, arr, cnt, cnt2;
+vector<pair<int, int>> arr2;
+
+void upt(int s, int e, int i, int v, int n) {
+	if (s == e) {
+		seg[n] = v;
+		return;
+	}
+	int m = (s + e) >> 1;
+	if (i <= m) upt(s, m, i, v, n << 1);
+	else upt(m + 1, e, i, v, n << 1 | 1);
+	seg[n] = max(seg[n << 1], seg[n << 1 | 1]);
+}
+
+int find(int s, int e, int l, int r, int n) {
+	if (l > r || l > e || r < s) return 0;
+	if (l <= s && e <= r) return seg[n];
+	int m = (s + e) >> 1;
+	return max(find(s, m, l, r, n << 1), find(m + 1, e, l, r, n << 1 | 1));
+}
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	for (cin >> T; T--;) {
+		cin >> N;
+		seg = vector<int>(4 * N);
+		arr = vector<int>(N + 1);
+		cnt = vector<int>(N + 1);
+		cnt2 = vector<int>(N + 1);
+		arr2 = vector<pair<int, int>>();
+		for (int i = 1; i <= N; i++) {
+			cin >> arr[i];
+			arr2.emplace_back(arr[i], i);
+			cnt[i] = arr[i - 1] < arr[i] ? cnt[i - 1] + 1 : 1;
+		}
+		sort(arr2.begin(), arr2.end(), [](auto a, auto b) -> bool {
+			if (a.first == b.first) return a.second > b.second;
+			return a.first < b.first;
+		});
+
+		for (auto [x, i] : arr2) {
+			cnt2[i] = find(1, N, 1, i - 1, 1) + 1;
+			upt(1, N, i, cnt[i], 1);
+		}
+		int ans = 0;
+		for (int i = 1; i <= N; i++) {
+			if (arr[i - 1] < arr[i]) cnt2[i] = max(cnt2[i], cnt2[i - 1] + 1);
+			ans = max(ans, cnt2[i]);
+		}
+		cout << ans << '\n';
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/3429

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
길이 N인 수열에서 임의의 연속한 구간 하나를 지웠을 때, 가장 긴 연속하는 증가 부분 수열의 길이를 구해보자.

## 🔍 풀이 방법
cnt[i] = i번째 원소 a[i]를 마지막으로 하는 가장 긴 연속 증가 부분 수열의 길이

(a[i], i) 리스트 만들어놓고 a[i]의 오름차순대로 (a[i], i) 쌍을 하나씩 처리
-> cnt2[i] = max(cnt[1], ..., cnt[i-1]) + 1
이걸로 연속한 구간 하나를 날려버리는 작업은 끝

연속한 구간을 날린 후에 증가 부분 수열이 뒤로 더 생길 수 있으니까
cnt2에서 한 번 돌면서 a[i-1] < a[i]인 i에 대해 cnt2[i] = max(cnt2[i], cnt2[i-1] + 1) 수행

답은 max(cnt2)로 구함.

## ⏳ 회고
생각보다 까다로움