### PR TITLE
[20251106] BOJ / G1 / 계단 수 / 한종욱

### DIFF
--- a/Ukj0ng/202511/06 BOJ G1 계단 수.md
+++ b/Ukj0ng/202511/06 BOJ G1 계단 수.md
@@ -1,0 +1,50 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static final int MOD = 1000000000;
+    private static int[][][] dp;
+    private static int N;
+    public static void main(String[] args) throws IOException {
+        init();
+        long answer = 0;
+        for (int i = 0; i < 10; i++) {
+            answer += dp[N][i][(1<<10) - 1];
+            answer %= MOD;
+        }
+
+        bw.write(answer + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+
+        dp = new int[N+1][10][1<<10];
+
+        for (int i = 1; i < 10; i++) {
+            dp[1][i][1<<i] = 1;
+        }
+
+        for (int i = 2; i <= N; i++) {
+            for (int j = 0; j < 10; j++) {
+                for (int k = 0; k < 1<<10; k++) {
+                    if (j < 9) {
+                        dp[i][j+1][k | (1<<(j+1))] += dp[i-1][j][k];
+                        dp[i][j+1][k | (1<<(j+1))] %= MOD;
+                    }
+                    if (j > 0) {
+                        dp[i][j-1][k | (1<<(j-1))] += dp[i-1][j][k];
+                        dp[i][j-1][k | (1<<(j-1))] %= MOD;
+                    }
+                }
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1562
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
인접한 모든 자리의 차이가 1치면서 0~9까지 모두 등장한 수의 개수를 세라
## 🔍 풀이 방법
상태정의를 `dp[N번째 자리][마지막 수][여태까지의 체크한 수]`로 표현하고 더했다. 
## ⏳ 회고
<< 연산자 순위를 잘 모를 땐, 그냥 ()로 다 묶어서 명시하자. C 선생과 같이 풀었는데 비슷한 문제를 많이 풀어봐야 체화가 될꺼 같다. 그래도 재밌었다. 