### PR TITLE
[20251206] BOJ / G5 / 암호코드 / 이준희

### DIFF
--- a/JHLEE325/202512/06 BOJ G5 암호코드.md
+++ b/JHLEE325/202512/06 BOJ G5 암호코드.md
@@ -1,0 +1,38 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String s = br.readLine();
+
+        int n = s.length();
+        int[] dp = new int[n + 1];
+        int MOD = 1000000;
+
+        if (s.charAt(0) == '0') {
+            System.out.println(0);
+            return;
+        }
+
+        dp[0] = 1;
+        dp[1] = 1;
+
+        for (int i = 2; i <= n; i++) {
+            int one = s.charAt(i - 1) - '0';
+            int two = (s.charAt(i - 2) - '0') * 10 + (s.charAt(i - 1) - '0');
+
+            if (one >= 1 && one <= 9) {
+                dp[i] = (dp[i] + dp[i - 1]) % MOD;
+            }
+
+            if (two >= 10 && two <= 26) {
+                dp[i] = (dp[i] + dp[i - 2]) % MOD;
+            }
+        }
+
+        System.out.println(dp[n]);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2011

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
단어를 숫자로 표현한 암호가 있고
각 알파벳이 1~26으로 표현됩니다.
이 때 숫자암호가 주어졌을 때 이를 단어로 바꿨을 때 만들 수 있는 단어의 가짓수를 구하는 문제입니다.

## 🔍 풀이 방법
dp를 이용해서 풀었습니다. 11 같은 숫자는 AA 또는 K 이렇게 2가지 경우로 나타낼 수 있으므로
숫자가 2자리, 1자리인 경우를 고려해서 dp 리스트를 갱신했습니다.

## ⏳ 회고
00 01 같은 숫자를 처리를 안했어가지고 이 부분에 대해 생각하는 것이 쉽지 않았던 것 같습니다.
