### PR TITLE
[20251108] BOJ / P5 / 바리스타의 힘 / 한종욱

### DIFF
--- a/Ukj0ng/202511/08 BOJ P5 바리스타의 힘.md
+++ b/Ukj0ng/202511/08 BOJ P5 바리스타의 힘.md
@@ -1,0 +1,105 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static final int INF = (int) 1e9;
+    private static final int[] dx = {1, 0, -1, 0};
+    private static final int[] dy = {0, 1, 0, -1};
+    private static int[][][] dist;
+    private static int[][] map;
+    private static int N, M;
+    public static void main(String[] args) throws IOException {
+        init();
+        int answer = BFS();
+
+        bw.write(answer + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        dist = new int[N+1][M+1][6];
+        map = new int[N+1][M+1];
+
+        for (int i = 1; i <= N; i++) {
+            char[] input = br.readLine().toCharArray();
+            for (int j = 1; j <= M; j++) {
+                map[i][j] = input[j-1] - '0';
+                Arrays.fill(dist[i][j], INF);
+            }
+        }
+    }
+
+    private static int BFS() {
+        Deque<int[]> q = new ArrayDeque<>();
+        int result = INF;
+        dist[1][1][0] = 0;
+        // x, y, mode
+        q.add(new int[]{1, 1, 0});
+
+        while (!q.isEmpty()) {
+            int[] current = q.poll();
+
+            if (current[2] == 0) {
+                for (int i = 0; i < 4; i++) {
+                    int nx = current[0] + dx[i];
+                    int ny = current[1] + dy[i];
+
+                    if (OOB(nx, ny) || map[nx][ny] == 1 || dist[nx][ny][current[2]] <= dist[current[0]][current[1]][current[2]] + 1) continue;
+                    dist[nx][ny][current[2]] = dist[current[0]][current[1]][current[2]] + 1;
+                    q.addLast(new int[]{nx, ny, current[2]});
+                }
+
+                for (int i = 0; i < 4; i++) {
+                    int newMode = i+2;
+                    if (dist[current[0]][current[1]][current[2]] < dist[current[0]][current[1]][newMode]) {
+                        dist[current[0]][current[1]][newMode] = dist[current[0]][current[1]][current[2]];
+                        q.addFirst(new int[]{current[0], current[1], newMode});
+                    }
+                }
+            } else if (current[2] == 1) {
+                for (int i = 0; i < 4; i++) {
+                    int nx = current[0] + dx[i];
+                    int ny = current[1] + dy[i];
+
+                    if (OOB(nx, ny) || map[nx][ny] == 1 || dist[nx][ny][current[2]] <= dist[current[0]][current[1]][current[2]] + 1) continue;
+                    dist[nx][ny][current[2]] = dist[current[0]][current[1]][current[2]] + 1;
+                    q.addLast(new int[]{nx, ny, current[2]});
+                }
+            } else {
+                if (dist[current[0]][current[1]][current[2]] < dist[current[0]][current[1]][1]) {
+                    dist[current[0]][current[1]][1] = dist[current[0]][current[1]][current[2]];
+                    q.addFirst(new int[]{current[0], current[1], 1});
+                }
+
+                int dir = current[2]-2;
+                int nx = current[0] + dx[dir];
+                int ny = current[1] + dy[dir];
+
+                if (OOB(nx, ny) || dist[nx][ny][current[2]] <= dist[current[0]][current[1]][current[2]] + 1) continue;
+                dist[nx][ny][current[2]] = dist[current[0]][current[1]][current[2]] + 1;
+                q.addLast(new int[]{nx, ny, current[2]});
+            }
+        }
+
+        for (int i = 0; i < 6; i++) {
+            result = Math.min(result, dist[N][M][i]);
+        }
+
+        return (result == INF) ? -1 : result;
+    }
+
+    private static boolean OOB(int nx, int ny) {
+        return nx < 1 || nx > N || ny < 1 || ny > M;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/24439
## 🧭 풀이 시간
90분 + 90분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
일반적인 문제인데 바라본 방향을 보고 벽을 뚫는다. 최단거리는?
## 🔍 풀이 방법
벽을 뚫을 때, 해당 방향으로 도착할 수 있는 곳을 모두 queue에 넣는다. 그리고 다익스트라 느낌으로 최단거리를 체크해야 한다. 중복이 될 수도 있거든. 

문제는 벽을 뚫을 때, 모든 도착할 수 있는 곳을 queue에 넣는 게 잘못됐다. 
BFS에서 진행될 행동을 잘게 자른다. 
1. 스킬 미사용
    1. 일반 이동
    2. 스킬 시작
2. 스킬 사용 완료
3. 스킬 사용 중
    1. 스킬 중지
    2. 스킬 계속 사용
으로 행동을 나눈 다음, 벽을 부술 땐 모두 부술 필요 없이 더 가까워질 때만 queue에 넣는다. 
## ⏳ 회고
배운 건 세 가지다. 
1. 우선순위 큐를 사용하지 않고 Deque만으로 addFirst, addLast를 통해 우선순위를 조절할 수 있다. 
2. 난 한 번에 처리하려는 습관이 있다. 잘 모르겠으면 단위를 잘게 나눠보자. 
3. continue를 사용할 땐, 아래 어떤 절차가 있는지 확인하기