### PR TITLE
[20251107] BOJ / G2 / 동전 옮기기 / 이종환

### DIFF
--- a/0224LJH/202511/07 BOJ 동전 옮기기.md
+++ b/0224LJH/202511/07 BOJ 동전 옮기기.md
@@ -1,0 +1,104 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main { 
+	
+	static int len,idx1,idx2;
+	static boolean[][] dp;
+	static char[] arr,comp,move = new char[2];
+	static char last = '1';
+	static String ans;
+	static Queue<Character> arrQ = new LinkedList<>();
+	static Queue<Character> fingerQ = new LinkedList<>();
+	
+    public static void main(String[] args) throws IOException {
+    	init();
+    	process();
+    	print();
+    }
+
+    private static void init() throws IOException{
+    	BufferedReader br = new BufferedReader(new InputStreamReader(System.in));;
+    	len = Integer.parseInt(br.readLine());
+    	char[] temp = br.readLine().toCharArray();
+    	arr = br.readLine().toCharArray();
+    	
+    	StringTokenizer st = new StringTokenizer(br.readLine());
+    	idx1 = Integer.parseInt(st.nextToken());
+    	idx2 = Integer.parseInt(st.nextToken());
+    	
+    	int idx = 0;
+    	int moveIdx = 0;
+    	
+    	comp = new char[len-2];
+    	
+    	for (int i = 0; i < len; i++) {
+    		if (i == idx1 || i == idx2) {
+    			move[moveIdx++] = temp[i];
+    		} else {
+    			comp[idx++] =temp[i];
+    		}
+    		
+    	}
+    	dp = new boolean[len][3]; // dp[i][j] move j개쓰고 이곳에 도달가능?
+
+    	
+    }
+    
+    
+    private static void process() {
+    	int idx = 0;
+    	int mIdx = 0;
+    	
+    	
+    	if (arr[0] != comp[0] && arr[0] != move[0]) {
+    		ans = "NO";
+    		return;
+    	}
+    	
+    	if (arr[0] == comp[0]) {
+    		dp[0][0] = true;
+    	}
+    	if (arr[0] == move[0]) {
+    		dp[0][1] = true;
+    	}
+    	
+    	
+    	for (int i = 1; i < len; i++) {
+    		for (int j = 0; j < 3; j++) {
+    			
+    			if (!dp[i-1][j]) continue;
+    			// 이제 비교
+    			
+    			if (i-j < len-2) {
+        			if (arr[i] == comp[i-j]) {
+        				dp[i][j] = true;
+        			} 
+    			}
+
+    			if (j!= 2 && arr[i] == move[j]) {
+    				dp[i][j+1] = true;
+    			}
+    		}
+    	}
+    	
+    	ans = dp[len-1][2]?"YES":"NO";
+    }
+    
+
+    
+    private static void print() {
+    	System.out.println(ans);
+    }
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/20047

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
100 원짜리 동전과 10 원짜리 동전이 임의의 순서로 한 선 위에 나열되어 있다고 하자. 이제 여기서 ‘두 손가락 이동’ 을 아래와 같이 정의하자.

단계 1: 임의의 두 동전을 선택한다.
단계 2: 단계 1 에서 선택한 두 동전을 둘의 순서를 유지한 채 임의의 위치로 이동한다. (두 동전 모두 제자리에 있거나 두 동전의 순서를 유지한다면 하나만 이동해도 된다.)
‘두 손가락 이동’ 후에도 다른 동전들 간의 순서는 그대로 유지된다. 예를 들어 100 원을 o, 10 원을 x 라 했을 때, 초기에 동전이 oxoxoxxxoo 와 같이 나열되어 있다 하자. 이제 이들 중 굵게 표시된 두 동전을 선택하여 두 손가락 이동을 한번 한 경우, 나올 수 있는 여러 결과들 중에서 네 가지 결과만 아래에 표시했다 (아래 예시에 없는 다른 결과들 또한 나올 수 있음에 유의하자).

oxoxoxxxoo
oxooxxxxoo
oxoxoxxoxo
oxoxoxxxoo
n 개의 동전이 나열되어 있는 두 상태 S, T와 함께 두 손가락 이동을 위해 선택할 두 동전의 위치가 주어졌을 때, 한번의 두 손가락 이동을 통해 S에서 T로의 변환이 가능한지 결정하는 프로그램을 작성하시오.


## 🔍 풀이 방법
처음에는 너무 날먹으러 하려다가 시간을 좀 버렸다.
다시 판단해보니 dp로 접근하는게 제일 간편했다.

dp[i][j] 움직이는 동전을 j개 쓰고 i번째까지 도달할 수 있냐를 저장하는 것이다.
이를 통해 dp를 진행하면 끝

## ⏳ 회고
