### PR TITLE
[20251203] BOJ / G5 / 합분해 / 이종환

### DIFF
--- a/0224LJH/202512/03 BOJ 합분해.md
+++ b/0224LJH/202512/03 BOJ 합분해.md
@@ -1,0 +1,53 @@
+```java
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Main {
+	
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static int target, cnt;
+	static long[][] dp;
+	
+    public static void main(String[] args) throws IOException {
+    	init();
+    	process();
+    	print();
+
+    }
+    
+    private static void init() throws IOException{
+    	StringTokenizer st = new StringTokenizer(br.readLine());
+    	target = Integer.parseInt(st.nextToken());
+    	cnt = Integer.parseInt(st.nextToken());
+    	dp = new long[target+1][cnt+1];
+    }
+    
+    private static void process() throws IOException {
+    	dp[0][0] = 1;
+    	for (int i = 0; i <= target; i++) {
+    		for (int j = 0; j <= target; j++) {
+    			if (i+j > target) break;
+    			for (int k = 1; k <= cnt; k++) {
+    				dp[i+j][k] += dp[i][k-1];
+    				dp[i+j][k] %= 1000_000_000;
+    			}
+    		}
+    	}
+    	
+    	
+    }
+
+    
+	private static void print() {
+		System.out.println(dp[target][cnt]);
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2225
## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
0부터 N까지의 정수 K개를 더해서 그 합이 N이 되는 경우의 수를 구하는 프로그램을 작성하시오.

덧셈의 순서가 바뀐 경우는 다른 경우로 센다(1+2와 2+1은 서로 다른 경우). 또한 한 개의 수를 여러 번 쓸 수도 있다.


## 🔍 풀이 방법
전형적인 dp문제이다. O(N*N*K)로 해결할 수 있다.


## ⏳ 회고
