### PR TITLE
[20251124] BOJ / G4 / 서울에서 경산까지/ 이준희

### DIFF
--- a/JHLEE325/202511/24 BOJ G4 서울에서 경산까지.md
+++ b/JHLEE325/202511/24 BOJ G4 서울에서 경산까지.md
@@ -1,0 +1,54 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static final int INF = -987654321;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int T = Integer.parseInt(st.nextToken());
+
+        int[] walk = new int[N];
+        int[] walkMoney = new int[N];
+        int[] bike = new int[N];
+        int[] bikeMoney = new int[N];
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            walk[i] = Integer.parseInt(st.nextToken());
+            walkMoney[i] = Integer.parseInt(st.nextToken());
+            bike[i] = Integer.parseInt(st.nextToken());
+            bikeMoney[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int[][] dp = new int[N + 1][T + 1];
+        for (int[] row : dp) Arrays.fill(row, INF);
+        dp[0][0] = 0;
+
+        for (int i = 0; i < N; i++) {
+            for (int t = 0; t <= T; t++) {
+                if (dp[i][t] == INF) continue;
+
+                if (t + walk[i] <= T) {
+                    dp[i + 1][t + walk[i]] = Math.max(dp[i + 1][t + walk[i]], dp[i][t] + walkMoney[i]);
+                }
+
+                if (t + bike[i] <= T) {
+                    dp[i + 1][t + bike[i]] = Math.max(dp[i + 1][t + bike[i]], dp[i][t] + bikeMoney[i]);
+                }
+            }
+        }
+
+        int res = 0;
+        for (int t = 0; t <= T; t++) {
+            res = Math.max(res, dp[N][t]);
+        }
+
+        System.out.println(res);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14863

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
서울에서 경산까지 가는 길에
거치는 마을마다 도보 이동시간, 모금액, 자전거 이동시간, 모금액이 주어졌을 때
주어진 시간안에 경산에 도착하면서 최대한 많은 모금액을 모으는 경우를 구하는 문제입니다.

## 🔍 풀이 방법
2차원 DP를 이용해서 풀었습니다.
n번째 마을에서 t시간 동안 얻는 모금액을 갱신해가면서 풀었습니다.

## ⏳ 회고
전형적인 dp 문제였습니다.
1차원 dp로도 풀어봐야될 것 같습니다.
