### PR TITLE
[20251108] BOJ / G5 / 기타 레슨 / 이준희

### DIFF
--- a/JHLEE325/202511/08 BOJ G5 기타 레슨.md
+++ b/JHLEE325/202511/08 BOJ G5 기타 레슨.md
@@ -1,0 +1,54 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        int[] lectures = new int[N];
+        long sum = 0;
+        int maxLen = 0;
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            lectures[i] = Integer.parseInt(st.nextToken());
+            sum += lectures[i];
+            if (lectures[i] > maxLen) {
+                maxLen = lectures[i];
+            }
+        }
+
+        long low = maxLen;
+        long high = sum;
+        long answer = sum;
+
+        while (low <= high) {
+            long mid = (low + high) / 2;
+
+            int cnt = 1;
+            long cur = 0;
+            for (int i = 0; i < N; i++) {
+                if (cur + lectures[i] > mid) {
+                    cnt++;
+                    cur = lectures[i];
+                } else {
+                    cur += lectures[i];
+                }
+            }
+
+            if (cnt > M) {
+                low = mid + 1;
+            } else {
+                answer = mid;
+                high = mid - 1;
+            }
+        }
+
+        System.out.println(answer);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2343

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
기타 레슨 동영상을 블루레이 몇개에 나눠서 팔려고 할 때
블루레이의 크기는 들어가는 동영상 크기의 합 입니다.
블루레이의 개수 제한이 주어졌을 때 블루레이 크기의 최솟값을 구하는 문제입니다.

## 🔍 풀이 방법
이분탐색으로 풀었습니다.
이분탐색을 시작할 때 최솟값은 동영상 길이의 최댓값이고
최댓값은 모든 동영상 길이의 합으로 하여 횟수를 줄였습니다.

## ⏳ 회고
뭔가 풀이방법을 떠올리기만 하면 쉬운 문제였던 것 같습니다.
