### PR TITLE
[20251108] PGM / LV2 / 카펫 / 김민진

### DIFF
--- a/zinnnn37/202511/8 PGM LV2 카펫.md
+++ b/zinnnn37/202511/8 PGM LV2 카펫.md
@@ -1,0 +1,16 @@
+```java
+public class PGM_LV2_카펫 {
+
+    public int[] solution(int B, int Y) {
+        int mul = B + Y;
+        int sum = (B + 4) / 2;
+
+        int sqrt = (int) Math.sqrt(sum * sum - 4 * (B + Y));
+
+        int a = (sum + sqrt) / 2;
+        int b = (sum - sqrt) / 2;
+
+        return new int[] { a, b };
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[카펫](https://school.programmers.co.kr/learn/courses/30/lessons/42842)

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
테두리 타일의 수와 내부 타일의 수가 주어졌을 때 타일의 가로 세로 크기 구하기
단 가로가 세로보다 길다

## 🔍 풀이 방법
근의공식

```java
// 가로 * 세로 = 타일의 총 갯수
ab = B + Y

// 테두리 타일의 갯수
2(a - 2) + 2(b - 2) + 4 = B
a + b = (B + 4) / 2

mul = ab;
sum = a + b;

b = sum - a;
a(sum - a) = mul;
a² - sum·a + mul = 0;

// 이후 근의공식 적용..
```

## ⏳ 회고
수학 문제는 내지 말아주면 좋겟네..