### PR TITLE
[20251126] BOJ / G5 / 행복 유치원 / 이준희

### DIFF
--- a/JHLEE325/202511/26 BOJ G5 행복 유치원.md
+++ b/JHLEE325/202511/26 BOJ G5 행복 유치원.md
@@ -1,0 +1,33 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        int N = Integer.parseInt(st.nextToken());
+        int K = Integer.parseInt(st.nextToken());
+
+        int[] arr = new int[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++)
+            arr[i] = Integer.parseInt(st.nextToken());
+
+        int[] diff = new int[N - 1];
+        for (int i = 0; i < N - 1; i++) {
+            diff[i] = arr[i + 1] - arr[i];
+        }
+
+        Arrays.sort(diff);
+
+        int answer = 0;
+        for (int i = 0; i < N - K; i++) {
+            answer += diff[i];
+        }
+
+        System.out.println(answer);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/13164

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
키 순서대로 주어진 아이들이 있을 때 K개의 조로 나누어 티셔츠를 맞추려고 합니다.
이 때 조를 만들 때 아이들의 순서는 건들지 않습니다.
조의 티셔츠 제작 비용은 조에서 키가 가장 큰 녀석과 가장 작은 녀석의 키 차이일 때
티셔츠 제작 비용이 최소가 되는 경우의 비용을 구하는 문제입니다.

## 🔍 풀이 방법
아이들의 키 차이를 계산하여 이를 배열로 만들었습니다.
이후 이 배열을 정렬해서 키차이가 큰 경우를 빼고 N-K개 만큼 더했습니다.

## ⏳ 회고
그리디? 문제였씁니다.
