### PR TITLE
[20251129] BOJ / G4 / 로또 / 이인희

### DIFF
--- a/LiiNi-coder/202511/29 BOJ 로또.md
+++ b/LiiNi-coder/202511/29 BOJ 로또.md
@@ -1,0 +1,39 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int T = Integer.parseInt(st.nextToken());
+        while(T-- > 0){
+            st = new StringTokenizer(br.readLine());
+            int n = Integer.parseInt(st.nextToken());
+            int m = Integer.parseInt(st.nextToken());
+            long[][] dp = new long[n + 1][m + 1];
+            for(int j = 1; j <= m; j++){
+                dp[1][j] = 1;
+            }
+
+            for(int k = 2; k <= n; k++){
+                for(int j = 1; j <= m; j++){
+                    long sum = 0;
+                    for(int prev = 1; prev * 2 <= j; prev++){
+                        sum += dp[k-1][prev];
+                    }
+                    dp[k][j] = sum;
+                }
+            }
+            long answer = 0;
+            
+            
+            for(int j = 1; j <= m; j++){
+                answer += dp[n][j];
+            }
+            System.out.println(answer);
+        }
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2758
## 🧭 풀이 시간
55 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 1부터 M까지의 수열에서 N개를 뽑는데, 뽑을수록 이전것의 곱하기2보다 크거나 같도록 N개를 뽑은 경우의 수 출력
## 🔍 풀이 방법
- dp
## ⏳ 회고
- n, m이 의외로 적다는 것을 보고 dp임을 떠올릴수있어야함