### PR TITLE
[20251205] BOJ / G2 / Escape Room / 김민진

### DIFF
--- a/zinnnn37/202512/5 BOJ G2 Escape Room.md
+++ b/zinnnn37/202512/5 BOJ G2 Escape Room.md
@@ -1,0 +1,88 @@
+```java
+import java.awt.*;
+import java.io.*;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class BJ_19606_Escape_Room {
+
+    private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static       StringTokenizer st;
+
+    private static int M, N;
+    private static int[][]      matrix;
+    private static boolean[]    checked;
+    private static boolean[][]  visited;
+    private static Queue<Point> q;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        M = Integer.parseInt(br.readLine());
+        N = Integer.parseInt(br.readLine());
+
+        checked = new boolean[1_000_001];
+        matrix = new int[M + 1][N + 1];
+        for (int i = 1; i <= M; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 1; j <= N; j++) {
+                matrix[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+        visited = new boolean[M + 1][N + 1];
+        q = new ArrayDeque<>();
+    }
+
+    private static void sol() throws IOException {
+        bfs();
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void bfs() throws IOException {
+        q.offer(new Point(1, 1));
+        visited[1][1] = true;
+
+        while (!q.isEmpty()) {
+            Point cur = q.poll();
+
+            if (cur.x == M && cur.y == N) {
+                bw.write("yes");
+                return;
+            }
+
+            int target = matrix[cur.x][cur.y];
+            if (checked[target]) continue;
+            checked[target] = true;
+
+            for (int i = 1; i * i <= target; i++) {
+                if (target % i != 0) continue;
+
+                int nx = i;
+                int ny = target / i;
+
+                if (!OOB(nx, ny) && !visited[nx][ny]) {
+                    q.offer(new Point(nx, ny));
+                    visited[nx][ny] = true;
+                }
+                if (!OOB(ny, nx) && !visited[ny][nx]) {
+                    q.offer(new Point(ny, nx));
+                    visited[ny][nx] = true;
+                }
+            }
+        }
+        bw.write("no");
+    }
+
+    private static boolean OOB(int x, int y) {
+        return x < 1 || x > M || y < 1 || y > N;
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[Escape Room](https://www.acmicpc.net/problem/19606)

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
`행 * 열 = 현재 위치한 셀의 수`인 셀로 이동 가능할 때 `(1, 1)`에서 `(M, N)`으로 이동 가능한가?

## 🔍 풀이 방법
약수 구해서 bfs 돌리면 됨
시간 고려해서 `i * i` 까지만 확인해주고 그 반대의 경우도 확인 필요

## ⏳ 회고
셀에 중복된 값이 들어갈 수 있어서 해당 숫자를 확인했는지 저장하는 boolean 배열 선언함
세 배 빨라짐 굿