### PR TITLE
[20251119] PGM / Lv2 / 서버 증설 횟수 / 이종환

### DIFF
--- a/0224LJH/202511/19 BOJ 서버 증설 횟수.md
+++ b/0224LJH/202511/19 BOJ 서버 증설 횟수.md
@@ -1,0 +1,36 @@
+```java
+import java.io.*;
+import java.util.*;
+
+class Solution {
+    public int solution(int[] players, int m, int k) {
+        int len = players.length;
+        int[] minus = new int[len];
+        
+        int cur = 0;
+        int total = 0;
+        
+        for (int i = 0; i < len; i++){
+            cur -= minus[i];
+            
+            int limit = m*(cur+1);
+            
+            if (players[i] < limit) continue;
+            
+            int diff = players[i] - limit;
+            
+            int plus = diff/m + 1;
+            cur += plus;
+            total += plus;
+            
+            if (i+k < len){
+                minus[i+k] = plus;
+            }
+            
+        }
+        
+        int answer = total;
+        return answer;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/389479?language=java
## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
당신은 온라인 게임을 운영하고 있습니다. 같은 시간대에 게임을 이용하는 사람이 m명 늘어날 때마다 서버 1대가 추가로 필요합니다. 어느 시간대의 이용자가 m명 미만이라면, 서버 증설이 필요하지 않습니다. 어느 시간대의 이용자가 n x m명 이상 (n + 1) x m명 미만이라면 최소 n대의 증설된 서버가 운영 중이어야 합니다. 한 번 증설한 서버는 k시간 동안 운영하고 그 이후에는 반납합니다. 예를 들어, k = 5 일 때 10시에 증설한 서버는 10 ~ 15시에만 운영됩니다.

하루 동안 모든 게임 이용자가 게임을 하기 위해 서버를 최소 몇 번 증설해야 하는지 알고 싶습니다. 같은 시간대에 서버를 x대 증설했다면 해당 시간대의 증설 횟수는 x회입니다.

## 🔍 풀이 방법
뭐 풀이라할게 없다. minus 배열에다가 언제 증설한 횟수가 사라지는지만 기록하면 된다.

## ⏳ 회고
