### PR TITLE
[20251121] BOJ / G3 / 나머지 합 / 설진영

### DIFF
--- a/Seol-JY/202511/21 BOJ G3 나머지 합.md‎
+++ b/Seol-JY/202511/21 BOJ G3 나머지 합.md‎
@@ -1,0 +1,34 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        
+        long[] count = new long[M];
+        count[0] = 1;
+        
+        long prefixSum = 0;
+        st = new StringTokenizer(br.readLine());
+        
+        for (int i = 0; i < N; i++) {
+            prefixSum += Long.parseLong(st.nextToken());
+            int mod = (int) (prefixSum % M);
+            count[mod]++;
+        }
+        
+        long answer = 0;
+        for (int i = 0; i < M; i++) {
+            answer += count[i] * (count[i] - 1) / 2;
+        }
+        
+        System.out.println(answer);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/10986

## 🧭 풀이 시간
35분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
N개의 수가 주어질 때, 연속된 부분 구간의 합이 M으로 나누어 떨어지는 구간의 개수 구하기

## 🔍 풀이 방법
누적 합 & 모듈러 연산 활용
나머지가 같으면 구간 합이 M의 배수

## ⏳ 회고
낫이지