### PR TITLE
[20251205] BOJ / G4 / 줄세우기 / 강신지

### DIFF
--- a/ksinji/202512/05 BOJ 줄세우기.md
+++ b/ksinji/202512/05 BOJ 줄세우기.md
@@ -1,0 +1,30 @@
+```java
+import java.io.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        int[] arr = new int[n];
+        int[] dp = new int[n];
+
+        for (int i=0; i<n; i++){
+            arr[i] = Integer.parseInt(br.readLine());
+        }
+
+        int lis = 0;
+        for (int i=0; i<n; i++){
+            dp[i] = 1;
+            for (int j=0; j<i; j++){
+                if (arr[j] < arr[i] && dp[j]+1>dp[i]){
+                    dp[i] = dp[j]+1;
+                    lis = Math.max(lis, dp[i]);
+                }
+            }
+        }
+
+        System.out.println(n-lis);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2631
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
3 7 5 2 6 1 4
위와 같은 식으로 나열된 숫자를 오름차순으로 다시 나열하려고 함
최소한 몇 개의 수를 움직여야 하는지?
## 🔍 풀이 방법
최장 증가 부분 수열을 구해서 전체 숫자의 수에서 빼면 됨
## ⏳ 회고
쉬운 문제인데 LIS 쓰면 된다는 생각을 못했다...