### PR TITLE
[20251122] BOJ / G5 / 김밥천국의 계단 / 설진영

### DIFF
--- a/Seol-JY/202511/22 BOJ G5 김밥천국의 계단.md‎
+++ b/Seol-JY/202511/22 BOJ G5 김밥천국의 계단.md‎
@@ -1,0 +1,45 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        int N = Integer.parseInt(st.nextToken());
+        int K = Integer.parseInt(st.nextToken());
+        
+        int[] dist = new int[N + 1];
+        Arrays.fill(dist, -1);
+        
+        ArrayDeque<Integer> queue = new ArrayDeque<>();
+        queue.offer(0);
+        dist[0] = 0;
+        
+        while (!queue.isEmpty()) {
+            int cur = queue.poll();
+            
+            if (dist[cur] >= K) continue;
+            
+            int next1 = cur + 1;
+            if (next1 <= N && dist[next1] == -1) {
+                dist[next1] = dist[cur] + 1;
+                queue.offer(next1);
+            }
+            
+            int next2 = cur + cur / 2;
+            if (next2 <= N && dist[next2] == -1) {
+                dist[next2] = dist[cur] + 1;
+                queue.offer(next2);
+            }
+        }
+        
+        if (dist[N] != -1 && dist[N] <= K) {
+            System.out.println("minigimbob");
+        } else {
+            System.out.println("water");
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/28069

## 🧭 풀이 시간
35분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
0번 계단에서 시작하여 정확히 K번의 행동으로 N번 계단에 도달해야 함

아래 행동 가능:
1. 계단 한 칸 올라가기: i → i + 1
2. 지팡이 두드리기: i → i + floor(i/2)

## 🔍 풀이 방법
BFS를 활용하여 각 계단에 도달하는 최소 횟수를 계산

1번 계단에서 지팡이를 두드리면 1 + floor(1/2) = 1로 제자리
-> N에 도달하는 최소 횟수가 K 이하이면, 남는 횟수는 1번 계단에서 지팡이를 두드려 소모 가능
-> 최소 도달 횟수 <= K이면 minigimbob 출력

## ⏳ 회고
1번 계단에서 지팡이가 제자리라는 점을 파악하면 단순히 최소 횟수만 비교하면 됨
ez 