### PR TITLE
[20251128] BOJ / G5 / 선발 명단 / 설진영

### DIFF
--- a/Seol-JY/202511/27 BOJ G5 선발 명단.md‎
+++ b/Seol-JY/202511/27 BOJ G5 선발 명단.md‎
@@ -1,0 +1,50 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static int N = 11;
+    static int[][] abilities;
+    static boolean[] visited;
+    static int maxAbility;
+
+    static void dfs(int position, int currentAbility) {
+        if (position == N) {
+            maxAbility = Math.max(maxAbility, currentAbility);
+            return;
+        }
+
+        for (int i = 0; i < N; i++) {
+            if (!visited[i] && abilities[i][position] > 0) {
+                visited[i] = true;
+                dfs(position + 1, currentAbility + abilities[i][position]);
+                visited[i] = false;
+            }
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        int T = Integer.parseInt(br.readLine());
+
+        for (int t = 0; t < T; t++) {
+            abilities = new int[N][N];
+            visited = new boolean[N];
+            maxAbility = 0;
+
+            for (int i = 0; i < N; i++) {
+                st = new StringTokenizer(br.readLine());
+                for (int j = 0; j < N; j++) {
+                    abilities[i][j] = Integer.parseInt(st.nextToken());
+                }
+            }
+
+            dfs(0, 0);
+            System.out.println(maxAbility);
+        }
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/3980
## 🧭 풀이 시간
15분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
맨체스터 유나이티드의 감독은 11명의 선수를 11개의 포지션에 배치하려고 한다.
각 선수의 포지션별 능력치를 제공하며, 이를 기반으로 11개의 포지션에 적합한 선수를 배치해 능력치의 합을 최대화해야 한다.

## 🔍 풀이 방법
백트래킹 사용
각 포지션에 대해 적합한 선수를 배치하고, 능력치의 합이 최대가 되도록 탐색

## ⏳ 회고
쉽네요