### PR TITLE
[20251107] BOJ / P4 / 트리와 XOR / 권혁준

### DIFF
--- a/khj20006/202511/07 BOJ P4 트리와 XOR.md
+++ b/khj20006/202511/07 BOJ P4 트리와 XOR.md
@@ -1,0 +1,48 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+using ll = long long;
+
+int N;
+vector<vector<int>> v;
+vector<ll> a, d, s, u;
+
+void dfs1(int n, int p) {
+    s[n] = 1;
+    for(int i:v[n]) if(i != p) {
+        dfs1(i,n);
+        s[n] += s[i];
+        d[n] += d[i] + (a[n]^a[i]) * s[i];
+    }
+}
+
+void dfs2(int n, int p) {
+    if(n != 1) u[n] = u[p] + d[p] - d[n] + (a[n]^a[p]) * (N - 2 * s[n]);
+    for(int i:v[n]) if(i != p) dfs2(i,n);
+}
+
+int main() {
+    cin.tie(0)->sync_with_stdio(0);
+    
+    int T;
+    for(cin>>T;T--;) {
+        cin>>N;
+        a = vector<ll>(N+1);
+        d = vector<ll>(N+1);
+        s = vector<ll>(N+1);
+        u = vector<ll>(N+1);
+        v = vector<vector<int>>(N+1);
+        for(int i=1;i<=N;i++) cin>>a[i];
+        for(int i=1,p,q;i<N;i++) {
+            cin>>p>>q;
+            v[p].push_back(q);
+            v[q].push_back(p);
+        }
+        dfs1(1,0);
+        dfs2(1,0);
+        for(int i=1;i<=N;i++) cout<<d[i]+u[i]<<' ';
+        cout<<'\n';
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/30239

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
정점 N개인 트리에서 i번 정점에는 정수 a[i]가 쓰여 있다.
시행 한 번에서 정점 v와 정수 c를 선택하고, v를 루트로 하는 서브트리의 모든 정점에 쓰인 수 a[i]를 a[i] xor c로 바꾼다. 이때 시행의 비용은 (v를 루트로 하는 서브트리의 크기)*c이다.

r번 점이 트리의 루트인 경우에 모든 정점에 적힌 수를 같게 하기 위한 최소 비용을 m[r]이라고 할 때, m[1], m[2], ..., m[N]을 구해보자.

## 🔍 풀이 방법
일단 1번 점을 루트로 잡는다.
`d[n] = n번 점을 루트로 하는 서브트리의 모든 점을 a[n]으로 만들기 위한 최소 비용`
`u[n] = n번 점을 루트로 하는 서브트리 외의 모든 점을 a[n]으로 만들기 위한 최소 비용`

n의 자식들을 c라 하면,
d[n] = sum(d[c] + (a[n]^a[c]) * s[c])
u[n] = u[p] + d[p] - d[n] + (a[n]^a[p]) * (N - 2*s[n])
m[n] = d[n] + u[n]

## ⏳ 회고
ez