### PR TITLE
[20251125] BOJ / G1 / 공평하게 팀 나누기 / 김민진

### DIFF
--- a/zinnnn37/202511/25 BOJ G1 공평하게 팀 나누기.md
+++ b/zinnnn37/202511/25 BOJ G1 공평하게 팀 나누기.md
@@ -1,0 +1,62 @@
+```java
+import java.io.*;
+
+public class BJ_4384_공평하게_팀_나누기 {
+
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+    private static int N, sum;
+    private static int[] weight;
+    private static boolean[][] dp;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+        sum = 0;
+
+        weight = new int[N];
+        for (int i = 0; i < N; i++) {
+            weight[i] = Integer.parseInt(br.readLine());
+            sum += weight[i];
+        }
+
+        dp = new boolean[N / 2 + 1][sum + 1];
+        dp[0][0] = true;
+    }
+
+    private static void sol() throws IOException {
+        // 각 사람에 대해
+        for (int k = 0; k < N; k++) {
+            for (int i = N / 2; i > 0; i--) {
+                for (int j = sum; j >= weight[k]; j--) {
+                    if (dp[i - 1][j - weight[k]]) {
+                        dp[i][j] = true;
+                    }
+                }
+            }
+        }
+
+        int minDiff = Integer.MAX_VALUE;
+        int ans = 0;
+        for (int j = 0; j <= sum; j++) {
+            if (dp[N / 2][j]) {
+                int diff = Math.abs(sum - j - j);
+                if (minDiff > diff) {
+                    minDiff = diff;
+                    ans = j;
+                }
+            }
+        }
+        bw.write(Math.min(ans, sum - ans) + " " + Math.max(ans, sum - ans));
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[공평하게 팀 나누기](https://www.acmicpc.net/problem/4384)

## 🧭 풀이 시간
100분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
사람들을 두 그룹으로 나누는데 그룹 간 사람의 수 차이는 1 이하
그룹 간 몸무게 차가 가장 적을 때 각 그룹의 몸무게 합을 오름차순으로 출력하시오

## 🔍 풀이 방법
```java
dp[i][j] = i명 선택했을 때 몸무게 j를 만들 수 있는지
```
어차피 두 그룹으로 나누어야 하고 그룹 간 사람 수의 차이는 1 이하여야 해서 `N/2`까지만 확인함
같은 맥락에서 굳이굳이 `sum` 전부 확인할 필요 없을 것 같은데..

## ⏳ 회고
dp
어
려
워

뭔가뭔가 어제 비트코인 문제랑 비슷해서 boolean dp겠거니 했는데 더 어려웠음
본인의 인덱스보다 작은 인덱스를 가져와서 갱신하면 역방향이어야 하고
본인의 인덱스보다 큰 인덱스를 가져와서 갱신하면 정방향

```
dp[현재] = f(dp[다른 값])

다른 값 < 현재 → 역방향 필수 (작은 쪽이 먼저 갱신되면 중복)
다른 값 > 현재 → 정방향 필수 (큰 쪽이 나중에 갱신되어야 함)
```