### PR TITLE
[20251114] BOJ / P4 / 구슬 발사기 / 권혁준

### DIFF
--- a/khj20006/202511/14 BOJ P4 구슬 발사기.md
+++ b/khj20006/202511/14 BOJ P4 구슬 발사기.md
@@ -1,0 +1,105 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+using ll = long long;
+
+const ll INF = 1e18;
+int N, S, E;
+map<int, vector<tuple<int, int, ll>>> mp[8]{};
+vector<vector<pair<int, ll>>> v(100001);
+vector<ll> dist(100001, INF);
+int par[100001]{};
+
+int main() {
+    cin.tie(0)->sync_with_stdio(0);
+
+    cin>>N>>S>>E;
+    for(int i=1;i<=N;i++) {
+        int x,y,c;
+        string d;
+        cin>>x>>y>>c>>d;
+
+        int dir = -1;
+        if(d == "N") dir = 0;
+        if(d == "NE") dir = 1;
+        if(d == "E") dir = 2;
+        if(d == "SE") dir = 3;
+        if(d == "S") dir = 4;
+        if(d == "SW") dir = 5;
+        if(d == "W") dir = 6;
+        if(d == "NW") dir = 7;
+
+        int cost = 0;
+        for(int j=dir;j<dir+8;j++) {
+            int k = j%8;
+            if(k == 0) {
+                mp[k][x].emplace_back(y,i,cost);
+            }
+            else if(k == 1) {
+                mp[k][y-x].emplace_back(x,i,cost);
+            }
+            else if(k == 2) {
+                mp[k][y].emplace_back(x,i,cost);
+            }
+            else if(k == 3) {
+                mp[k][y+x].emplace_back(x,i,cost);
+            }
+            else if(k == 4) {
+                mp[k][x].emplace_back(y,i,cost);
+            }
+            else if(k == 5) {
+                mp[k][y-x].emplace_back(x,i,cost);
+            }
+            else if(k == 6) {
+                mp[k][y].emplace_back(x,i,cost);
+            }
+            else {
+                mp[k][y+x].emplace_back(x,i,cost);
+            }
+            cost += c;
+        }
+
+    }
+
+    for(int i=0;i<8;i++) {
+        for(auto [a,b] : mp[i]) {
+            if(i<4) sort(b.begin(), b.end());
+            else sort(b.begin(), b.end(), greater<>());
+
+            for(int j=1;j<b.size();j++) {
+                auto [p,n1,c1] = b[j-1];
+                auto [q,n2,c2] = b[j];
+                v[n1].emplace_back(n2,c1);
+            }
+        }
+    }
+
+    dist[S] = 0;
+    priority_queue<pair<ll, int>, vector<pair<ll, int>>, greater<>> q;
+    q.emplace(0,S);
+    while(!q.empty()) {
+        auto [d,n] = q.top(); q.pop();
+        if(d > dist[n]) continue;
+        if(n == E) {
+            cout<<d<<'\n';
+            stack<int> st;
+            while(n) {
+                st.push(n);
+                n = par[n];
+            }
+            while(!st.empty()) {
+                cout<<st.top()<<' ';
+                st.pop();
+            }
+            return 0;
+        }
+        for(auto [i,c]:v[n]) if(dist[i] > d+c) {
+            dist[i] = d+c;
+            par[i] = n;
+            q.emplace(dist[i], i);
+        }
+    }
+    cout<<-1;
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/23329

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
2차원 좌표 평면에 N개의 구슬 발사기가 있다.
구슬 발사기는 8방향을 바라볼 수 있고, i번째 구슬 발사기를 시계 방향으로 45도 회전시키는 비용은 c[i]이다.

구슬 발사기들을 적절히 회전시켜서, 발사기 s로에서 출발하여 e에 도착하는 비용을 최소로 하고 그 경로를 출력해보자.

## 🔍 풀이 방법
8방향 각각에 대한 직선을 `map`으로 관리한다.
같은 직선에 포함된 점들을 모두 정렬시켜서 그래프를 구성해주고 `다익스트라`를 돌려 해결했다.
경로 출력은 다익스트라 트리에 대한 `역추적`으로 구해줬다.

## ⏳ 회고
어질어질