### PR TITLE
[20251123] BOJ / G5 / 용액 / 강신지

### DIFF
--- a/ksinji/202511/23 BOJ 용액.md
+++ b/ksinji/202511/23 BOJ 용액.md
@@ -1,0 +1,38 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        int[] value = new int[n];
+
+        for (int i=0; i<n; i++){
+            value[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int l = 0, r = n-1;
+        int bestL = 0, bestR = n-1;
+        int bestSum = value[l]+value[r];
+        
+        while(l < r){
+            int sum = value[l] + value[r];
+
+            if (Math.abs(sum) < Math.abs(bestSum)){
+                bestSum = sum;
+                bestL = l;
+                bestR = r;
+            }
+
+            if (sum > 0) r--;
+            if (sum < 0) l++;
+            if (sum == 0) break;
+        }
+
+        System.out.println(value[bestL] + " " + value[bestR]);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2467
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
특성을 정수로 나타내는 용액들이 있다.
두 개의 서로 다른 용액을 혼합하여 특성값이 0에 가장 가까운 용액을 만들어내라
## 🔍 풀이 방법
투포인터로 풀었습니다.
두 용액 문제와 달리 이번 '용액' 문제는 배열이 이미 정렬된 상태로 주어지기 때문에 그냥 바로 l, r 잡고 계산하면 됩니다.
bestSum과 새 sum의 절댓값을 비교하며 best 값을 갱신하고 sum 값을 0과 비교하여 적절히 l, r을 조절합니다.
## ⏳ 회고
두 용액 문제는 여기서 배열 정렬하는 코드만 추가하면 되더군요