### PR TITLE
[20251105] BOJ / G1 / 멀티탭 스케줄링 / 이종환

### DIFF
--- a/0224LJH/202511/05 BOJ 멀티탭 스케줄링.md
+++ b/0224LJH/202511/05 BOJ 멀티탭 스케줄링.md
@@ -1,0 +1,81 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.StringTokenizer;
+
+public class Main { 
+	
+	static int size,totalLen,count;
+	static int[] arr;
+	static HashSet<Integer> set = new HashSet<>();
+	
+    public static void main(String[] args) throws IOException {
+    	init();
+    	process();
+    	print();
+    }
+
+    private static void init() throws IOException{
+    	BufferedReader br = new BufferedReader(new InputStreamReader(System.in));;
+    	StringTokenizer st = new StringTokenizer(br.readLine());
+    	//이거 그냥 lfd 라는 페이지 교체 알고리즘을 쓰면 된다!
+    	size = Integer.parseInt(st.nextToken());
+    	totalLen = Integer.parseInt(st.nextToken());
+    	arr = new int[totalLen];
+    	
+    	st = new StringTokenizer(br.readLine());
+    	for (int i = 0; i <totalLen; i++) {
+    		arr[i] = Integer.parseInt(st.nextToken());
+    	}
+
+    	
+    }
+    
+    private static void process() {
+    	count = 0;
+
+    	
+    	for (int i = 0; i < totalLen; i++) {
+    		if (set.size() < size) {
+    			set.add(arr[i]);
+    			continue;
+    		}
+    		if (set.contains(arr[i])) continue;
+    		
+    		int target = -1;
+    		int targetDistance = 0;
+    		for (int num: set) {
+    			int distance = 10000;
+    			for (int j = i; j < totalLen; j++) {
+    				if (arr[j] == num) {
+    					distance = j-i;
+    					break;
+    				}
+    			}
+    			if (targetDistance < distance) {
+    				target = num;
+    				targetDistance = distance;
+    			}
+    		}
+    		
+    		count++;
+    		set.remove(target);
+    		set.add(arr[i]);
+    		
+    	}
+
+
+    }
+    
+
+    
+    private static void print() {
+    	System.out.println(count);
+    }
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1700
## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
기숙사에서 살고 있는 준규는 한 개의 멀티탭을 이용하고 있다. 준규는 키보드, 헤어드라이기, 핸드폰 충전기, 디지털 카메라 충전기 등 여러 개의 전기용품을 사용하면서 어쩔 수 없이 각종 전기용품의 플러그를 뺐다 꽂았다 하는 불편함을 겪고 있다. 그래서 준규는 자신의 생활 패턴을 분석하여, 자기가 사용하고 있는 전기용품의 사용순서를 알아내었고, 이를 기반으로 플러그를 빼는 횟수를 최소화하는 방법을 고안하여 보다 쾌적한 생활환경을 만들려고 한다.

예를 들어 3 구(구멍이 세 개 달린) 멀티탭을 쓸 때, 전기용품의 사용 순서가 아래와 같이 주어진다면,

- 키보드
- 헤어드라이기
- 핸드폰 충전기
- 디지털 카메라 충전기
- 키보드
- 헤어드라이기

키보드, 헤어드라이기, 핸드폰 충전기의 플러그를 순서대로 멀티탭에 꽂은 다음 디지털 카메라 충전기 플러그를 꽂기 전에 핸드폰충전기 플러그를 빼는 것이 최적일 것이므로 플러그는 한 번만 빼면 된다.


## 🔍 풀이 방법
이거 멀티탭..이라고 하는데, 어디서 많이 본거 같은데 해서 생각해보니 페이징 교체 상황과 똑같다. 그리고 페이징 교체 알고리즘 중 제일 좋은 방법이며, 실제로는 불가능 한것이 LFD(longest forward distance) 알고리즘이다.

지금 문제의 경우, 앞으로 어떻게 주어질지 다 나오기에, 그냥 LFD를 적용하면 손쉽게 풀 수 있다.


## ⏳ 회고
CS랑 이렇게 연결될 줄은 몰랐다.