### PR TITLE
[20251121] BOJ / G3 / 나머지 합 / 이준희

### DIFF
--- a/JHLEE325/202511/21 BOJ G3 나머지 합.md
+++ b/JHLEE325/202511/21 BOJ G3 나머지 합.md
@@ -1,0 +1,36 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        long[] count = new long[M];
+        long answer = 0;
+
+        long prefix = 0;
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            prefix = (prefix + Integer.parseInt(st.nextToken())) % M;
+            count[(int) prefix]++;
+        }
+
+        answer += count[0];
+
+        for (int i = 0; i < M; i++) {
+            long c = count[i];
+            if (c >= 2) {
+                answer += (c * (c - 1)) / 2;
+            }
+        }
+
+        System.out.println(answer);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/10986

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
수열이 주어졌을 때
구간의 합이 M으로 나누어 떨어지는 경우의 갯수를 구하는 문제입니다.

## 🔍 풀이 방법
수열을 입력받으면서 나머지의 구간합을 구해서 수열을 구성하며 각 나머지 경우마다 몇번 등장하는지 수열로 유지하엿습니다.
이후 각 나머지의 갯수 k 개 중에서 2개를 뽑아서 서로 - 해서 나머지를 0으로 만드는 경우의 수를 계산했습니다.

## ⏳ 회고
생각보다 어려웠던 문제였습니다.
나머지끼리 빼서 0을 만드는 경우를 생각하는 것이 어려웠습니다.