### PR TITLE
[20251204] BOJ / G4 / 수들의 합 4 / 강신지

### DIFF
--- a/ksinji/202512/04 BOJ 수들의 합 4.md
+++ b/ksinji/202512/04 BOJ 수들의 합 4.md
@@ -1,0 +1,36 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+
+        st = new StringTokenizer(br.readLine());
+
+        long sum = 0L;
+        long answer = 0L;
+
+        Map<Long, Long> count = new HashMap<>();
+        count.put(0L, 1L);
+
+        for (int i = 0; i < n; i++) {
+            int x = Integer.parseInt(st.nextToken());
+            sum += x;
+
+            long target = sum - k;
+            if (count.containsKey(target)) {
+                answer += count.get(target);
+            }
+
+            count.put(sum, count.getOrDefault(sum, 0L) + 1);
+        }
+
+        System.out.println(answer);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2015
## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
수열에서 연속된 부분 구간을 골랐을 때, 그 구간의 합이 정확히 K가 되는 경우의 수를 계산하는 문제
## 🔍 풀이 방법
누적합을 계산하며 현재 누적합 sum 에 대해 sum - K 가 이전에 몇 번 등장했는지 해시맵에서 찾아 그 횟수를 정답에 더하기
## ⏳ 회고
누적합에 해시맵 생각하기 어려웠다