### PR TITLE
[20251111] BOJ / P2 / 아인타 게임 / 권혁준

### DIFF
--- a/khj20006/202511/11 BOJ P2 아인타 게임.md
+++ b/khj20006/202511/11 BOJ P2 아인타 게임.md
@@ -1,0 +1,23 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	long long T, N, M, K;
+	for (cin >> T; T--;) {
+		cin >> K >> N >> M;
+		N--, M--;
+		if (K == 1) {
+			cout << (((N & 1LL) | (M & 1LL)) ? "koosaga\n" : "cubelover\n");
+			continue;
+		}
+		long long z = min(N, M) / (K + 1), zz = z * (K + 1);
+		N -= zz, M -= zz;
+		long long g = (N < K || M < K) ?  ((N & 1LL) ^ (M & 1LL) ^ (z & 1LL)) : (((N & 1LL) ^ (M & 1LL)) | 2LL);
+		cout << (g ? "koosaga\n" : "cubelover\n");
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16897

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N*M 크기의 체스판 위 (1,1) 지점에 말이 하나 놓여 있다.
말은 한 번의 이동에서 오른쪽으로 한 칸, 아래로 한 칸, 오른쪽 아래 방향으로 K칸 이동할 수 있다.
두 사람이 번갈아가며 말을 이동시키며, 말을 더 이상 이동시킬 수 없는 사람이 진다.
누가 이기는지 구해보자.

## 🔍 풀이 방법
어떤 칸이 (N, M)으로부터 떨어진 행, 열의 수를 각각 x, y라 하고, 이 상태에서 선공이 이기는지 여부를 g[x][y]라 둔다.
g[x][y] = 1이면 선공 승, 0이면 후공 승이다.

K = 1일 때는 반드시 g[x][y] = (x&1) | (y&1) 이다.
따라서 K = 1이 아닐 때만 생각한다.

z = min(x,y) / (K+1)로 두면, g[x][y] = g[x-z(K+1)][y-z(K+1)] 이다.

이제 두 가지 경우로 나뉜다.
1. x < K 혹은 y < K인 경우
- g[x][y] = (x&1)^(y&1)^(z&1)
2. 아닌 경우
- g[x][y] = 1

g[x][y]가 0이면 후공이 승리하고, 0이 아니면 선공이 승리한다.

## ⏳ 회고
ez