### PR TITLE
[20251129] BOJ / G5 / 동전 2 / 강신지

### DIFF
--- a/ksinji/202511/29 BOJ 동전 2.md
+++ b/ksinji/202511/29 BOJ 동전 2.md
@@ -1,0 +1,38 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+
+        int[] coins = new int[n];
+        for (int i = 0; i < n; i++) {
+            coins[i] = Integer.parseInt(br.readLine());
+        }
+
+        int[] dp = new int[k + 1];
+        Arrays.fill(dp, 10001);
+        dp[0] = 0;
+
+        for (int i = 0; i < n; i++) {
+            int coin = coins[i];
+            for (int j = coin; j <= k; j++) {
+                if (dp[j - coin] != 10001) {
+                    dp[j] = Math.min(dp[j], dp[j - coin] + 1);
+                }
+            }
+        }
+
+        if (dp[k] == 10001) {
+            System.out.println(-1);
+        } else {
+            System.out.println(dp[k]);
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2294
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
n개의 동전으로 k원을 정확히 만들 때, 사용할 동전 개수의 최소값을 구하는 문제

## 🔍 풀이 방법
dpdp

## ⏳ 회고
