### PR TITLE
[20251205] BOJ / G5 / 연속합 2 / 설진영

### DIFF
--- a/Seol-JY/202512/05 BOJ G5 연속합 2.md
+++ b/Seol-JY/202512/05 BOJ G5 연속합 2.md
@@ -1,0 +1,32 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        int[] arr = new int[n];
+        
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+        
+        int dp0 = arr[0];
+        int dp1 = Integer.MIN_VALUE / 2;
+        
+        int answer = dp0;
+        
+        for (int i = 1; i < n; i++) {
+            dp1 = Math.max(dp1 + arr[i], dp0);
+            dp0 = Math.max(dp0 + arr[i], arr[i]);
+            
+            answer = Math.max(answer, Math.max(dp0, dp1));
+        }
+        
+        System.out.println(answer);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/13398

## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
N개의 정수로 된 수열이 있을 때, 구할 수 있는 연속합 중 최대 구하기

## 🔍 풀이 방법
dp[0] = max (dp[0] + arr[i])
dp[1] = max (dp[1] + arr[i], dp[0])

## ⏳ 회고
EZ