### PR TITLE
[20251105] BOJ / G5 / 물병 / 김수연

### DIFF
--- a/suyeun84/202511/05 BOJ G5 물병.md
+++ b/suyeun84/202511/05 BOJ G5 물병.md
@@ -1,0 +1,26 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		
+		int n = Integer.parseInt(st.nextToken());
+		int k = Integer.parseInt(st.nextToken());
+		
+		int ans = solution(n, k);
+		System.out.println(ans);
+	}
+	
+	public static int solution(int n, int k) {
+		int ans = 0;
+		while(Integer.bitCount(n) > k) {
+			n ++;
+			ans ++;
+		}
+		return ans;
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1052
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
물병 N개로 K개를 넘지않는 비어있지 않은 물병을 만드려고 할 때, 상점에서 사야하는 물병의 최솟값 구하기
## 🔍 풀이 방법
N을 비트로 나타내서 1의 개수가 하나의 병이라고 가정
N을 1씩 더해서 비트 1의 개수가 K보다 작거나 같으면 수행 중지
## ⏳ 회고
비트마스킹..쩝..