### PR TITLE
[20251206] BOJ / G5 / 암호코드 / 설진영

### DIFF
--- a/Seol-JY/202512/06 BOJ G5 암호코드.md‎
+++ b/Seol-JY/202512/06 BOJ G5 암호코드.md‎
@@ -1,0 +1,38 @@
+```java
+import java.io.*;
+
+public class Main {
+    static final int MOD = 1000000;
+    
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String s = br.readLine();
+        int n = s.length();
+        
+        if (s.charAt(0) == '0') {
+            System.out.println(0);
+            return;
+        }
+        
+        int[] dp = new int[n + 1];
+        dp[0] = 1;
+        
+        for (int i = 1; i <= n; i++) {
+            int one = s.charAt(i - 1) - '0';
+            if (one >= 1 && one <= 9) {
+                dp[i] = (dp[i] + dp[i - 1]) % MOD;
+            }
+            
+            if (i >= 2) {
+                int two = (s.charAt(i - 2) - '0') * 10 + one;
+                if (two >= 10 && two <= 26) {
+                    dp[i] = (dp[i] + dp[i - 2]) % MOD;
+                }
+            }
+        }
+        
+        System.out.println(dp[n]);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2011

## 🧭 풀이 시간
20분


## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
A=1, B=2, ..., Z=26으로 암호화된 숫자 문자열이 주어질 때, 가능한 해석의 경우의 수를 구하는 문제. 결과는 1000000으로 나눈 나머지 출력

## 🔍 풀이 방법
dp[i] = 앞 i자리를 해석하는 경우의 수
한 자리(1~9) 해석 가능 → dp[i] += dp[i-1]
두 자리(10~26) 해석 가능 → dp[i] += dp[i-2]
걍 일반적인 dp문제

## ⏳ 회고
ez