### PR TITLE
[20251127] BOJ / G5 / 강의실 / 이준희

### DIFF
--- a/JHLEE325/202511/26 BOJ G5 강의실.md
+++ b/JHLEE325/202511/26 BOJ G5 강의실.md
@@ -1,0 +1,45 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static class study {
+        int s, e;
+        study(int s, int e) {
+            this.s = s;
+            this.e = e;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        int N = Integer.parseInt(br.readLine());
+
+        study[] arr = new study[N];
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            st.nextToken();
+            int s = Integer.parseInt(st.nextToken());
+            int e = Integer.parseInt(st.nextToken());
+            arr[i] = new study(s, e);
+        }
+
+        Arrays.sort(arr, (a, b) -> a.s - b.s);
+
+        PriorityQueue<Integer> pq = new PriorityQueue<>();
+
+        for (study s : arr) {
+            if (!pq.isEmpty() && pq.peek() <= s.s) {
+                pq.poll();
+            }
+
+            pq.offer(s.e);
+        }
+
+        System.out.println(pq.size());
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1374

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
강의의 시작시간, 종료시간이 주어졌을 때
최소한의 강의실 개수로 강의를 모두 마칠 수 있는 강의실의 개수를 구하는 문제입니다.

## 🔍 풀이 방법
강의실 클래스를 만들어서 pq를 이용했습니다.
우선 시작순으로 정렬한 후 다음 강의가 현재 강의가 끝나는 시간보다 빨리 시작하면 강의실이 1개 더 필요한 것으로 쳤습니다.

## ⏳ 회고
기본적인 그리딩비니다
