### PR TITLE
[20251206] BOJ / G2 / 환승 / 권혁준

### DIFF
--- a/khj20006/202512/06 BOJ G2 환승.md
+++ b/khj20006/202512/06 BOJ G2 환승.md
@@ -1,0 +1,44 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+
+const int INF = 1e9 + 7;
+
+int N, K, M;
+vector<vector<int>> v(101001);
+
+int bfs01(int start, int end) {
+	vector<int> dist(101001, INF);
+	deque<pair<int, int>> q;
+	dist[start] = 1;
+	q.emplace_back(1, start);
+	while (!q.empty()) {
+		auto [d, n] = q.front(); q.pop_front();
+		for (int i : v[n]) {
+			int cost = i > N ? 0 : 1;
+			if (dist[i] > d + cost) {
+				dist[i] = d + cost;
+				if (cost) q.emplace_back(dist[i], i);
+				else q.emplace_front(dist[i], i);
+			}
+		}
+	}
+	return dist[end] == INF ? -1 : dist[end];
+}
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin >> N >> K >> M;
+	for (int i = 1; i <= M; i++) {
+		for (int j = 1, a; j <= K; j++) {
+			cin >> a;
+			v[a].push_back(N + i);
+			v[N + i].push_back(a);
+		}
+	}
+
+	cout << bfs01(1, N);
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/5214

## 🧭 풀이 시간
10분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N개의 역과 M개의 하이퍼튜브가 있다.
하이퍼튜브 하나는 역 K개를 서로 연결한다.
1번 역에서 N번 역으로 가는데 방문하는 최소 역의 수를 구해보자.

## 🔍 풀이 방법
정점 1부터 N까지는 원래의 역, N+1부터 N+M까지는 i번째 하이퍼튜브를 나타내는 가상의 정점으로 생각하고 0-1 BFS로 최단 거리를 구했다.

## ⏳ 회고
최근에 본 문제들 중 가장 교육적인 문제인 듯