### PR TITLE
[20251115] BOJ / G1 / 난민 / 이강현

### DIFF
--- a/lkhyun/202511/15 BOJ G1 난민.md
+++ b/lkhyun/202511/15 BOJ G1 난민.md
@@ -1,0 +1,40 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringBuilder sb = new StringBuilder();
+    static StringTokenizer st;
+    static int N;
+
+    static PriorityQueue<Long> minheap = new PriorityQueue<>();
+    static PriorityQueue<Long> maxheap = new PriorityQueue<>(Comparator.reverseOrder());
+    public static void main(String[] args) throws Exception {
+        N = Integer.parseInt(br.readLine());
+        long prevY = 0;
+        long accumulation = 0; //누적 이동거리
+        for(int i = 1; i <= N; i++){
+            st = new StringTokenizer(br.readLine());
+            long curX = Long.parseLong(st.nextToken());
+            long curY = Long.parseLong(st.nextToken());
+
+            maxheap.add(curY); //일단 maxheap에 넣음.
+            minheap.add(maxheap.poll());
+            if(maxheap.size() < minheap.size()){
+                maxheap.add(minheap.poll());
+            }
+            if(i % 2 == 0){
+                accumulation += (Math.abs(curX) + Math.abs(prevY - curY));
+                prevY = maxheap.peek();
+            }else{
+                prevY = maxheap.peek();
+                accumulation += (Math.abs(curX) + Math.abs(prevY - curY));
+            }
+            bw.write(prevY + " " + accumulation + "\n");
+        }
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/23090
## 🧭 풀이 시간
120분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
난민촌들을 위한 정수시설을 지을거임..
정수시설은 x=0 그래프 위에 있음.
난민촌 N개가 순서대로 들어옴.
매 순서마다 모든 난민촌들의 정수시설까지 유클리드 거리가 최소가 되는 지점에 지을거임.
이때 정수시설의 y좌표와 거리 합을 같이 출력.
## 🔍 풀이 방법
우선순위큐
중앙값이 최소임. 우선순위 큐 두개로 구현
최소 힙과 최대 힙이 가지는 각각의 원소들은 개수가 같거나 최대힙이 하나 더 많음.
그니까 현재 짝수 개의 난민촌이 있으면, 힙의 개수 균형이 맞는 상태이니, 현재 난민촌을 추가하고 중앙값을 구하면 작은쪽과 큰쪽에서 오는 거리가 상쇄될거임. 그래서 현재 중앙값까지의 현재 추가된 난민촌의 거리를 더하면 됨.
홀수 개의 난민촌이 있는 경우는 최대 힙이 하나 더 많음. 따라서 중앙값이 변할때, 상쇄가 안됨. 그니까 일단 난민촌을 이전 중앙값까지의 거리로 추가하고 중앙값을 바꾸면 개수가 맞아져서 상쇄됨.
## ⏳ 회고
잘 구현해놓고 중앙값 구하는 로직을 잘못구해서 시간 개많이썼네 에효