### PR TITLE
[20251107] PGM / LV2 / 연속 부분 수열의 합 / 이인희

### DIFF
--- a/LiiNi-coder/202511/07 PGM 연속 부분 수열의 합의 개수.md
+++ b/LiiNi-coder/202511/07 PGM 연속 부분 수열의 합의 개수.md
@@ -1,0 +1,26 @@
+```java
+import java.util.*;
+
+class Solution {
+    public int solution(int[] elements) {
+        int length = elements.length;
+        int[] arr = new int[length * 2];
+        for(int i = 0; i < length * 2; i++){
+            arr[i] = elements[i % length];
+        }
+        Set<Integer> set = new HashSet<>();
+        for(int size = 1; size <= length; size++){
+            for(int start = 0; start < length; start++){
+                int sum = 0;
+                for(int i = start; i < start + size; i++){
+                    sum += arr[i];
+                }
+                set.add(sum);
+            }
+        }
+
+        return set.size();
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/131701
## 🧭 풀이 시간
30 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 원형 수열이 주어질때, 연속으로 더한 값의 종류 구하기
## 🔍 풀이 방법
- HashSet
## ⏳ 회고
- 간이 arr로 *2하는 전략