### PR TITLE
[20251121] BOJ / G5 / 합분해 / 이인희

### DIFF
--- a/LiiNi-coder/202511/21 BOJ 합분해.md
+++ b/LiiNi-coder/202511/21 BOJ 합분해.md
@@ -1,0 +1,34 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final int MOD = 1_000_000_000;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int K = Integer.parseInt(st.nextToken());
+
+        int[][] dp = new int[N + 1][K + 1];
+
+        for(int j = 1; j <= K; j++){
+            dp[0][j] = 1;
+        }
+        for(int i = 0; i <= N; i++){
+            dp[i][1] = 1;
+        }
+
+        
+        for(int i = 1; i <= N; i++){
+            for(int j = 2; j <= K; j++){
+                dp[i][j] = (dp[i][j - 1] + dp[i - 1][j]) % MOD;
+            }
+        }
+        System.out.println(dp[N][K]);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2225
## 🧭 풀이 시간
40 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 0~N까지의 정수 K개를 더해서 그 합이 N이 되는 경우의수
## 🔍 풀이 방법
- dp
## ⏳ 회고
- dp[i][j] :합이 i가 되도도록 하여 숫자를 j개 고른 경우의 수