### PR TITLE
[20251120] BOJ / G5 / 농장관리 / 설진영

### DIFF
--- a/Seol-JY/202511/20 BOJ G5 농장관리.md‎
+++ b/Seol-JY/202511/20 BOJ G5 농장관리.md‎
@@ -1,0 +1,77 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int N, M;
+    static int[][] grid;
+    static boolean[][] visited;
+    static int[] dx = {-1, -1, -1, 0, 0, 1, 1, 1};
+    static int[] dy = {-1, 0, 1, -1, 1, -1, 0, 1};
+    
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        
+        grid = new int[N][M];
+        visited = new boolean[N][M];
+        
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) {
+                grid[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+        
+        int count = 0;
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                if (!visited[i][j] && isPeak(i, j)) {
+                    count++;
+                }
+            }
+        }
+        
+        System.out.println(count);
+    }
+    
+    static boolean isPeak(int x, int y) {
+        ArrayDeque<int[]> queue = new ArrayDeque<>();
+        List<int[]> component = new ArrayList<>();
+        
+        queue.offer(new int[]{x, y});
+        visited[x][y] = true;
+        component.add(new int[]{x, y});
+        
+        int height = grid[x][y];
+        boolean isPeak = true;
+        
+        while (!queue.isEmpty()) {
+            int[] cur = queue.poll();
+            
+            for (int i = 0; i < 8; i++) {
+                int nx = cur[0] + dx[i];
+                int ny = cur[1] + dy[i];
+                
+                if (nx < 0 || nx >= N || ny < 0 || ny >= M) continue;
+                
+                if (grid[nx][ny] > height) {
+                    isPeak = false;
+                }
+                
+                if (!visited[nx][ny] && grid[nx][ny] == height) {
+                    visited[nx][ny] = true;
+                    queue.offer(new int[]{nx, ny});
+                    component.add(new int[]{nx, ny});
+                }
+            }
+        }
+        
+        return isPeak;
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1245

## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
N×M 격자에서 산봉우리의 개수를 세는 문제
8방향으로 인접한 모든 격자가 산봉우리보다 낮아야 함

## 🔍 풀이 방법
BFS로 같은 높이의 연결된 영역을 탐색, 탐색 중 인접한 격자 중 더 높은 곳이 있으면 산봉우리가 아님
방문하지 않은 모든 위치에 대해 탐색하며 산봉우리 개수 카운트

## ⏳ 회고
쉽네요