### PR TITLE
[20251107] BOJ / G3 / 수상 택시 / 이준희

### DIFF
--- a/JHLEE325/202511/07 BOJ G3 수상택시.md
+++ b/JHLEE325/202511/07 BOJ G3 수상택시.md
@@ -1,0 +1,61 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static class taxi implements Comparable<taxi> {
+        int start, end;
+        taxi(int s, int e) {
+            this.start = s;
+            this.end = e;
+        }
+        public int compareTo(taxi o) {
+            if (this.start != o.start) return Integer.compare(this.start, o.start);
+            return Integer.compare(this.end, o.end);
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        List<taxi> list = new ArrayList<>();
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            if (a > b) {
+                list.add(new taxi(b, a));
+            }
+        }
+
+        if (list.isEmpty()) {
+            System.out.println(M);
+            return;
+        }
+
+        Collections.sort(list);
+
+        long extra = 0;
+        int curStart = list.get(0).start;
+        int curEnd = list.get(0).end;
+
+        for (int i = 1; i < list.size(); i++) {
+            taxi t = list.get(i);
+            if (t.start <= curEnd) {
+                curEnd = Math.max(curEnd, t.end);
+            } else {
+                extra += (long)(curEnd - curStart) * 2;
+                curStart = t.start;
+                curEnd = t.end;
+            }
+        }
+        extra += (long)(curEnd - curStart) * 2;
+
+        long answer = M + extra;
+        System.out.println(answer);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2836

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
0번집에 사는 상근이가 M번 집까지 가는 길에 중간에 사는 사람들을 모두 데려다 주려고 할 때
상근이가 움직여야 하는 거리의 최솟값을 구하는 문제입니다.

## 🔍 풀이 방법
어차피 M번집까지 가야하기 때문에 정방향으로 가는 경우는 고려하지 않아도 됐었습니다.
그래서 역방향으로 가는 경우만 찾아서 배열에 넣은 후
겹치는 구간을 구해서 총 역방향 이동거리를 구했습니다.
역방향 이동거리만큼 다시 정방향으로 이동해야하기 때문에 M + (역방향이동*2) 로 구했습니다.

## ⏳ 회고
얼마전에 풀었던 아우어아 어쩌구랑 비슷했습니다.
