### PR TITLE
[20251122] BOJ / P5 / 최솟값 찾기 / 김민진

### DIFF
--- a/zinnnn37/202511/22 BOJ P5 최솟값 찾기.md
+++ b/zinnnn37/202511/22 BOJ P5 최솟값 찾기.md
@@ -1,0 +1,65 @@
+```java
+import java.io.*;
+import java.util.ArrayDeque;
+import java.util.StringTokenizer;
+
+public class BJ_11003_최솟값_찻기 {
+
+    private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static       StringTokenizer st;
+
+    private static int N, L;
+    private static int[]            nums;
+    private static ArrayDeque<Node> dq;
+
+    private static class Node {
+
+        int idx;
+        int val;
+
+        Node(int idx, int val) {
+            this.idx = idx;
+            this.val = val;
+        }
+
+    }
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        L = Integer.parseInt(st.nextToken());
+
+        nums = new int[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            nums[i] = Integer.parseInt(st.nextToken());
+        }
+        dq = new ArrayDeque<>();
+    }
+
+    private static void sol() throws IOException {
+        for (int i = 0; i < N; i++) {
+            while (!dq.isEmpty() && dq.getLast().val >= nums[i]) dq.removeLast();
+
+            dq.addLast(new Node(i, nums[i]));
+
+            if (dq.getFirst().idx <= i - L) dq.removeFirst();
+
+            bw.write(Integer.toString(dq.getFirst().val));
+            bw.write(' ');
+        }
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[최솟값 찾기](https://www.acmicpc.net/problem/11003)

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
길이 `N`이 숫자 배열이 주어졌을 때 `i ~ i + L` 범위의 부분 수열에서 최솟값 나열하기

## 🔍 풀이 방법
인덱스와 값을 저장하는 `Node` 객체를 저장하는 덱을 선언
덱에 있는 숫자 중에서 넣으려는 현 숫자보다 큰 수들은 있어봐야 아무 의미 없으니까 전부 제거
범위를 벗어나는 수도 제거
범위를 벗어나는 수는 무조건 최솟값이기 때문에 왼쪽에 있음
제거 후 왼쪽에 있는 값 출력
마지막 숫자까지 진행하면 됨

## ⏳ 회고
알고리즘의 세계는 무궁무진하구나~..