### PR TITLE
[20251128] BOJ / G2 / 가장 긴 증가하는 부분 수열 3

### DIFF
--- a/Ukj0ng/202511/28 BOJ G2 가장 긴 증가하는 부분 수열 3.md
+++ b/Ukj0ng/202511/28 BOJ G2 가장 긴 증가하는 부분 수열 3.md
@@ -1,0 +1,34 @@
+```
+import java.io.*;
+import java.util.StringTokenizer;
+import java.util.TreeSet;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static TreeSet<Integer> set;
+    private static int n;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        bw.write(String.valueOf(set.size()));
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        n = Integer.parseInt(br.readLine());
+
+        set = new TreeSet<>();
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            int num = Integer.parseInt(st.nextToken());
+            Integer ceiling = set.ceiling(num);
+            if (ceiling != null) set.remove(ceiling);
+            set.add(num);
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/12738
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
가장 긴 증가하는 부분 수열을 구하시오
## 🔍 풀이 방법
TreeSet에 저장하는데, 여기엔 가능성의 집합을 저장한다. 

set의 첫 번째 원소: 길이 1인 수열의 최소 끝 값
set의 두 번째 원소: 길이 2인 수열의 최소 끝 값
set의 세 번째 원소: 길이 3인 수열의 최소 끝 값
## ⏳ 회고
어떻게 이분 탐색인데 이거