### PR TITLE
[20251122] BOJ / P2 / MST의 기댓값 / 권혁준

### DIFF
--- a/khj20006/202511/22 BOJ P2 MST의 기댓값.md
+++ b/khj20006/202511/22 BOJ P2 MST의 기댓값.md
@@ -1,0 +1,86 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+using ll = long long;
+
+const ll MOD = 1e9 + 7;
+
+int N, M;
+vector<tuple<int, int, int>> edges;
+map<ll, ll> events;
+vector<int> root;
+vector<ll> cost;
+ll X = 0, P = 0;
+
+ll power(ll a, ll b) {
+    if(b == 0) return 1;
+    if(b == 1) return a % MOD;
+    ll h = power(a, b>>1) % MOD;
+    h = (h * h) % MOD;
+    return (b&1) ? h * a % MOD : h;
+}
+
+ll g(ll x) { return x*(x+1)%MOD*power(2,MOD-2)%MOD; }
+ll h(ll x) { return x*(x+1)%MOD*(2*x+1)%MOD*power(6,MOD-2)%MOD; }
+
+int find(int x) { return x == root[x] ? x : root[x] = find(root[x]); }
+
+int main(){
+    cin.tie(0)->sync_with_stdio(0);
+
+    cin>>N>>M;
+    P = power((1000000001LL * N % MOD * (N-1) % MOD * power(2, MOD-2) % MOD), MOD-2);
+    for(int a,b,c;M--;) {
+        cin>>a>>b>>c;
+        edges.emplace_back(c,a,b);
+    }
+
+    root.resize(N+1);
+    cost.resize(N+1);
+    iota(root.begin(), root.end(), 0);
+    fill(cost.begin(), cost.end(), 1);
+    cost[0] = 0;
+    
+    sort(edges.begin(), edges.end());
+    
+    for(auto [c,a,b] : edges) {
+        int x = find(a), y = find(b);
+        if(x == y) continue;
+        events[c] = (events[c] + cost[x]*cost[y]) % MOD;
+        events[0] = (events[0] + (cost[x]*cost[y] % MOD * (1000000001 - c) % MOD)) % MOD;
+        cost[y] += cost[x];
+        root[x] = y;
+        X += c;
+    }
+
+    ll C = 0, ans = 0, D = 0;
+    for(auto it = events.rbegin();it != events.rend();) {
+        // cur - i
+        // C + it->second
+        ll k = it->second;
+        D = (D + k) % MOD;
+        C = (C + D) % MOD;
+        if(it->first == 0) {
+            ans = (ans + (C * X % MOD)) % MOD;
+            break;
+        }
+        ll s = it->first;
+        ll e = (++it)->first;
+        ll cnt = s - e - 1;
+        
+        ll cur = (X - s) % MOD;
+        ll _1 = cur * C % MOD * (cnt + 1) % MOD;
+        ll _2 = cur * D % MOD * g(cnt) % MOD;
+        ll _3 = C * g(cnt) % MOD;
+        ll _4 = D * h(cnt) % MOD;
+        ans = (ans + (_1 + _2 + _3 + _4)) % MOD;
+        // cout<<"1 : "<<_1<<'\t';
+        // cout<<"2 : "<<_2<<'\t';
+        // cout<<"3 : "<<_3<<'\t';
+        // cout<<"4 : "<<_4<<'\n';
+        C = (C + D * cnt) % MOD;
+    }
+    cout<<ans * P % MOD;
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/33988

## 🧭 풀이 시간
180분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
정점 N개 간선 M개인 무향 연결 그래프 G가 주어진다.
집합 S는 1 <= i < j <= N, 0 <= w <= 10^9를 만족하는 모든 간선 쌍 (i,j,w)을 원소로 가진다.
S에서 하나를 뽑아서 G에 추가한 새 그래프 G'의 가중치 합의 기댓값을 구해보자.

## 🔍 풀이 방법
사건 i가 일어날 확률 P[i], 그 떄의 값이 E[i]일 때,
기댓값은 sum(P[i] * E[i])

X = G의 MST 가중치

어떤 정점 쌍 (u,v)에 대해,
d[u][v] = MST에서 u와 v를 잇는 경로 상의 최대 가중치로 정의

모든 정점 쌍 (u,v)에 대해,
S 내에서 둘을 잇는 간선의 개수는 10^9 + 1개
이 중에서 MST를
X-d[u][v]로 만드는 경우 1개
X-d[u][v]+1로 만드는 경우 1개
...
X-1로 만드는 경우 1개
X로 만드는 경우 10^9 + 1 - d[u][v]개

전체 사건의 개수는 N*(N-1)/2개
-> O(N^2)임. 시간 초과
전체 경우의 수 P = N*(N-1)/2 * (10^9 + 1)

하지만 d[u][v]의 총 가짓수는 N-1개임.
MST에 쓰인 간선들 중, 가중치 최소 간선부터 분리 집합으로 합쳐주며 컴포넌트의 개수를 관리
현재 추가한 간선 (u,v,w)에 대해,
f(a) = MST를 X-a로 만드는 경우의 수 라고 하면,
f(1)부터 f(w)까지 c[u] * c[v]만큼이 추가되고, f(0)에는 (10^9 + 1 - w)*c[u]*c[v]만큼 추가됨.

답은 sum(f(a)*(X-a)/P)

근데 이거도 가중치 범위가 10^9라 시간 초과임
어케 더 줄이지?

위에서 각 작업을 튜플 (w, c[u]*c[v])로 배열 E에 관리하자.
w에대한 내림차순으로 정렬하면,
E[i]와 E[i+1] 사이에 대한 구간을 효율적으로 처리할 방법을 생각해보자

경우의 수에 대한 누적 합 C를 관리.
E[i+1].w + 1 <= e <= E[i].w 인 e에 대해,
cnt = E[i].w - E[i+1].w라고 하자.
g(n) = n*(n+1)/2라고 하면, s = g(E[i].w) - g(E[i+1].w)라고 두자.

((X-E[i].w * (C + E[i].c)) + (X-E[i].w-1 * (C + 2E[i].c)) + ... ) / P
이걸 구한 뒤, 마지막에 f(0)만 따로 처리.

## ⏳ 회고
맞는 거 같은데 왜 답이 안나오지?