### PR TITLE
[20251116] PGM / LV2 / 연속 부분 수열 / 이종환

### DIFF
--- a/0224LJH/202511/16 PGM 연속 부분 수열.md
+++ b/0224LJH/202511/16 PGM 연속 부분 수열.md
@@ -1,0 +1,42 @@
+```java
+import java.io.*;
+import java.util.*;
+
+class Solution {
+    
+    static HashSet<Integer> set = new HashSet<>();
+    
+    
+    public int solution(int[] elements) {
+        int len = elements.length;
+        
+        for (int i = 1; i <= len; i++){
+            int curLen = i;
+            
+            int curSum = 0;
+            for (int j = 0; j < curLen; j++){
+                curSum += elements[j];
+            }
+            
+            int st = 0;
+            int end = curLen-1;
+            set.add(curSum);
+            
+            for (int j = 1; j < len; j++){
+                curSum -= elements[st];
+                st++;
+                end++;
+                end %= len;
+                curSum += elements[end];
+                
+                set.add(curSum);
+            }
+            
+        }
+        
+        
+        int answer = set.size();
+        return answer;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/131701
## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
원형 수열은 처음과 끝이 연결되어 끊기는 부분이 없기 때문에 연속하는 부분 수열도 일반적인 수열보다 많아집니다.
원형 수열의 모든 원소 elements가 순서대로 주어질 때, 원형 수열의 연속 부분 수열 합으로 만들 수 있는 수의 개수를 return 하도록 solution 함수를 완성해주세요.

## 🔍 풀이 방법
그냥 모든 길이별로 시작지점을 0~ len-1로 잡아서 전부 슬라이딩 윈도우 식으로 구하면 끝이다
## ⏳ 회고
