### PR TITLE
[20251207] BOJ / G5 / 벽장문의 이동 / 이준희

### DIFF
--- a/JHLEE325/202512/07 BOJ G5 벽장문의 이동.md
+++ b/JHLEE325/202512/07 BOJ G5 벽장문의 이동.md
@@ -1,0 +1,57 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static final int INF = 1_000_000_000;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int N = Integer.parseInt(br.readLine());
+
+        st = new StringTokenizer(br.readLine());
+        int open1 = Integer.parseInt(st.nextToken());
+        int open2 = Integer.parseInt(st.nextToken());
+
+        int K = Integer.parseInt(br.readLine());
+        int[] use = new int[K + 1];
+        for (int i = 1; i <= K; i++) {
+            use[i] = Integer.parseInt(br.readLine());
+        }
+
+        int[][][] dp = new int[K + 1][N + 1][N + 1];
+        for (int i = 0; i <= K; i++) {
+            for (int a = 1; a <= N; a++) {
+                Arrays.fill(dp[i][a], INF);
+            }
+        }
+
+        dp[0][open1][open2] = 0;
+
+        for (int i = 0; i < K; i++) {
+            int x = use[i + 1];
+            for (int a = 1; a <= N; a++) {
+                for (int b = 1; b <= N; b++) {
+                    if (dp[i][a][b] == INF) continue;
+
+                    dp[i + 1][x][b] = Math.min(dp[i + 1][x][b], dp[i][a][b] + Math.abs(a - x));
+
+                    dp[i + 1][a][x] = Math.min(dp[i + 1][a][x], dp[i][a][b] + Math.abs(b - x));
+                }
+            }
+        }
+
+        int answer = INF;
+        for (int a = 1; a <= N; a++) {
+            for (int b = 1; b <= N; b++) {
+                answer = Math.min(answer, dp[K][a][b]);
+            }
+        }
+
+        System.out.println(answer);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2666

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
벽장이 있고 그 벽장은 2칸이 열리는 미닫이 벽장일 때
초기 상태가 주어지고 각 순서대로 사용해야할 벽장을 최소한의 문 이동으로 사용하는 경우를 구하는 문제입니다.

## 🔍 풀이 방법
dp를 이용해서 풀었습니다. 3중배열로 dp[i][a][b] 는 i번째 시간에 a칸, b칸이 열려있을 때 문을 움직인 거리를 나타냅니다.
각 순간마다 a문을 이동, b문을 이동하는 경우 모두 계산했습니다.

## ⏳ 회고
방법 자체가 잘 안떠올라서 오래 걸렸던 문제였습니다.
