### PR TITLE
[20251201] BOJ / G4 / 타일 채우기 / 설진영

### DIFF
--- a/Seol-JY/202512/01 BOJ 타일 채우기.md‎
+++ b/Seol-JY/202512/01 BOJ 타일 채우기.md‎
@@ -1,0 +1,27 @@
+```java
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine().trim());
+        
+        if (n % 2 == 1) {
+            System.out.println(0);
+            return;
+        }
+        
+        int[] dp = new int[31];
+        dp[0] = 1;
+        dp[2] = 3;
+        
+        for (int i = 4; i <= n; i += 2) {
+            dp[i] = 4 * dp[i - 2] - dp[i - 4];
+        }
+        
+        System.out.println(dp[n]);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2133

## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
3×N 크기의 벽을 2×1, 1×2 크기의 타일로 채우는 경우의 수를 구하는 문제.

## 🔍 풀이 방법
1. N이 홀수면 답은 0
2. N=2일 때 기본 패턴 3가지
3. N=4, 6, 8, ... 에서 각각 2개씩 새로운 특수 패턴 등장

dp[n] = 4 * dp[n-2] - dp[n-4]

## ⏳ 회고
타일링 문제