### PR TITLE
[20251127] BOJ / G5 / 강의실 / 설진영

### DIFF
--- a/Seol-JY/202511/27 BOJ G5 강의실.md
+++ b/Seol-JY/202511/27 BOJ G5 강의실.md
@@ -1,0 +1,32 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        
+        int[][] lectures = new int[n][2];
+        for (int i = 0; i < n; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            st.nextToken();
+            lectures[i][0] = Integer.parseInt(st.nextToken());
+            lectures[i][1] = Integer.parseInt(st.nextToken());
+        }
+        
+        Arrays.sort(lectures, (a, b) -> a[0] - b[0]);
+        
+        PriorityQueue<Integer> pq = new PriorityQueue<>();
+        
+        for (int[] lecture : lectures) {
+            if (!pq.isEmpty() && pq.peek() <= lecture[0]) {
+                pq.poll();
+            }
+            pq.offer(lecture[1]);
+        }
+        
+        System.out.println(pq.size());
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1374

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명

N개의 강의가 주어지고,
각 강의의 시작/종료 시간이 주어진다. 모든 강의를 진행하기 위해 필요한 최소 강의실 개수를 구하는 문제.

## 🔍 풀이 방법
그리디 + 우선순위 큐
강의를 시작 시간 기준 오름차순 정렬, 우선순위 큐에 현재 사용 중인 강의실들의 종료 시간을 저장
최종 크기가 필요한 최소 강의실 수

시작 시간 순으로 처리하면서, 재사용 가능한 강의실 중 가장 빨리 끝나는 것을 그리디하게 선택


## ⏳ 회고
전형적인 회의실 문제