### PR TITLE
[20251105] PGM / LV2 / 도넛과 막대 그래프 / 김민진

### DIFF
--- a/zinnnn37/202511/5 PGM LV2 도넛과 막대 그래프.md
+++ b/zinnnn37/202511/5 PGM LV2 도넛과 막대 그래프.md
@@ -1,0 +1,114 @@
+```java
+import java.util.*;
+
+class Solution {
+    
+    private static int maxNode;
+    private static int[] answer;
+    private static boolean[] isParent, isChild, visited;
+    private static Queue<Integer> q;
+    
+    private static Map<Integer, List<Integer>> graph;
+    
+    private static void init(int[][] edges) {
+        answer = new int[4];
+        isParent = new boolean[1000001];
+        isChild = new boolean[1000001];
+        
+        graph = new HashMap<>();
+        
+        maxNode = 0;
+        for (int[] edge : edges) {
+            List<Integer> tmp;
+            
+            maxNode = Math.max(maxNode, Math.max(edge[0], edge[1]));
+            
+            isParent[edge[0]] = true;
+            isChild[edge[1]] = true;
+            
+            if (graph.get(edge[0]) == null) {
+                tmp = new ArrayList<>();
+            } else {
+                tmp = graph.get(edge[0]);
+            }
+            
+            tmp.add(edge[1]);
+            graph.put(edge[0], tmp);
+        }
+        q = new ArrayDeque<>();
+        visited = new boolean[maxNode + 1];
+    }
+    
+    private static void findRoot() {
+        for (int i = 0; i <= maxNode; i++) {
+            if (isParent[i] && !isChild[i]) {
+                List<Integer> children = graph.get(i);
+                
+                // 나가는 간선이 2개 이상
+                if (children != null && children.size() >= 2) {
+                    answer[0] = i;
+                    break;
+                }
+            }
+        }
+    }
+    
+    private static void bfs(int start) {        
+        q.offer(start);
+        visited[start] = true;
+        
+        int nodeCnt = 0;
+        int edgeCnt = 0;
+        
+        while (!q.isEmpty()) {
+            int cur = q.poll();
+            nodeCnt++;
+            
+            List<Integer> children = graph.get(cur);
+            
+            // |
+            if (children == null) {
+                answer[2]++;
+                return;
+            }
+            
+            edgeCnt += children.size();
+            
+            // 자식 정점이 2개 이상 - 8
+            if (children.size() > 1) {
+                answer[3]++;
+                return;
+            }
+            
+            for (int next : children) {
+                if (visited[next]) {
+                    // 간선 수 == 노드 수 - O
+                    // 간선 수 > 노드 수 - 8자
+                    if (edgeCnt == nodeCnt) {
+                        answer[1]++;
+                    } else {
+                        answer[3]++;
+                    }
+                    return;
+                }
+                
+                visited[next] = true;
+                q.offer(next);
+            }
+        }
+    }
+    
+    public int[] solution(int[][] edges) {
+        init(edges);        
+        findRoot();
+        
+        for (int n : graph.get(answer[0])) {
+            Arrays.fill(visited, false);
+            bfs(n);
+            q.clear();
+        }
+        
+        return answer;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[도넛과 막대 그래프](https://school.programmers.co.kr/learn/courses/30/lessons/258711?language=java)

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
막대, 도넛, 8자 그래프의 갯수 세기
임의의 정점이 각 도넛의 임의의 노드를 가리킴
그래프 갯수는 2개 이상

## 🔍 풀이 방법
bfs 돌면서 간선 수, 노드 수 비교로 도넛과 8자 그래프 판단
-> 나가는 간선 수 2개이면 8자 그래프
-> 방문 처리된 노드를 발견했을 때 거쳐온 노드와 간선의 수가 같으면 도넛, 간선이 더 많으면 8(8은 나가는 간선이 2개인 노드가 있기 때문)

막대 그래프는 자식노드가 없는 노드가 있는 경우

그래프가 2개 이상이라고 해서 부모노드가 없고 자식 노드가 2개 이상인 경우가 임의의 노드
-> 막대그래프 중간에 임의의 간선이 연결되면 막대그래프의 최상단 노드도 부모노드가 없음

## ⏳ 회고
프로그래머스 너무 불편한데..