### PR TITLE
[20251114] BOJ / G5 / 최소 회의실 개수 / 김민진

### DIFF
--- a/zinnnn37/202511/14 BOJ G5 최소 회의실 개수.md
+++ b/zinnnn37/202511/14 BOJ G5 최소 회의실 개수.md
@@ -1,0 +1,79 @@
+```java
+import java.io.*;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class BJ_19598_최소_회의실_개수 {
+
+    private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static       StringTokenizer st;
+
+    private static int            N;
+    private static Room[]         rooms;
+    private static Queue<Integer> pq;
+
+    private static class Room implements Comparable<Room> {
+
+        int start;
+        int end;
+
+        Room(int start, int end) {
+            this.start = start;
+            this.end = end;
+        }
+
+        @Override
+        public int compareTo(Room o) {
+            if (this.start == o.start) {
+                return Integer.compare(this.end, o.end);
+            }
+            return Integer.compare(this.start, o.start);
+        }
+
+        @Override
+        public String toString() {
+            return "[" + start + " " + end + "]";
+        }
+
+    }
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+
+        rooms = new Room[N];
+        pq = new PriorityQueue<>();
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+
+            int s = Integer.parseInt(st.nextToken());
+            int e = Integer.parseInt(st.nextToken());
+
+            rooms[i] = new Room(s, e);
+        }
+        Arrays.sort(rooms);
+        pq.offer(rooms[0].end);
+    }
+
+    private static void sol() throws IOException {
+        for (int i = 1; i < N; i++) {
+            if (rooms[i].start >= pq.peek()) {
+                pq.poll();
+            }
+            pq.offer(rooms[i].end);
+        }
+        bw.write(pq.size() + "");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[최소 회의실 개수](https://www.acmicpc.net/problem/19598)

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
주어진 회의를 모두 진행하는데 필요한 회의실 수의 최솟값

## 🔍 풀이 방법
1. 회의 시작 기준으로 회의실 시간 정렬
2. 회의 종료시간을 우선순위 큐에 넣어서 1. 배열의 시작시간과 비교. 만약 시작시간이 더 크면 회의와 이어서 할 수 있으므로 `poll()`
3. 모든 회의실 시간을 확인한 후 우선순위 큐 크기가 필요한 회의실 갯수

## ⏳ 회고
처음에는 끝나는 지점을 기준으로 정렬해서 틀림
습관적 회의실 배정..