### PR TITLE
[20251204] BOJ / P3 / Mowing the Lawn / 권혁준

### DIFF
--- a/khj20006/202512/04 BOJ P3 Mowing the Lawn.md
+++ b/khj20006/202512/04 BOJ P3 Mowing the Lawn.md
@@ -1,0 +1,37 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+using ll = long long;
+
+int N, K;
+ll dp[100001]{}, s[100001]{};
+deque<pair<ll, int>> d;
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin >> N >> K;
+	for (int i = 1, a; i <= N; i++) {
+		cin >> a;
+		s[i] = s[i - 1] + a;
+	}
+
+	ll ans = 0;
+	d.emplace_back(s[N], -1);
+	d.emplace_back(s[N] - s[1], 0);
+	for (int i = 1; i <= N; i++) {
+		while (!d.empty() && i - d.front().second > K + 1) d.pop_front();
+		int idx = d.front().second;
+		dp[i] = (idx >= 0 ? dp[idx] : 0) + s[i] - s[idx + 1];
+
+		ans = max(ans, dp[i]);
+		if (i < N) {
+			ll val = dp[i] + s[N] - s[i + 1];
+			while (!d.empty() && d.back().first <= val) d.pop_back();
+			d.emplace_back(val, i);
+		}
+	}
+	cout << ans;
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/5977

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
길이 N인 수열 A에서 연속한 K+1개 이상의 원소를 고르지 않고 만들 수 있는 부분 수열 합의 최댓값을 구해보자.

## 🔍 풀이 방법
dp[i] = i번째 원소까지 고른 경우의 최댓값이라 정의하고,
s[i] = a[1] + ... + a[i]라고 정의하면,
dp[i] = max(dp[i-j-1] + s[i] - s[i-j]) (j <= K) 이다.

그대로 구현하면 O(NK)로 시간 초과가 날 거라서 `monotone deque`을 이용해 max가 되는 지점의 인덱스를 뽑아주었다.
deque에 넣을 때는 dp[i] + s[N] - s[i+1]을 넣어 deque 내에서의 일관성이 깨지지 않도록 했다.

## ⏳ 회고
ez