### PR TITLE
[20251125] BOJ / G3 / 색상환 / 설진영

### DIFF
--- a/Seol-JY/202511/25 BOJ G3 색상환.md
+++ b/Seol-JY/202511/25 BOJ G3 색상환.md
@@ -1,0 +1,53 @@
+```java
+import java.util.*;
+
+public class Main {
+    static final int MOD = 1000000003;
+    
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        int N = sc.nextInt();
+        int K = sc.nextInt();
+        
+        if (K * 2 > N) {
+            System.out.println(0);
+            return;
+        }
+        
+        if (K == 1) {
+            System.out.println(N);
+            return;
+        }
+
+        long case1 = solve(N - 3, K - 1);
+        long case2 = solve(N - 1, K);
+        
+        long answer = (case1 + case2) % MOD;
+        System.out.println(answer);
+    }
+    
+    static long solve(int n, int k) {
+        if (n < 0 || k < 0) return 0;
+        if (k == 0) return 1;
+        if (n < k) return 0;
+        if (k * 2 - 1 > n) return 0;
+        
+        long[][] dp = new long[n + 1][k + 1];
+        
+        dp[0][0] = 1;
+        if (n >= 1) {
+            dp[1][0] = 1;
+            dp[1][1] = 1;
+        }
+        
+        for (int i = 2; i <= n; i++) {
+            dp[i][0] = 1;
+            for (int j = 1; j <= Math.min(i, k); j++) {
+                dp[i][j] = (dp[i - 1][j] + dp[i - 2][j - 1]) % MOD;
+            }
+        }
+        
+        return dp[n][k];
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2482

## 🧭 풀이 시간
1시간

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하


## ✏️ 문제 설명
N개의 색이 원형으로 배열된 색상환에서 인접하지 않은 K개의 색을 선택하는 경우의 수를 구하는 문제

## 🔍 풀이 방법
 dp[i][j] = i개 중 인접하지 않게 j개 선택
dp[i][j] = dp[i-1][j] + dp[i-2][j-1]
i번째 안 선택 + i번째 선택(i-1은 불가)

## ⏳ 회고
원형 배열을 두 케이스로 분리해야함
왤케어렵지