### PR TITLE
[20251128] BOJ / G5 / 선발 명단 / 이준희

### DIFF
--- a/JHLEE325/202511/27 BOJ G5 선발 명단.md
+++ b/JHLEE325/202511/27 BOJ G5 선발 명단.md
@@ -1,0 +1,45 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int[][] player = new int[11][11];
+    static boolean[] visited = new boolean[11];
+    static int res;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int T = Integer.parseInt(br.readLine());
+
+        for (int t = 0; t < T; t++) {
+            for (int i = 0; i < 11; i++) {
+                st = new StringTokenizer(br.readLine());
+                for (int j = 0; j < 11; j++) {
+                    player[i][j] = Integer.parseInt(st.nextToken());
+                }
+            }
+            
+            res = 0;
+            dfs(0, 0);
+            System.out.println(res);
+        }
+    }
+
+    static void dfs(int pos, int temp) {
+        if (pos == 11) {
+            res = Math.max(res, temp);
+            return;
+        }
+
+        for (int i = 0; i < 11; i++) {
+            if (!visited[i] && player[i][pos] > 0) {
+                visited[i] = true;
+                dfs(pos + 1, temp + player[i][pos]);
+                visited[i] = false;
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/3980

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
11명의 선수들의 각 포지션 별 능력치가 주어질 때
선발 명단의 능력치 총합이 가장 높은 경우를 구하는 문제입니다.

## 🔍 풀이 방법
dfs를 이용해서 풀었습니다.
각 포지션 별로 순회하면서 가장 높은 경우를 찾았습니다.

## ⏳ 회고
간단한 문제였습니다.
