### PR TITLE
[20251128] BOJ / G4 / 전력난 / 이인희

### DIFF
--- a/LiiNi-coder/202511/28 BOJ 전력난.md
+++ b/LiiNi-coder/202511/28 BOJ 전력난.md
@@ -1,0 +1,81 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main{
+	private static int M;
+	private static int N;
+	private static List<int[]> Edges;
+	private static int sumEdge;
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		String[] temp;
+		while(true){
+			temp = br.readLine().split(" ");
+			M = Integer.parseInt(temp[0]);
+			N = Integer.parseInt(temp[1] );
+			if(M == 0 && N == 0){
+				break;
+			}
+			Edges = new ArrayList<>();
+			sumEdge = 0;
+			int n = N;
+			while(n-->0){
+				temp = br.readLine().split(" ");
+				sumEdge += Integer.parseInt(temp[2]);
+				Edges.add(new int[]{
+					Integer.parseInt(temp[0]),
+					Integer.parseInt(temp[1]),
+					Integer.parseInt(temp[2])
+				});
+			}
+			solve();
+			System.out.println(sumEdge);
+		}
+	}
+
+	private static void solve() {
+		List<List<int[]>> graph = new ArrayList<>();
+		for(int i = 0; i < M; i++)
+			graph.add(new ArrayList<>());
+		for(int[] edge : Edges){
+			graph.get(edge[0]).add(new int[]{edge[1], edge[2]});
+			graph.get(edge[1]).add(new int[]{edge[0], edge[2]});
+		}
+		//프림
+		Queue<int[]> q = new PriorityQueue<>((o1, o2) -> o1[1] - o2[1]);
+		boolean[] visited = new boolean[M];
+		int visitedCount = 1;
+		visited[0] = true;
+		for(int[] next : graph.get(0)){
+			int nv = next[0];
+			int w = next[1];
+			q.offer(new int[]{nv, w});
+		}
+		while(visitedCount < M){
+			// -- 최소힙에서 팝
+			int[] temp = q.poll();
+			int nv = temp[0];
+			int w = temp[1];
+			// -- 만약 다음 정점번호가 방문이면 컨티뉴
+			if(visited[nv])
+				continue;
+			// 방문여부 표시
+			visited[nv] =true;
+			visitedCount++;
+			// -- 스패닝 트리 간선 처리
+			sumEdge -= w;
+			for(int[] next : graph.get(nv)){
+				int nnv = next[0];
+				if(visited[nnv])
+					continue;
+				int nw = next[1];
+				q.offer(new int[]{nnv, nw});
+			}
+			// -- 최소힙에 푸시
+		}
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/6497
## 🧭 풀이 시간
60 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 어떤 싱글컴포넌트 그래프가 주어지고, 그래프의 간선 가중치의 합에서 그것의 최소 스패닝 그래프의 간선 가중치의 합을 뺀값을 출력
## 🔍 풀이 방법
- 프림
## ⏳ 회고
- 최소 스패닝 트리는 2가지가 있다. 프림, 크루스칼.
- 2가지는 각각 간선 기준, 정점 기준이 있는데, `크루스칼 => ㅋ -> ㄱ => 간선기준` 으로 외우자.
- 프림은 정점 기준으로 점점 스패닝트리의 정점을 추가하면서 그것에 연결되어있는 모든 간선들을 추가해나가며 이중에서 가장 가중치가 작은 것을 poll하면서 진행하는 것(우선순위 큐 사용)
- 크루스칼은 간선 중심이니, 그냥 간선을 애초에 그리디하게 작은것부터 고르다가, 사이클이 발생하는 지 여부는 disjoint set으로 알아냄