### PR TITLE
[20251206] BOJ / G4 / 우유 도시 / 이강현

### DIFF
--- a/lkhyun/202512/06 BOJ G4 우유 도시.md
+++ b/lkhyun/202512/06 BOJ G4 우유 도시.md
@@ -1,0 +1,97 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main{
+    static class State{
+        int lastMilk;
+        int cnt;
+        State(int lastMilk,int cnt){
+            this.lastMilk = lastMilk;
+            this.cnt = cnt;
+        }
+    }
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+    static StringBuilder sb = new StringBuilder();
+    static int N;
+    static int[][] stores;
+    static State[][] dp;
+
+    public static void main(String[] args) throws Exception {
+        N = Integer.parseInt(br.readLine());
+        stores = new int[N+1][N+1];
+        
+        for(int i = 1; i<=N; i++){
+            st = new StringTokenizer(br.readLine());
+            for(int j = 1; j <= N; j++){
+                stores[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        dp = new State[N+1][N+1];
+        
+        if(stores[1][1] == 0){
+            dp[1][1] = new State(0, 1);
+        }else{
+            dp[1][1] = new State(-1, 0);
+        }
+        
+
+        for(int j = 2; j <= N; j++){
+            int nextMilk = (dp[1][j-1].lastMilk + 1) % 3;
+            if(dp[1][j-1].lastMilk == -1) nextMilk = 0;
+            
+            if(stores[1][j] == nextMilk){
+                dp[1][j] = new State(stores[1][j], dp[1][j-1].cnt + 1);
+            }else{
+                dp[1][j] = new State(dp[1][j-1].lastMilk, dp[1][j-1].cnt);
+            }
+        }
+        
+        for(int i = 2; i <= N; i++){
+            int nextMilk = (dp[i-1][1].lastMilk + 1) % 3;
+            if(dp[i-1][1].lastMilk == -1) nextMilk = 0;
+            
+            if(stores[i][1] == nextMilk){
+                dp[i][1] = new State(stores[i][1], dp[i-1][1].cnt + 1);
+            }else{
+                dp[i][1] = new State(dp[i-1][1].lastMilk, dp[i-1][1].cnt);
+            }
+        }
+        
+        for(int i = 2; i<=N;i++){
+            for(int j = 2; j<=N; j++){
+                State up = dp[i-1][j];
+                State left = dp[i][j-1];
+                
+                int upNextMilk = (up.lastMilk + 1) % 3;
+                if(up.lastMilk == -1) upNextMilk = 0;
+                
+                int leftNextMilk = (left.lastMilk + 1) % 3;
+                if(left.lastMilk == -1) leftNextMilk = 0;
+                
+                int upCnt = up.cnt + (stores[i][j] == upNextMilk ? 1 : 0);
+                int leftCnt = left.cnt + (stores[i][j] == leftNextMilk ? 1 : 0);
+                
+                if(upCnt >= leftCnt){
+                    if(stores[i][j] == upNextMilk){
+                        dp[i][j] = new State(stores[i][j], upCnt);
+                    }else{
+                        dp[i][j] = new State(up.lastMilk, upCnt);
+                    }
+                }else{
+                    if(stores[i][j] == leftNextMilk){
+                        dp[i][j] = new State(stores[i][j], leftCnt);
+                    }else{
+                        dp[i][j] = new State(left.lastMilk, leftCnt);
+                    }
+                }
+            }
+        }
+        bw.write(dp[N][N].cnt+"");
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14722
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
우유는 딸기,초코,바나나순으로만 마실 수 있음.
NxN의 격자무늬의 지도에서 각 칸들은 우유를 한종류만 팜
이때 (1,1)부터 (N,N)까지 가는데, 우유를 최대한 많이 마실때 그 개수를 출력.
## 🔍 풀이 방법
dp
0일때를 초기화하고 첫행, 첫열을 초기화한 후,
(2,2)부터 위와 왼쪽에서 오는 값을 비교해서 구했다.
## ⏳ 회고
직접 구현하니까 코드가 복잡했는데, 잘짠 코드를 둘러보다 기발한 아이디어를 발견했다.
무조건 딸기,초코,바나나순서로 먹어야하므로 우유의 종류를 따로 저장하지 않는다는 것.
즉, 현재까지 먹은 개수가 0이면 딸기를 먹어야하고 1이면 초코, 2면 바나나 3이면 다시 딸기를 먹어야 한다.
따라서 나머지 연산을 통해 간단하게 구현할 수 있었다.