### PR TITLE
[20251205] BOJ / G5 / 개업 / 이인희

### DIFF
--- a/LiiNi-coder/202512/05 BOJ 개업.md
+++ b/LiiNi-coder/202512/05 BOJ 개업.md
@@ -1,0 +1,47 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main{
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        st = new StringTokenizer(br.readLine());
+        int[] wok = new int[M];
+        for(int i = 0; i < M; i++){
+            wok[i] = Integer.parseInt(st.nextToken());
+        }
+
+        ArrayList<Integer> cook = new ArrayList<>();
+        for(int i = 0; i < M; i++){
+            cook.add(wok[i]);
+        }
+        for(int i = 0; i < M; i++){
+            for(int j = i + 1; j < M; j++){
+                cook.add(wok[i] + wok[j]);
+            }
+        }
+
+        int INF = 100_000_000;
+        int[] dp = new int[N + 1];
+        Arrays.fill(dp, INF);
+        dp[0] = 0;
+        for(int x = 0; x <= N; x++){
+            if(dp[x] == INF)
+                continue;
+            for(int c : cook){
+                int nx = x + c;
+                if(nx <= N){
+                    dp[nx] = Math.min(dp[nx], dp[x] + 1);
+                }
+            }
+        }
+        int answer = dp[N];
+        System.out.println((answer >= INF)? -1 : answer);
+        
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/submit/13910/100831201
## 🧭 풀이 시간
50 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- N이 주어지고, M개의 자연수 수열이 주어질때, N에서 자연수 수열의 원소만큼 적절히 빼서, 0을 만드는데 가장 적게 원소를 빼는 경우
## 🔍 풀이 방법
- dp
## ⏳ 회고
- 다소 어려운 dp였음