### PR TITLE
[20251206] BOJ / G2 / 환승 / 한종욱

### DIFF
--- a/Ukj0ng/202512/06 BOJ G2 환승.md
+++ b/Ukj0ng/202512/06 BOJ G2 환승.md
@@ -1,0 +1,87 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static List<Integer>[] edges;
+    private static BitSet[] tubes;
+    private static Set<Integer> start, end;
+    private static boolean[] visited;
+    private static int N, K, M;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        int answer = N!=1 ? BFS() : 1;
+
+        bw.write(answer + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        edges = new List[M];
+        tubes = new BitSet[M];
+        visited = new boolean[M];
+        start = new HashSet<>();
+        end = new HashSet<>();
+
+        for (int i = 0; i < M; i++) {
+            edges[i] = new ArrayList<>();
+            tubes[i] = new BitSet();
+        }
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < K; j++) {
+                int num = Integer.parseInt(st.nextToken());
+                tubes[i].set(num);
+                if (num == 1) start.add(i);
+                if (num == N) end.add(i);
+            }
+        }
+
+        for (int i = 0; i < M-1; i++) {
+            for (int j = i+1; j < M; j++) {
+                if (tubes[i].intersects(tubes[j])) {
+                    edges[i].add(j);
+                    edges[j].add(i);
+                }
+            }
+        }
+    }
+
+    private static int BFS() {
+        Queue<int[]> q = new ArrayDeque<>();
+        int result = -1;
+        for (int s : start) {
+            visited[s] = true;
+            q.add(new int[]{s, 2});
+        }
+
+        while (!q.isEmpty()) {
+            int[] current = q.poll();
+
+            if (end.contains(current[0])) {
+                result = current[1];
+                break;
+            }
+
+            for (int next : edges[current[0]]) {
+                if (visited[next]) continue;
+                visited[next] = true;
+                q.add(new int[]{next, current[1]+1});
+            }
+        }
+
+        return result;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/5214
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
하이퍼튜브가 K개의 역을 서로 연결한다. 1번역부터 N번역으로 가는데 방문하는 최소 역의 개수는?
## 🔍 풀이 방법
1개의 하이퍼튜브를 1개의 정점으로 생각했다. 
각 하이퍼튜브에 포함되는 역을 `BitSet`에 저장하고 1을 포함하고 있는 하이퍼튜브와 N을 포함하고 있는 하이퍼튜브를 구분했다. 
그 다음 BFS를 통해 지나가는 역의 개수를 구했다.
N이 1일 경우엔 1개이므로 그 부분은 보정했다.
## ⏳ 회고
그냥 HashSet과 BitSet의 속도 차이는 어마어마하다. 