### PR TITLE
[20251106] BOJ / G6 / 하노이 탑 / 이준희

### DIFF
--- a/JHLEE325/202511/06 BOJ G5 하노이 탑.md
+++ b/JHLEE325/202511/06 BOJ G5 하노이 탑.md
@@ -1,0 +1,33 @@
+```java
+import java.io.*;
+import java.math.BigInteger;
+import java.util.*;
+
+public class Main {
+    static StringBuilder sb = new StringBuilder();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+
+        BigInteger moves = BigInteger.ONE.shiftLeft(N).subtract(BigInteger.ONE);
+        sb.append(moves).append("\n");
+
+        if (N <= 20) {
+            hanoi(N, 1, 3, 2);
+        }
+
+        System.out.println(sb.toString());
+    }
+
+    static void hanoi(int n, int from, int to, int temp) {
+        if (n == 1) {
+            sb.append(from).append(" ").append(to).append("\n");
+            return;
+        }
+        hanoi(n - 1, from, temp, to);
+        sb.append(from).append(" ").append(to).append("\n");
+        hanoi(n - 1, temp, to, from);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1914

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
N개의 원판을 하노이탑 했을 때 몇회 이동해야하는지 출력하고
N이 20이하라면 그 이동경로도 출력하는 문제입니다.

## 🔍 풀이 방법
하노이탑 재귀를 만들어서 풀었습니다.
N이 최대 100으로 매우 큰데 하노이탑 이동 횟수는 2^N -1 이기 때문에 long으로도 안됩니다. 그래서 BigInteger 사용했습니다.

## ⏳ 회고
처음에 long으로 풀었는데 틀릴 수가 없는데 틀렸다 해서 열받았는데 long 범위 문제였습니다.
