### PR TITLE
[20251117] BOJ / G5 / 비요뜨의 징검다리 건너기 / 권혁준

### DIFF
--- a/khj20006/202511/17 BOJ G5 비요뜨의 징검다리 건너기.md
+++ b/khj20006/202511/17 BOJ G5 비요뜨의 징검다리 건너기.md
@@ -1,0 +1,25 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+using ll = long long;
+
+ll MOD = 1e9 + 7;
+
+ll power(ll a) {
+	if (a <= 1) return (1 << a);
+	ll h = power(a >> 1) % MOD;
+	h = h * h % MOD;
+	return (a & 1) ? h * 2 % MOD : h;
+}
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	ll T, N, MOD = 1e9 + 7;
+	for (cin >> T; T--;) {
+		cin >> N;
+		cout << (N <= 2 ? 1 : power(N - 2)) << '\n';
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/18291

## 🧭 풀이 시간
5분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
징검다리 N개가 일렬로 놓여있다.
각 징검다리에서 임의의 길이만큼 다음 징검다리로 점프할 수 있다.
1에서 출발하여 정확히 N에 도착하는 경우의 수를 구해보자.

## 🔍 풀이 방법
1에서 출발하여 x에 도착하는 경우의 수를 f(x)라고 하면,
f(x) = f(1) + ... + f(x-1)이다.
구해보면 f(1) = 1이고 x = 2이상의 f(x)에 대해서는 2^(x-2)가 된다.
N이 커서 `분할 정복 거듭제곱`으로 구해줬다.

## ⏳ 회고
