### PR TITLE
[20251109] BOJ / G4 / 램프 / 이강현

### DIFF
--- a/lkhyun/202511/09 BOJ G4 램프.md
+++ b/lkhyun/202511/09 BOJ G4 램프.md
@@ -1,0 +1,39 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main{
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringBuilder sb = new StringBuilder();
+    static StringTokenizer st;
+    static int N,M,K;
+    static Map<String, Integer> patterns = new HashMap<>();
+    static int max = 0;
+
+    public static void main(String[] args) throws Exception {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        for(int i = 0;i<N;i++){
+            String input = br.readLine();
+            patterns.put(input, patterns.getOrDefault(input, 0)+1);
+        }
+        K = Integer.parseInt(br.readLine());
+
+        for(String s : patterns.keySet()){
+            int zeroCnt = 0;
+            for(int i = 0; i<s.length(); i++){
+                if(s.charAt(i) == '0'){
+                    zeroCnt++;
+                }
+            }
+            if(zeroCnt <= K && (K-zeroCnt)%2 == 0){
+                max = Math.max(max,patterns.get(s));
+            }
+        }
+        bw.write(max+"");
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1034
## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
램프가 N x M의 형태로 존재함.
각 열의 맨 아래에는 해당 열을 반전시키는 스위치가 있음.
행이 모두 켜졌을때, 램프가 켜졌다고 함.
이때, 최대한 램프를 켰을때 그 개수를 출력.
## 🔍 풀이 방법
맵, 브루트포스
행을 하나의 패턴으로 보고 맵에 개수와 함께 저장.
패턴을 순회하면서 0의 개수를 세기
0의 개수가 K보다 작거나 같으면서 0의 개수만큼 반전시킨후 남은 반전횟수가 짝수인지 확인
짝수여야 켰다 끄면서 상태를 유지할 수 있기 때문.
위 조건을 만족하면서 가장 많은 패턴 개수를 출력.
## ⏳ 회고
정확히 K번 스위치를 눌러야 한다는 것을 생각하지 못했음.
행을 하나의 패턴으로 보고 접근해야한다는 아이디어.