### PR TITLE
[20251124] BOJ / G4 / 트리의 기둥과 가지 / 이인희

### DIFF
--- a/LiiNi-coder/202511/24 BOJ 트리의 기둥과 가지.md
+++ b/LiiNi-coder/202511/24 BOJ 트리의 기둥과 가지.md
@@ -1,0 +1,90 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+public class Main{
+	static class Node{
+		int nv;
+		int w;
+		Node(int nv, int w){
+			this.nv = nv; this.w = w;
+		}
+	}
+	private static int N;
+	private static int R;
+	private static List<List<Node>> tree;
+	private static long maxLength = 0L;
+	private static boolean[] visited;
+	public static void main(String[] args) throws IOException {
+		String[] temp;
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		temp = br.readLine().split(" ");
+		N = Integer.parseInt(temp[0] );
+		R = Integer.parseInt(temp[1]);
+
+		visited = new boolean[N+1];
+		tree = new ArrayList<>();
+		for(int i = 0; i<N+1; i++){
+			tree.add(new ArrayList<>());
+		}
+
+		for(int i = 0; i<N-1; i++){
+			temp = br.readLine().split(" ");
+			int v = Integer.parseInt(temp[0]);
+			int nv = Integer.parseInt(temp[1] );
+			int w = Integer.parseInt(temp[2]);
+			tree.get(v).add(new Node(nv, w));
+			tree.get(nv).add(new Node(v, w));
+		}
+		// 기가노드를 찾을때까지 진행
+		int gigaNode = 0;
+		int iterNode = R;
+		int height = 0;
+		while(gigaNode == 0) {
+			visited[iterNode] = true;
+			List<Node> nextNodes = tree.get(iterNode);
+			int size = 0;
+			Node nextNode = null;
+			for(Node node : nextNodes){
+				if(visited[node.nv]){
+					continue;
+				}
+				size++;
+				nextNode = node;
+			}
+			// 기둥 높이 카운트
+			// if 기가노드 발견(자식이 2개이상)
+			if(size > 1 || size == 0){
+				// - 기둥 높이 카운트 중지 & 탈출
+				gigaNode = iterNode;
+				break;
+			}
+			height += nextNode.w;
+			iterNode = nextNode.nv;
+		}
+
+		//System.out.println("height, giganode: "+ height + " " + gigaNode);
+		// 기가노드에서 부터 dfs시작
+		dfs(gigaNode, 0);
+		System.out.println(height + " " + maxLength);
+		br.close();
+	}
+	private static void dfs(int n, int length){
+		visited[n] = true;
+		List<Node> nextNodes = tree.get(n);
+		if(nextNodes.size() == 1){
+			// 리프 노드일때
+			maxLength = Math.max(length, maxLength);
+			return;
+		}
+		for(Node nv : tree.get(n)){
+			if(visited[nv.nv]){
+				continue;
+			}
+			dfs(nv.nv, nv.w + length);
+		}
+		return;
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/20924
## 🧭 풀이 시간
55 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 첫 부분부터 쭈욱 일자로 기다란 그래프가 그려지다, 어느 노드 시점으로 트리가 전개되는 그래프가 있다. 해당 노드를 기가노드라 부를때, 시작 노드부터 기가노드까지의 가중치 합은 트리 기둥이라하고, 기가노드에서 여러 리프노드까지의 가중치 합은 가지 길이라고할때, 트리기둥과 가지길이의 최댓값 출력
## 🔍 풀이 방법
- dfs
## ⏳ 회고
- 해당 문제에서 삽질한게 있다.`a->b 가 주어졌을때, 그래프 자료구조인 List<List<Node>>에 추가할때,  b->a 도 추가하지않아서 틀린 것이다.` 앞으로 무방향인지, 양방향인지 항상 체크하도록하자 