### PR TITLE
[20251203] BOJ / G5 / 합분해 / 설진영

### DIFF
--- a/Seol-JY/202512/03 BOJ G5 합분해.md‎
+++ b/Seol-JY/202512/03 BOJ G5 합분해.md‎
@@ -1,0 +1,32 @@
+```java
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static final int MOD = 1_000_000_000;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        int N = Integer.parseInt(st.nextToken());
+        int K = Integer.parseInt(st.nextToken());
+        
+        int[][] dp = new int[K + 1][N + 1];
+        
+        for (int n = 0; n <= N; n++) {
+            dp[1][n] = 1;
+        }
+        
+        for (int k = 2; k <= K; k++) {
+            dp[k][0] = 1;
+            for (int n = 1; n <= N; n++) {
+                dp[k][n] = (dp[k][n - 1] + dp[k - 1][n]) % MOD;
+            }
+        }
+        
+        System.out.println(dp[K][N]);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2225

## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [x] 중             
- [ ] 하

## ✏️ 문제 설명
0부터 N까지의 정수 K개를 더해서 합이 N이 되는 경우의 수를 구하는 문제

## 🔍 풀이 방법
dp[k][n] = k개의 수로 합 n을 만드는 경우의 수

점화식: dp[k][n] = dp[k][n-1] + dp[k-1][n]
  - `dp[k][n-1]`: 마지막 수에 1을 더한 경우
  - `dp[k-1][n]`: 마지막 수로 0을 선택한 경우
누적합 성질 이용

## ⏳ 회고
dp 꿀잼 