### PR TITLE
[20251129] BOJ / G5 / 동전 2 / 설진영

### DIFF
--- a/Seol-JY/202511/29 BOJ G5 동전 2.md‎
+++ b/Seol-JY/202511/29 BOJ G5 동전 2.md‎
@@ -1,0 +1,33 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        int n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+        
+        int[] coins = new int[n];
+        for (int i = 0; i < n; i++) {
+            coins[i] = Integer.parseInt(br.readLine().trim());
+        }
+        
+        int[] dp = new int[k + 1];
+        Arrays.fill(dp, Integer.MAX_VALUE);
+        dp[0] = 0;
+        
+        for (int i = 1; i <= k; i++) {
+            for (int coin : coins) {
+                if (coin <= i && dp[i - coin] != Integer.MAX_VALUE) {
+                    dp[i] = Math.min(dp[i], dp[i - coin] + 1);
+                }
+            }
+        }
+        
+        System.out.println(dp[k] == Integer.MAX_VALUE ? -1 : dp[k]);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2294

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
n가지 동전으로 가치 합이 k원이 되도록 할 때, 사용하는 동전 개수의 최솟값을 구하는 문제
각 동전은 무제한 사용 가능


## 🔍 풀이 방법
DP로 품
dp[i] = 가치 i를 만드는 데 필요한 최소 동전 개수
dp[i] = min(dp[i], dp[i - coin] + 1)
dp[0] = 0

## ⏳ 회고
dp 기본문제