### PR TITLE
[20251116] BOJ / G3 / 오등큰수 / 이준희

### DIFF
--- a/JHLEE325/202511/16 BOJ G3 오등큰수.md
+++ b/JHLEE325/202511/16 BOJ G3 오등큰수.md
@@ -1,0 +1,45 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int[] arr = new int[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int mnum = 1000000;
+        int[] count = new int[mnum + 1];
+        for (int i = 0; i < N; i++) {
+            count[arr[i]]++;
+        }
+
+        int[] result = new int[N];
+        Stack<Integer> stack = new Stack<>();
+
+        for (int i = N - 1; i >= 0; i--) {
+            int f = count[arr[i]];
+            while (!stack.isEmpty() && count[stack.peek()] <= f) {
+                stack.pop();
+            }
+            if (stack.isEmpty()) {
+                result[i] = -1;
+            } else {
+                result[i] = stack.peek();
+            }
+            stack.push(arr[i]);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < N; i++) {
+            sb.append(result[i]).append(' ');
+        }
+        System.out.println(sb.toString());
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17299

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
수열에서 특정 인덱스의 수보다 오른쪽에 있는 수 중에 현재 수보다 출현 빈도가 높은 수를 오등큰수라고 하는데 그 수 중 위치가 가장 가까운 수를 구하는 문제입니다.

## 🔍 풀이 방법
수열과, 최대 100만 까지기 때문에 100만 크기의 빈도 배열을 만들었습니다.
그 각 수의 오른쪽을 계산하기 때문에 역으로 맨 오른쪽 부터 찾았습니다.
스택을 이용햇습니다.

## ⏳ 회고
문제 설명이 어려웠습니다
