### PR TITLE
[20251205] BOJ / G5 / 연속합 2 / 이준희

### DIFF
--- a/JHLEE325/202512/05 BOJ G5 연속합 2.md
+++ b/JHLEE325/202512/05 BOJ G5 연속합 2.md
@@ -1,0 +1,39 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        int[] arr = new int[N];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int[] left = new int[N];
+        int[] right = new int[N];
+
+        left[0] = arr[0];
+        int answer = arr[0];
+
+        for (int i = 1; i < N; i++) {
+            left[i] = Math.max(left[i - 1] + arr[i], arr[i]);
+            answer = Math.max(answer, left[i]);
+        }
+
+        right[N - 1] = arr[N - 1];
+        for (int i = N - 2; i >= 0; i--) {
+            right[i] = Math.max(right[i + 1] + arr[i], arr[i]);
+        }
+
+        for (int i = 1; i < N - 1; i++) {
+            answer = Math.max(answer, left[i - 1] + right[i + 1]);
+        }
+
+        System.out.println(answer);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/13398

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
n개의 정수로 된 수열이 주어졌을 때 이 중 연속된 몇개의 수를 이용하여 연속합을 구하려고 합니다.
하나의 숫자를 제거하거나 안할 수 있을 때
구할 수 있는 연속합 중 최대값을 구하는 문제입니다.

## 🔍 풀이 방법
DP를 이용해서 연속합 배열을 만들었습니다.
계속 이전 연속합과, 현재값 중 최대값을 갱신하면서 유지했습니다.
한 숫자를 제거했을 때를 계산하기 위해 왼쪽부터 구한 연속합, 오른쪽 부터 구한 연속합 2개를 구해서
i에서 하나 뺀 경우 i-1 i+1 까지 두개를 더해서 구하는 식으로 숫자 뺐을 때를 찾았습니다.

## ⏳ 회고
숫자 하나를 빼고 연속합을 구하는 부분이 특이했던 문제였습니다.
