### PR TITLE
[20251117] BOJ / G4 / 서울에서 경산까지 / 이강현

### DIFF
--- a/lkhyun/202511/17 BOJ G4 서울에서 경산까지.md
+++ b/lkhyun/202511/17 BOJ G4 서울에서 경산까지.md
@@ -1,0 +1,97 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static int N, K;
+    static int[] vehicleTime, vehiclePrice, walkTime, walkPrice;
+    static int[] dp;
+    static boolean[] impossible;
+    
+    public static void main(String[] args) throws Exception {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+        walkTime = new int[N + 1];
+        walkPrice = new int[N + 1];
+        vehicleTime = new int[N + 1];
+        vehiclePrice = new int[N + 1];
+        dp = new int[K + 1];
+        impossible = new boolean[K + 1];
+
+        for (int i = 1; i <= N; i++) {
+            st = new StringTokenizer(br.readLine());
+            walkTime[i] = Integer.parseInt(st.nextToken());
+            walkPrice[i] = Integer.parseInt(st.nextToken());
+            vehicleTime[i] = Integer.parseInt(st.nextToken());
+            vehiclePrice[i] = Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.fill(impossible, true);
+        
+        if (walkTime[1] <= K) {
+            dp[walkTime[1]] = walkPrice[1];
+            impossible[walkTime[1]] = false;
+        }
+        if (vehicleTime[1] <= K) {
+            if (impossible[vehicleTime[1]]) {
+                dp[vehicleTime[1]] = vehiclePrice[1];
+                impossible[vehicleTime[1]] = false;
+            } else {
+                dp[vehicleTime[1]] = Math.max(dp[vehicleTime[1]], vehiclePrice[1]);
+            }
+        }
+
+        for (int i = 2; i <= N; i++) {
+            boolean[] nextImpossible = new boolean[K + 1];
+            Arrays.fill(nextImpossible, true);
+            int[] nextDp = new int[K + 1];
+
+            for (int j = K; j >= 0; j--) {
+                if (impossible[j]) continue;
+                
+                if (j + walkTime[i] <= K) {
+                    int nextTime = j + walkTime[i];
+                    int nextMoney = dp[j] + walkPrice[i];
+                    
+                    if (nextImpossible[nextTime]) {
+                        nextDp[nextTime] = nextMoney;
+                        nextImpossible[nextTime] = false;
+                    } else {
+                        nextDp[nextTime] = Math.max(nextDp[nextTime], nextMoney);
+                    }
+                }
+
+                if (j + vehicleTime[i] <= K) {
+                    int nextTime = j + vehicleTime[i];
+                    int nextMoney = dp[j] + vehiclePrice[i];
+                    
+                    if (nextImpossible[nextTime]) {
+                        nextDp[nextTime] = nextMoney;
+                        nextImpossible[nextTime] = false;
+                    } else {
+                        nextDp[nextTime] = Math.max(nextDp[nextTime], nextMoney);
+                    }
+                }
+            }
+            
+            dp = nextDp;
+            impossible = nextImpossible;
+        }
+
+        int answer = 0;
+        for (int j = 0; j <= K; j++) {
+            if (!impossible[j]) {
+                answer = Math.max(answer, dp[j]);
+            }
+        }
+
+        bw.write(answer + "");
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14863
## 🧭 풀이 시간
120분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
서울에서 경산까지 N개의 구간을 자전거 혹은 도보를 통해 갈거임.
가면서 구간마다 모금을 할거임. 이때 이동수단에 따라 모금액이 다름.
K분 이내로 가는데 가장 많은 모금액을 얻도록 할때, 그 모금액을 출력.
## 🔍 풀이 방법
배낭
배낭문제처럼 풀되, 갈 수 없는 경우의 dp값이 전파되는 것을 꼭 막는 것이 핵심.
## ⏳ 회고
어차피 K안에 갈 수 있으니 간단하게 풀었는데, 유효하지 않은 dp값을 업데이트시 사용하지 않도록 하는 것이 중요했다.