### PR TITLE
[20251128] BOJ / P4 / Island Travels / 권혁준

### DIFF
--- a/khj20006/202511/28 BOJ P4 Island Travels.md
+++ b/khj20006/202511/28 BOJ P4 Island Travels.md
@@ -1,0 +1,93 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+
+const int dx[4] = {1,0,-1,0};
+const int dy[4] = {0,1,0,-1};
+const int INF = 1e9 + 7;
+
+int N, W, H;
+char arr[50][50]{};
+int num[50][50]{};
+bool vis[50][50]{};
+int cost[15][15]{};
+int dp[15][1<<15]{};
+vector<vector<pair<int, int>>> islands;
+
+int get(int n, int k) {
+    if(dp[n][k] != INF) return dp[n][k];
+    int &ret = dp[n][k];
+    int p = k ^ (1<<n);
+    for(int i=0;i<N;i++) if((1<<i) & p) ret = min(ret, get(i,p) + cost[i][n]);
+    return ret;
+}
+
+int main(){
+    cin.tie(0)->sync_with_stdio(0);
+
+    cin>>W>>H;
+    for(int i=0;i<W;i++) for(int j=0;j<H;j++) cin>>arr[i][j], num[i][j] = -1;
+
+    for(int i=0;i<W;i++) for(int j=0;j<H;j++) if(arr[i][j] == 'X' && !vis[i][j]) {
+        queue<pair<int, int>> q;
+        q.emplace(i,j);
+        vis[i][j] = 1;
+        vector<pair<int, int>> grounds;
+        while(!q.empty()) {
+            auto [x,y] = q.front(); q.pop();
+            num[x][y] = islands.size();
+            grounds.emplace_back(x,y);
+            for(int k=0;k<4;k++) {
+                int xx = x+dx[k], yy = y+dy[k];
+                if(xx<0 || xx>=W || yy<0 || yy>=H || arr[xx][yy] != 'X' || vis[xx][yy]) continue;
+                vis[xx][yy] = 1;
+                q.emplace(xx,yy);
+            }
+        }
+        islands.push_back(grounds);
+    }
+
+    N = islands.size();
+    if(N == 1) return cout<<0, 0;
+    for(int i=0;i<N;i++) for(int j=0;j<N;j++) cost[i][j] = INF;
+
+    for(int i=0;i<N;i++) {
+        for(int i=0;i<W;i++) for(int j=0;j<H;j++) vis[i][j] = 0;
+
+        queue<tuple<int, int, int>> q;
+        for(auto [x,y] : islands[i]) {
+            q.emplace(x,y,0);
+            vis[x][y] = 1;
+        }
+        while(!q.empty()) {
+            auto [x,y,d] = q.front(); q.pop();
+            for(int k=0;k<4;k++) {
+                int xx = x+dx[k], yy = y+dy[k];
+                if(xx<0 || xx>=W || yy<0 || yy>=H || arr[xx][yy] == '.' || vis[xx][yy]) continue;
+                if(arr[xx][yy] == 'X') {
+                    if(num[xx][yy] == num[x][y]) continue;
+                    int a = num[xx][yy];
+                    cost[a][i] = min(cost[a][i], d);
+                    cost[i][a] = min(cost[i][a], d);
+                }
+                else {
+                    q.emplace(xx,yy,d+1);
+                    vis[xx][yy] = 1;
+                }
+            }
+        }
+    }
+
+    for(int i=0;i<N;i++) for(int j=0;j<N;j++) for(int k=0;k<N;k++) cost[j][k] = min(cost[j][k], cost[j][i] + cost[i][k]);
+
+    for(int i=0;i<N;i++) {
+        for(int j=0;j<(1<<N);j++) dp[i][j] = INF;
+        dp[i][1<<i] = 0;
+    }
+
+    int ans = INF;
+    for(int i=0;i<N;i++) ans = min(ans, get(i,(1<<N)-1));
+    cout<<ans;
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/5852

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
R*C 크기의 2차원 격자가 있고, 칸의 종류는 3가지이다.
'X'인 칸은 **땅**이고, 'S'인 칸은 **얕은 물**, '.'인 칸은 **깊은 물**이다.

**땅**으로 이루어진 최대 연결 요소 각각을 **섬**이라 부른다.
섬에서 섬으로 이동할 때는 **땅**이나 **얕은 물**을 거쳐서만 갈 수 있다.

어떤 섬에서 출발하여 모든 섬을 방문하려고 한다.
이때 지나가야 하는 **얕은 물**의 최소 개수를 구해보자. (같은 칸을 여러 번 방문하면 여러 번 센다.)

## 🔍 풀이 방법
`BFS`로 각 섬에 번호를 달아줬다.
또 다른 `BFS`로 모든 섬들 사이에 얕은 물로만 이동 가능한 최단 거리를 구해줬다.
이후 `플로이드-워셜`로 모든 섬들 사이의 진짜 최단 거리를 구해줬다.
마지막으로 `bit dp`를 돌려서 최소 비용을 구했다.

## ⏳ 회고
ez