### PR TITLE
[20251118] BOJ / G5 / 옥상 정원 꾸미기 / 이준희

### DIFF
--- a/JHLEE325/202511/18 BOJ G5 옥상 정원 꾸미기.md
+++ b/JHLEE325/202511/18 BOJ G5 옥상 정원 꾸미기.md
@@ -1,0 +1,28 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+
+        long answer = 0;
+        Stack<Integer> stack = new Stack<>();
+
+        for (int i = 0; i < N; i++) {
+            int height = Integer.parseInt(br.readLine());
+
+            while (!stack.isEmpty() && stack.peek() <= height) {
+                stack.pop();
+            }
+
+            answer += stack.size();
+
+            stack.push(height);
+        }
+
+        System.out.println(answer);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/6198

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
옥상 정원을 관리하는 경비원은 각각 오른쪽에 있는 건물들의 옥상을 참고합니다.
본인의 건물보다 높거나 그래서 가리게 되는 건물은 못보게 됩니다.
이 때 각 건물에서 볼 수 있는 빌딩의 수의 총합을 구하는 문제입니다.

## 🔍 풀이 방법
입력받는 순서대로 스택에 넣으면서 계산했습니다.
각 건물의 높이를 입력 받을 때 마다 스택에서 그 높이보다 작은 경우 스택에서 뽑아서 버리고
최종적으로 남은 스택의 사이즈를 각 사이클마다 더해줬습니다.

## ⏳ 회고
코드는 엄청 짧은데 그래도 생각해야 하는 문제였던 것 같습니다.
