### PR TITLE
[20251207] BOJ / P3 / 건초 더미 / 권혁준

### DIFF
--- a/khj20006/202512/07 BOJ P3 건초 더미.md
+++ b/khj20006/202512/07 BOJ P3 건초 더미.md
@@ -1,0 +1,76 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+using ll = long long;
+
+int N, Q;
+vector<pair<int, int>> infos;
+int arr[300001]{}, idx[300001]{}, cnt[300001]{}, ans[300000]{};
+ll sum[300001]{};
+vector<tuple<int, int, int>> queries;
+
+void upt(int x, int v) {
+	for (; x <= 300000; x += x & -x) {
+		sum[x] += v;
+		cnt[x]++;
+	}
+}
+
+pair<ll, int> find(int x) {
+	pair<ll, int> ret = { 0,0 };
+	for (; x > 0; x -= x & -x) {
+		ret.first += sum[x];
+		ret.second += cnt[x];
+	}
+	return ret;
+}
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin >> N >> Q;
+	for (int i = 1; i <= N; i++) {
+		cin >> arr[i];
+		infos.emplace_back(arr[i], i);
+	}
+
+	sort(infos.begin(), infos.end());
+	for (int i = 0; i < N; i++) {
+		auto [v, x] = infos[i];
+		idx[x] = i + 1;
+	}
+
+	queries.resize(Q);
+	for (int i = 0; i < Q; i++) {
+		auto& [X, P, x] = queries[i];
+		cin >> X >> P;
+		x = i;
+	}
+
+	sort(queries.begin(), queries.end());
+
+	int pos = 0;
+	for (auto [X, P, x] : queries) {
+		while (pos < X) {
+			pos++;
+			upt(idx[pos], arr[pos]);
+		}
+		pair<ll, int> ri = find(N);
+		if (P > ri.first) {
+			ans[x] = -1;
+			continue;
+		}
+		int s = 0, e = N - 1, m = (s + e + 1) >> 1;
+		while (s < e) {
+			pair<ll, int> le = find(m);
+			if (ri.first - le.first >= P) s = m;
+			else e = m - 1;
+			m = (s + e + 1) >> 1;
+		}
+		ans[x] = ri.second - find(m).second;
+	}
+
+	for (int i = 0; i < Q; i++) cout << ans[i] << '\n';
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/34119

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
수직선의 위치 0에서 오른쪽 방향으로 정수 크기의 힘을 가진 화살이 발사된다.
위치 1부터 N까지에는 방어력이 각각 D[i]인 건초 더미를 하나 설치할 수 있다.

화살이 건초 더미에 부딪칠 때 화살의 힘이 건초 더미의 방어력 D[i]보다 높다면 힘이 D[i]만큼 감소된 채로 관통하여 날아가고, 그렇지 않다면 멈춘다.

**f(X, P) = 힘이 P인 화살이 위치 X 이하에서 멈추도록 하기 위해 설치해야 하는 건초 더미의 최소 개수**라고 할 때, 이걸 Q번 구해보자.

## 🔍 풀이 방법
주어지는 쿼리들의 순서를 바꿔도 답을 구하는데 지장이 전혀 없으니까 `오프라인 쿼리`, 위치 기준 오름차순으로 처리해야겠다고 생각했다.
-> 사용 가능한 건초 더미를 점점 늘려가며 쿼리 처리를 할 수 있게 된다.

건초 더미의 개수를 최소화하기 위해서는 방어력이 가장 높은 것부터 사용하는 것이 항상 최적이다.
따라서, **사용 가능한 건초 더미들 중에서 방어력이 높은 순으로 몇 개를 합쳐야 처음으로 P 이상이 되는지** 확인하면 된다.

저걸 보니 `이분 탐색`을 굉장히 쓰고 싶게 생겼다.
**K개를 합쳤을 때 P이상이 되는가?**로 문제를 바꾸고, K를 **이분 탐색**으로 찾아주었다.
합을 빠르게 구하기 위해서 `세그먼트 트리`를 사용했다.

## ⏳ 회고
구현이 생각보다 복잡했음