### PR TITLE
[20251205] BOJ / P5 / 가장 긴 팰린드롬 부분 문자열 / 권혁준

### DIFF
--- a/khj20006/202512/05 BOJ P5 가장 긴 팰린드롬 부분 문자열.md
+++ b/khj20006/202512/05 BOJ P5 가장 긴 팰린드롬 부분 문자열.md
@@ -1,0 +1,24 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+
+string t, s = "#";
+int A[222222]{}, C = 1, R = 1;
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin >> t;
+	for (char i : t) s += i, s += "#";
+	
+	int ans = 0;
+	for (int i = 1; i < s.size(); i++) {
+		A[i] = min(A[2 * C - i], R - i);
+		while (i > A[i] && i + A[i] + 1 < s.size() && s[i - A[i] - 1] == s[i + A[i] + 1]) A[i]++;
+		if (i + A[i] >= R) C = i, R = i + A[i];
+		ans = max(ans, A[i]);
+	}
+	cout << ans;
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/13275

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
주어지는 문자열의 연속된 부분 문자열 중에서 팰린드롬인 것 중 가장 긴 것의 길이를 구해보자.

## 🔍 풀이 방법
`manacher's algorithm`에 대해 공부했다.

A[i] = i번째 문자를 중심으로 하는 최대 팰린드롬의 반지름으로 정의한다.
현재까지 찾은 가장 긴 팰린드롬의 중심을 c, 반지름을 r이라고 가정한다.
문자열의 앞에서부터 보면서, 현재 인덱스 i에 대해 A[i] >= min(A[2c-i], r-i)이 성립한다.
따라서 일단 A[i] = min(A[2c-i], r-i)로 잡아놓고, 반복문으로 직접 양 옆으로 확장시켜 A[i]를 구한다.

모든 인덱스에 대한 A[i]값을 통해 정답을 구했다.

## ⏳ 회고
알고리즘의 동작 원리 자체는 금방 이해했다.
근데 이게 왜 O(N^2)이 아니라 O(N)인지 이해하는 게 어려웠다.
현재까지 찾은 팰린드롬의 오른쪽 끝 점은 c+r이고, 이 값보다 작은 지점에 대한 비교 연산을 수행하지 않기 때문에 O(N)이 되는 거였다.