### PR TITLE
[20251106] BOJ / G1 / XOR Hashing / 권혁준

### DIFF
--- a/khj20006/202511/06 BOJ G1 XOR Hashing.md
+++ b/khj20006/202511/06 BOJ G1 XOR Hashing.md
@@ -1,0 +1,31 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+using ll = long long;
+
+const ll MOD = 1e9 + 7;
+ll N, M;
+
+ll power(ll a, ll b) {
+	if (b == 0) return 1;
+	if (b == 1) return a % MOD;
+	ll h = power(a, b >> 1) % MOD;
+	h = h * h % MOD;
+	return (b & 1) ? h * a % MOD : h;
+}
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin >> N >> M;
+	N = (1 << N);
+	if (M > N) return cout << 1, 0;
+
+	ll g = power(N, M), p = 1;
+	for (ll i = N; i > N - M; i--) p = (p * i) % MOD;
+
+	ll ans = ((g - p + MOD) % MOD) * power(g, MOD - 2) % MOD;
+	cout << ans;
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/26653

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
2차원 평면에서 좌표값의 범위가 0 이상 2^N 미만에 속하도록 M개의 점을 균일한 확률로 뽑는다.
점 (x,y)의 해시 값을 x와 y의 xor값으로 정할 때, M개의 점 중 같은 해시 값을 가진 쌍이 존재할 확률을 구해보자.

## 🔍 풀이 방법
어떤 점을 골라도 xor값은 항상 0 이상 2^N 미만이기 때문에, `비둘기집 원리`에 의해 M > 2^N인 경우에는 같은 값이 항상 존재하게 된다. -> 1 출력

이제부터는 M <= 2^N인 경우만 고려한다.
점을 하나 골랐을 때 xor 값이 i일 확률을 f(i)라고 하면, f(0)부터 f(2^N - 1)까지 모두 동일하다.
그래서 답은 1 - (xor 값이 모두 다를 확률)로 구했다.
xor값이 모두 다를 확률은 (2^N)개의 점 중에서 서로 다른 점 M개를 뽑을 확률이니까 permutation(2^N, M) / 2^NM이 된다.

분수에 대한 나머지 연산은 `페르마의 소정리`와 `분할 정복 거듭제곱`을 이용해서 처리해줬다.

## ⏳ 회고
ez