### PR TITLE
[20251114] BOJ / G4 / 수 묶기 / 이준희

### DIFF
--- a/JHLEE325/202511/14 BOJ G4 수 묶기.md
+++ b/JHLEE325/202511/14 BOJ G4 수 묶기.md
@@ -1,0 +1,48 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+
+        List<Integer> plus = new ArrayList<>();
+        List<Integer> minus = new ArrayList<>();
+        int ones = 0;
+        int zeros = 0;
+
+        for (int i = 0; i < N; i++) {
+            int x = Integer.parseInt(br.readLine());
+            if (x > 1) plus.add(x);
+            else if (x == 1) ones++;
+            else if (x == 0) zeros++;
+            else minus.add(x);
+        }
+
+        int sum = ones;
+
+        Collections.sort(plus, Collections.reverseOrder());
+        for (int i = 0; i < plus.size(); i += 2) {
+            if (i + 1 < plus.size())
+                sum += plus.get(i) * plus.get(i + 1);
+            else sum += plus.get(i);
+        }
+
+        Collections.sort(minus);
+        for (int i = 0; i < minus.size(); i += 2) {
+            if (i + 1 < minus.size())
+                sum += minus.get(i) * minus.get(i + 1);
+            else {
+                if (zeros > 0) {
+                    zeros--;
+                } else {
+                    sum += minus.get(i);
+                }
+            }
+        }
+
+        System.out.println(sum);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1744

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
수열이 주어지고 수는 위치 상관없이 두개씩 묶거나 안묶을 수 있고 묶은 경우에는 곱해서 더하게 되는데 이 때 결과값의 최대를 구하는 문제입니다.

## 🔍 풀이 방법
양수 끼리는 최대한 큰거끼리 곱하고
1이랑은 곱하지 않고
음수는 0이랑 곱해서 0으로 만들거나 절댓값이 큰거끼리 묶어서 양수로 만들었습니다.

## ⏳ 회고
분기해야 하는 조건이 꽤 있었습니다
