### PR TITLE
[20251129] BOJ / G5 / 난로 / 이종환

### DIFF
--- a/0224LJH/202511/29 BOJ 난로.md
+++ b/0224LJH/202511/29 BOJ 난로.md
@@ -1,0 +1,56 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+	
+	static int len, blockCnt;
+	static long total;
+	static long[] arr,diff;
+			
+	public static void main (String[] args) throws NumberFormatException, IOException {
+		init();
+		process();
+		print();
+
+
+
+	}
+	
+	public static void init() throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		len = Integer.parseInt(st.nextToken());
+		blockCnt = Integer.parseInt(st.nextToken());
+		arr = new long[len];
+		total = 1;
+		for (int i = 0; i < len; i++) {
+			arr[i] = Long.parseLong(br.readLine());
+		}
+
+	}
+	
+	public static void process() {
+		PriorityQueue<Long> q = new PriorityQueue<>(Collections.reverseOrder());
+		for (int i = 0; i < len-1; i++) {
+			q.add(arr[i+1]-arr[i]);
+		}
+		
+		for (int i = 0; i < len-1; i++) {
+			long cost = q.poll();
+			if (i < blockCnt -1) cost =1;
+			total += cost;
+		}
+
+	}
+	
+
+	
+	public static void print() {
+		System.out.println(total);
+	}
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/15553

## 🧭 풀이 시간
15분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
구사과의 방에는 난로가 하나 있다. 구사과는 절약 정신이 투철하기 때문에, 방에 혼자 있을 때는 난로를 되도록 켜지 않는다. 구사과는 방에 친구가 왔을 때는 항상 난로를 켠다.

오늘은 N명의 친구들이 구사과의 집에 방문하는 날이다. 구사과는 친구들을 쉽게 구분하기 위해 1부터 N까지 번호를 매겼다. i번째 친구는 구사과의 방에 시간 Ti에 도착하고, 시간 Ti+1에 나간다. 구사과의 방은 좁기 때문에, 한 번에 한 명만 방문할 수 있다. 즉, 방안에는 항상 구사과를 포함해 2명 이하의 사람만 있게 된다.

구사과는 난로를 아무 때나 켤 수 있고, 끌 수 있다. 난로를 켜려면 성냥을 이용해야 한다. 오늘 구사과는 총 K개의 성냥을 가지고 있다. 따라서, 최대 K번 난로를 켤 수 있다. 가장 처음에 난로는 꺼져있다.

구사과는 난로가 켜져 있는 시간을 최소로 하려고 한다. 구사과의 친구들이 도착하는 시간과 가지고 있는 성냥의 개수가 주어졌을 때, 난로가 켜져 있는 시간의 최솟값을 구하는 프로그램을 작성하시오.

## 🔍 풀이 방법
다음사람이 올때까지의 간격중 제일 큰 K-1개의 간격을 없애면된다. 

## ⏳ 회고
