### PR TITLE
[20251206] BOJ / G5 / 주사위 / 강신지

### DIFF
--- a/ksinji/202512/06 BOJ 주사위.md
+++ b/ksinji/202512/06 BOJ 주사위.md
@@ -1,0 +1,51 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        long n = Long.parseLong(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        long[] d = new long[6];
+        for (int i = 0; i < 6; i++) {
+            d[i] = Long.parseLong(st.nextToken());
+        }
+
+        if (n == 1) {
+            long sum = 0;
+            long max = 0;
+            for (long v : d) {
+                sum += v;
+                if (v > max) max = v;
+            }
+            System.out.println(sum - max);
+            return;
+        }
+
+        long min1 = Long.MAX_VALUE;
+        for (long v : d) {
+            if (v < min1) min1 = v;
+        }
+
+        long[] p = new long[3];
+        p[0] = Math.min(d[0], d[5]);
+        p[1] = Math.min(d[1], d[4]);
+        p[2] = Math.min(d[2], d[3]);
+        Arrays.sort(p);
+
+        long min2 = p[0] + p[1];
+        long min3 = p[0] + p[1] + p[2];
+
+        long cnt3 = 4;
+        long cnt2 = 8 * (n - 2) + 4;
+        long cnt1 = 5 * (n - 2) * (n - 2) + 4 * (n - 2);
+
+        long ans = min1 * cnt1 + min2 * cnt2 + min3 * cnt3;
+        System.out.println(ans);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1041
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
동일한 주사위를 N^3개로 N×N×N크기의 정육면체를 만들려고 한다. 
이 정육면체는 탁자위에 있으므로, 5개의 면만 보인다.
N과 주사위에 쓰여 있는 수가 주어질 때, 보이는 5개의 면에 쓰여 있는 수의 합의 최솟값을 구하라.

## 🔍 풀이 방법
주사위의 한 면만 보이는 것의 개수, 두 면이 보이는 것의 개수, 세 면이 보이는 것의 개수를 구하고 각각의 경우 보이는 면의 최솟값을 곱해서 답 도출
## ⏳ 회고
long 써야한다ㅏㅏ