### PR TITLE
[20251125] BOJ / P5 / 플레이리스트 / 이종환

### DIFF
--- a/0224LJH/202511/25 BOJ 플레이리스트.md
+++ b/0224LJH/202511/25 BOJ 플레이리스트.md
@@ -1,0 +1,74 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+	
+	// dp[i][j]: i번째까지 k개의 숫자로 채운 경우
+	// -> dp[i]
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static long[][] dp;
+	static int songCnt, minDis, totalLen;
+	
+	static final long DIVISOR = 1_000_000_007l;
+	
+    public static void main(String[] args) throws IOException {
+
+        init();
+        process();
+    	print();
+
+    }
+    
+    private static void init() throws IOException{
+    	StringTokenizer st = new StringTokenizer(br.readLine());
+    	songCnt = Integer.parseInt(st.nextToken());
+    	minDis = Integer.parseInt(st.nextToken());
+    	totalLen = Integer.parseInt(st.nextToken());
+    	dp = new long[totalLen+1][songCnt+1];
+    	dp[1][1] = songCnt;
+    }
+    
+    private static void process() throws IOException {
+    	for (int i = 2; i <= totalLen; i++) {
+    		if (i <= minDis) {
+    			// 아직 총 길이가 간격보다 적은 경우. 
+    			// 그냥 i개의 노래로 줄세우는 것과 동일하다.
+    			dp[i][i] = (dp[i-1][i-1] * (songCnt-i+1))%DIVISOR;
+    			continue;
+    		}
+    		
+    		//적어도 minDis개 만큼의 부분배열에서는 겹치는게 없다는 것을 고려하자
+    		for (int j = 1; j <= songCnt; j++) {
+    			if (dp[i-1][j] == 0) continue;
+    			
+    			//이전에 있는 것과 동일한 것을 선택하는 경우
+    			//이 경우, curSongCnt - minDis개의 선택지가 존재하게 된다.
+    			dp[i][j] += dp[i-1][j] * (j - minDis);
+    			dp[i][j] %= DIVISOR;
+    			
+    			// 이전과 다른 것을 선택하는 경우
+    			if (j == songCnt) continue;
+    			dp[i][j+1] += dp[i-1][j] * (songCnt - j);
+    			dp[i][j+1] %= DIVISOR;
+    		}
+    	}
+    	
+    }
+    
+
+    
+    
+
+    
+    
+
+	private static void print() {
+		System.out.println(dp[totalLen][songCnt]);
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/12872

## 🧭 풀이 시간
90분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
수빈이는 BOJ 알고리즘 캠프에서 음악을 들으면서 문제를 풀고 있다. 지금 수빈이의 스마트폰에는 N개의 노래가 저장되어 있다. 오늘 수빈이는 P개의 노래를 들으려고 한다. 수빈이는 다음과 같은 조건을 만족하는 플레이리스트를 만들려고 한다. 플레이리스트에는 같은 노래를 여러 번 추가해도 된다.

모든 노래를 플레이리스트에 추가해야 한다.
같은 노래를 추가하려면, 플레이리스트에서 두 노래 사이에 적어도 M개의 곡이 있어야 한다.
수빈이는 플레이리스트를 만들 수 있는 경우의 수가 궁금해졌다. N, M, P가 주어졌을 때, 수빈이가 만들 수 있는 플레이리스트의 경우의 수를 구하는 프로그램을 작성하시오.

## 🔍 풀이 방법
딱 보자마자 dp인 것은 알았지만, 로직을 찾아내는데 한참 걸렸다.

우선 노래마다 차이점이 존재하는 것이 아니고, 결국 모든 노래를 한 번씩은 사용해야하기에, 
dp[i][j]: i번째자리까지 j개의 숫자로 채우는 경우의 수

이렇게 지정하고 접근하였다.
이때 간격만큼의 부분배열에는 겹치는게 없다는 것을 이용하였다.

## ⏳ 회고
