### PR TITLE
[20251110] PGM / LV2 / 전력망을 둘로 나누기 / 김민진

### DIFF
--- a/zinnnn37/202511/10 PGM LV2 전력망 둘로 나누기.md
+++ b/zinnnn37/202511/10 PGM LV2 전력망 둘로 나누기.md
@@ -1,0 +1,66 @@
+```java
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class PGM_LV2_전력망_둘로_나누기 {
+
+    private static int N, ans;
+    private static int[][] wires;
+    private static boolean[] visited;
+    private static List<Integer>[] graph;
+
+    private static void init(int n, int[][] wire) {
+        N = n;
+        ans = Integer.MAX_VALUE;
+        wires = wire;
+
+        visited = new boolean[N + 1];
+
+        graph = new List[N + 1];
+        for (int i = 0; i <= N; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        for (int[] edge : wires) {
+            graph[edge[0]].add(edge[1]);
+            graph[edge[1]].add(edge[0]);
+        }
+    }
+
+    private static void sol() {
+        int cnt;
+        int left;
+        for (int i = 0; i < N - 1; i++) {
+            Arrays.fill(visited, false);
+
+            visited[wires[i][0]] = true;
+            visited[wires[i][1]] = true;
+
+            cnt = exclude(wires[i][0], wires[i]);
+
+            left = N - cnt;
+            ans = Math.min(ans, Math.abs(cnt - left));
+        }
+    }
+
+    private static int exclude(int start, int[] target) {
+        int cnt = 0;
+
+        for (int n : graph[start]) {
+            if (visited[n]) continue;
+
+            visited[n] = true;
+            cnt += exclude(n, target);
+        }
+        return cnt + 1;
+    }
+
+    public int solution(int n, int[][] wires) {
+        init(n, wires);
+        sol();
+        return ans;
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[전력망을 둘로 나누기](https://school.programmers.co.kr/learn/courses/30/lessons/86971)

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
트리 형식의 전력망이 있음
전선 하나를 끊을 때 전력망 두 그룹에서 가지는 노드 갯수의 차 중 최솟값

## 🔍 풀이 방법
어떤 전선을 끊을지 정하고 전선이 끊어진 노드부터 시작해서 자식의 갯수를 세면 됨

## ⏳ 회고
target 빼도 됨.. 수정 전의 잔해..
약간 구 한컴타자가 아닌 곳에서 타자연습을 할 때와 같은 묘한 불편함이 있음..
프로그래머스에서 왜 이렇게 코드가 안 읽히지 큰일낫다