### PR TITLE
[20251120] BOJ / G4 / 물통 / 김민진

### DIFF
--- a/zinnnn37/202511/20 BJ G4 물통.md
+++ b/zinnnn37/202511/20 BJ G4 물통.md
@@ -1,0 +1,90 @@
+```java
+import java.io.*;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.TreeSet;
+
+public class BJ_2251_물통 {
+
+    private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static final StringBuilder   sb = new StringBuilder();
+    private static       StringTokenizer st;
+
+    private static int[]        capacity;
+    private static Set<Integer> candidate;
+    private static boolean[][]  visited;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        st = new StringTokenizer(br.readLine());
+
+        capacity = new int[3];
+        for (int i = 0; i < 3; i++) {
+            capacity[i] = Integer.parseInt(st.nextToken());
+        }
+        visited = new boolean[capacity[0] + 1][capacity[1] + 1];
+        candidate = new TreeSet<>();
+    }
+
+    private static void sol() throws IOException {
+        dfs(0, 0, capacity[2]);
+
+        for (int c : candidate) {
+            bw.write(c + " ");
+        }
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void dfs(int a, int b, int c) throws IOException {
+        if (visited[a][b]) return;
+
+        // a가 0일 때 c에 담긴 물의 양
+        if (a == 0) candidate.add(c);
+
+        visited[a][b] = true;
+
+        // a -> b
+        if (a + b <= capacity[1]) {
+            dfs(0, a + b, c);
+        } else {
+            dfs(a + b - capacity[1], capacity[1], c);
+        }
+
+        // b -> a
+        if (a + b <= capacity[0]) {
+            dfs(a + b, 0, c);
+        } else {
+            dfs(capacity[0], a + b - capacity[0], c);
+        }
+
+        // b -> c
+        if (b + c <= capacity[2]) {
+            dfs(a, 0, b + c);
+        } else {
+            dfs(a, b + c - capacity[2], capacity[2]);
+        }
+
+        // c -> a
+        if (a + c <= capacity[0]) {
+            dfs(a + c, b, 0);
+        } else {
+            dfs(capacity[0], b, a + c - capacity[0]);
+        }
+
+        // c -> b
+        if (b + c <= capacity[1]) {
+            dfs(a, b + c, 0);
+        } else {
+            dfs(a, capacity[1], b + c - capacity[1]);
+        }
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[물통](https://www.acmicpc.net/problem/2251)

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
물통 3개가 있음(A, B, C)
물통에 있는 물은 옮겨담을 수 있고 다른 통에 꽉 채우거나 물병을 비우거나 둘 중 하나 가능
A 물통이 비어있을 때 C 물통에 담을 수 있는 물의 양을 오름차순으로 출력

## 🔍 풀이 방법
물통은 3개로 고정이니까 물을 옮겨 담을 수 있는 방법은 6가지
6가지 중에서도 물을 전부 옮겨 담을 수 있는지 없는지 추가적으로 고려해주면 됨
물 양은 고정이라 방문 처리 배열 3차원까지는 의미 없는듯?
물 양은 중복 불가 + 오름차순이라 TreeSet에다 저장함

## ⏳ 회고
걍 노가다인데 밤샘 이슈로 머리 안굴러가서 미치는줄
근데 왜 bfs지 dfs가 더 쉽지 않나
아무튼 이제 잘거임