### PR TITLE
[20251114] BOJ / G5 / 최소 회의실 개수 / 설진영

### DIFF
--- a/Seol-JY/202511/14 BOJ G5 최소 회의실 개수.md
+++ b/Seol-JY/202511/14 BOJ G5 최소 회의실 개수.md
@@ -1,0 +1,36 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        
+        int[][] meetings = new int[N][2];
+        
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            meetings[i][0] = Integer.parseInt(st.nextToken());
+            meetings[i][1] = Integer.parseInt(st.nextToken());
+        }
+        
+        Arrays.sort(meetings, (a, b) -> Integer.compare(a[0], b[0]));
+        
+        PriorityQueue<Integer> pq = new PriorityQueue<>();
+        
+        for (int[] meeting : meetings) {
+            int start = meeting[0];
+            int end = meeting[1];
+            
+            if (!pq.isEmpty() && pq.peek() <= start) {
+                pq.poll();
+            }
+            
+            pq.offer(end);
+        }
+        
+        System.out.println(pq.size());
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/19598

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
N개의 회의를 모두 진행할 수 있는 최소 회의실 개수 구하기

## 🔍 풀이 방법
회의를 시작 시간 기준으로 정렬, 우선순위 큐에 회의실 종료 시간 저장
3가장 빨리 끝나는 회의실 종료시간 보다 새 회의 시작시간이 크면 재사용, 아니면 추가
큐 크기 = 필요한 회의실 개수

## ⏳ 회고
그리디같이 생김
