### PR TITLE
[20251109] BOJ / G4 / 대전 도시철도 2호선 / 권혁준

### DIFF
--- a/khj20006/202511/09 BOJ G4 대전 도시철도 2호선.md
+++ b/khj20006/202511/09 BOJ G4 대전 도시철도 2호선.md
@@ -1,0 +1,52 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+
+int N;
+vector<vector<int>> v(100001);
+vector<int> arr;
+bitset<100001> vis;
+
+void dfs(int n, int p) {
+    if(n == N) vis[n] = 1;
+    for(int i:v[n]) if(i != p) {
+        dfs(i,n);
+        if(vis[i]) vis[n] = 1;
+    }
+}
+
+int main() {
+    cin.tie(0)->sync_with_stdio(0);
+
+    cin>>N;
+    for(int i=1,a,b;i<N;i++) {
+        cin>>a>>b;
+        v[a].push_back(b);
+        v[b].push_back(a);
+    }
+
+    dfs(1,0);
+    for(int i=1;i<=N;i++) if(!vis[i]) {
+        int cnt = 0;
+        queue<int> q;
+        vis[i] = 1;
+        q.push(i);
+        while(!q.empty()) {
+            int n = q.front(); q.pop();
+            cnt++;
+            for(int j:v[n]) if(!vis[j]) {
+                vis[j] = 1;
+                q.push(j);
+            }
+        }
+        arr.push_back(cnt);
+    }
+    long long sum = 0, ans = 0;
+    for(int i:arr) {
+        ans += sum * i;
+        sum += i;
+    }
+    cout<<ans;
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/32408

## 🧭 풀이 시간
10분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
정점 N개인 트리에서 1번 점과 N번 점을 잇는 경로 상의 정점들을 **1호선 역**으로 지정한다.
조건을 만족하는 두 점 (s, e) 쌍의 개수를 구해보자.
- s < e
- s번 점과 e번 점은 **1호선 역**에 속하면 안 된다.
- s번 점과 e번 점을 잇는 경로 상에 **1호선 역**이 하나 이상 포함되어야 한다.

## 🔍 풀이 방법
1호선 역은 `dfs`로 찾아줬다.
1호선 역들을 모두 제외한 그래프에서 각 컴포넌트의 크기 배열을 arr이라 하고,
arr의 누적 합을 srr이라 정의한다.

답은 arr[i] * srr[i-1]로 구해줬다.

## ⏳ 회고
ez