### PR TITLE
[20251125] BOJ / G3 / 색상환 / 이강현

### DIFF
--- a/lkhyun/202511/25 BOJ G3 색상환.md
+++ b/lkhyun/202511/25 BOJ G3 색상환.md
@@ -1,0 +1,34 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main{
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static StringBuilder sb = new StringBuilder();
+    static int N,K;
+    static int[][] dp;
+    static int MOD = 1000000003;
+
+    public static void main(String[] args) throws Exception {
+        N = Integer.parseInt(br.readLine());
+        K = Integer.parseInt(br.readLine());
+        dp = new int[N+1][K+1]; //N개의 색중 K개를 선택하는 경우의 수
+
+        for(int i=0;i<=N;i++){
+            dp[i][1] = i; //색 i를 칠하는 경우의 수 여기서 1개를 색칠하는 경우는 i개임.
+            dp[i][0] = 1;
+        }
+        for(int i = 2;i<=N;i++){
+            for(int j = 2;j<=K;j++){
+                dp[i][j] = (dp[i-1][j] + dp[i-2][j-1]) % MOD;
+            }
+        }
+
+        int ans = (dp[N-1][K] + dp[N-3][K-1]) % MOD;
+        bw.write(ans+"");
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2482
## 🧭 풀이 시간
2일

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N개의 색깔 종류가 원형으로 주어짐.
이중 K개의 색상을 고를것임.
인접한 두 색깔을 고를 수 없음.
경우의 수 출력.
## 🔍 풀이 방법
원형 dp
dp[N][K]를 N개의 색깔중 K개를 고르는 경우의 수라고 정의.
이미 순서가 정해져있고 따라서 고르면 되는 문제이므로 순서는 중요치 않음.
선형 dp라고 생각하고 dp를 업데이트한 후,
마지막 색깔을 칠하는지, 칠하지 않는지로 나누어서 원형 dp 조건을 만족시키자.
## ⏳ 회고
어렵네