### PR TITLE
[20251125] BOJ / G5 / 숨바꼭질 3 / 강신지

### DIFF
--- a/ksinji/202511/26 BOJ 숨바꼭질 3.md
+++ b/ksinji/202511/26 BOJ 숨바꼭질 3.md
@@ -1,0 +1,52 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+        
+        if (n >= k) {
+            System.out.print(n-k);
+            return;
+        }
+
+        Deque<Integer> dq = new ArrayDeque<>();
+        int[] time = new int[100001];
+        Arrays.fill(time, Integer.MAX_VALUE);
+        time[n] = 0;
+        dq.add(n);
+        
+        while(!dq.isEmpty()){
+            int cur = dq.pollFirst();
+
+            if (cur == k) {
+                System.out.println(time[cur]);
+                return;
+            }
+
+            int next = cur * 2;
+            if (next <= 100000 && time[next] > time[cur]) {
+                time[next] = time[cur];
+                dq.addFirst(next);
+            }
+
+            next = cur - 1;
+            if (next >= 0 && time[next] > time[cur] + 1) {
+                time[next] = time[cur] + 1;
+                dq.addLast(next);
+            }
+
+            next = cur + 1;
+            if (next <= 100000 && time[next] > time[cur] + 1) {
+                time[next] = time[cur] + 1;
+                dq.addLast(next);
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/13549
## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
수빈이가 동생의 위치까지 도달하는 가장 빠른 시각을 구하라.
수빈이의 위치가 x일 때, 아래 방식으로 이동할 수 있다.
1. 0초 소비하고 x*2로 이동
2. 1초 소비하고 x-1 또는 x+1로 이동
## 🔍 풀이 방법
다익스트라로 풀어야 하나 했는데 가중치가 0과 1뿐이면 0-1 BFS를 쓰는 게 훨 빠르다고 알고 있어서 그거 썼다.
deque 써서 0초 걸리는 경우는 addFirst하고 1초 걸리는 경우는 addLast 하면 된다.

## ⏳ 회고
