### PR TITLE
[20251201] BOJ / G4 / 타일 채우기 / 이인희

### DIFF
--- a/LiiNi-coder/202512/01 BOJ 타일 채우기.md
+++ b/LiiNi-coder/202512/01 BOJ 타일 채우기.md
@@ -1,0 +1,32 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        if(N % 2 == 1) {
+            System.out.println(0);
+            return;
+        }
+
+        
+        int[] dp = new int[N + 1];
+        dp[0] = 1;
+        dp[2] = 3;
+
+        for(int i = 4; i <= N; i += 2){
+            //dp[i-2]에 3개 패턴적용
+            dp[i] = dp[i - 2] * 3;
+            //짝수 이전 칸에 2개 패턴적용
+            for(int j = i - 4; j >= 0; j -= 2){
+                dp[i] += dp[j] * 2;
+            }
+        }
+
+        System.out.println(dp[N]);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2133
## 🧭 풀이 시간
45 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 2x1타일로 3xN을 채우는 경우의수
## 🔍 풀이 방법
- dp
## ⏳ 회고
- 이번 dp는 점화식 고려가 꽤어려워서 인터넷 참고..