### PR TITLE
[20251126] BOJ / G5 / 내려가기 / 강신지

### DIFF
--- a/ksinji/202511/26 BOJ 내려가기.md
+++ b/ksinji/202511/26 BOJ 내려가기.md
@@ -1,0 +1,54 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        
+        int n = Integer.parseInt(br.readLine());
+        int[][] map = new int[n][3];
+        int[] maxdp = new int[3];
+        int[] mindp = new int[3];
+
+        for (int i=0; i<n; i++){
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j=0; j<3; j++){
+                int num = Integer.parseInt(st.nextToken());
+                if (i==0) {
+                    maxdp[j] = num;
+                    mindp[j] = num;
+                }
+                map[i][j] = num;
+            }
+        }
+
+        for (int i=1; i<n; i++){
+            int max1 = Math.max(maxdp[0], maxdp[1]);
+            int max2 = Math.max(maxdp[1], maxdp[2]);
+            maxdp[0] = max1 + map[i][0];
+            maxdp[2] = max2 + map[i][2];
+
+            int max3 = Math.max(max1, max2);
+            maxdp[1] = max3 + map[i][1];
+
+            int min1 = Math.min(mindp[0], mindp[1]);
+            int min2 = Math.min(mindp[1], mindp[2]);
+            mindp[0] = min1 + map[i][0];
+            mindp[2] = min2 + map[i][2];
+
+            int min3 = Math.min(min1, min2);
+            mindp[1] = min3 + map[i][1];
+        }
+
+        int min = Integer.MAX_VALUE;
+        int max = 0;
+        for (int i=0; i<3; i++){
+            min = Math.min(min, mindp[i]);
+            max = Math.max(max, maxdp[i]);
+        }
+
+        System.out.print(max+" "+min);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2096
## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
N줄에 0 이상 9 이하의 숫자가 세 개씩 적혀 있다.
한 줄에 하나씩 수를 선택하며 그 숫자가 점수에 더해진다.
선택할 때는 사진처럼 바로 아래, 혹은 그 인근의 수만 선택 가능.
<img width="1209" height="174" alt="스크린샷 2025-11-26 152942" src="https://github.com/user-attachments/assets/c6f13c2d-0a4f-40ae-b500-7ec275fa3c29" />
마지막 줄까지 도달했을 때 얻을 수 있는 최대/최소 점수를 구하라.

## 🔍 풀이 방법
dp로 풀었다.
max와 min을 모두 구하기 위해 3 크기의 배열을 두 개 두었음.
초기화 해두고 n-1까지 반복하며 최대/최소 갱신.

## ⏳ 회고
처음에 메모리 초과가 나서 당황했는데,
아무생각 없이 풀다가 2차원 배열 map을 [n][n]으로 잡아뒀었다...