### PR TITLE
[20251115] BOJ / P2 / 점프 점프 2 / 권혁준

### DIFF
--- a/khj20006/202511/15 BOJ P2 점프 점프 2.md
+++ b/khj20006/202511/15 BOJ P2 점프 점프 2.md
@@ -1,0 +1,87 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+
+int N, S;
+vector<vector<int>> v(100001), r(100001), g(100001);
+stack<int> st;
+bitset<100001> vis;
+int f[100001]{}, c[100001]{}, dp[100001]{}, deg[100001]{};
+set<pair<int, int>> s;
+
+void dfs1(int n) {
+    for(int i:v[n]) if(!vis[i]) {
+        vis[i] = 1;
+        dfs1(i);
+    }
+    st.push(n);
+}
+
+void dfs2(int n, int k) {
+    f[n] = k;
+    c[k]++;
+    for(int i:r[n]) if(!vis[i]) {
+        vis[i] = 1;
+        dfs2(i,k);
+    }
+}
+
+void dfs3(int n) {
+    for(int i:g[n]) {
+        deg[i]++;
+        if(!vis[i]) {
+            vis[i] = 1;
+            dfs3(i);
+        }
+    }
+}
+
+int main() {
+    cin.tie(0)->sync_with_stdio(0);
+
+    cin>>N;
+    for(int i=1,a;i<=N;i++) {
+        cin>>a;
+        if(i-a>=1) v[i].push_back(i-a), r[i-a].push_back(i);
+        if(i+a<=N) v[i].push_back(i+a), r[i+a].push_back(i);
+    }
+    cin>>S;
+    for(int i=1;i<=N;i++) if(!vis[i]) {
+        vis[i] = 1;
+        dfs1(i);
+    }
+
+    vis.reset();
+    int num = 0;
+    while(!st.empty()) {
+        int n = st.top(); st.pop();
+        if(vis[n]) continue;
+        vis[n] = 1;
+        dfs2(n,++num);
+    }
+
+    for(int i=1;i<=N;i++) for(int j:v[i]) {
+        if(f[i] != f[j] && !s.count(make_pair(f[i], f[j]))) {
+            g[f[i]].push_back(f[j]);
+            s.emplace(f[i], f[j]);
+        }
+    }
+
+    vis.reset();
+    dfs3(f[S]);
+    queue<int> q;
+    q.push(f[S]);
+    dp[f[S]] = c[f[S]];
+    int ans = 0;
+    while(!q.empty()) {
+        int n = q.front(); q.pop();
+        ans = max(ans, dp[n]);
+        for(int i:g[n]) {
+            dp[i] = max(dp[i], dp[n] + c[i]);
+            if(!--deg[i]) q.push(i);
+        }
+    }
+    cout<<ans;
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14249

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N개의 돌이 일렬로 놓여있다.
i번 돌에서는 왼쪽 혹은 오른쪽으로 a[i]만큼 점프할 수 있다.
S번 돌에서 출발해서 방문할 수 있는 최대 돌의 개수를 구해보자.

## 🔍 풀이 방법
`SCC`단위로 그래프를 압축시켜 `DAG`를 만든다.
압축된 점의 가중치는 해당 `SCC`에 속한 점의 개수로 두고, 이 그래프에서 `위상 정렬` + `DP`로 최대 방문 가능한 점의 수를 구해줬다.

## ⏳ 회고
얼마 전에 푼 ATM 문제랑 비슷함