### PR TITLE
[20251207] BOJ / G5 / 벽장문의 이동 / 설진영

### DIFF
--- a/Seol-JY/202512/07 BOJ G5 벽장문의 이동.md
+++ b/Seol-JY/202512/07 BOJ G5 벽장문의 이동.md
@@ -1,0 +1,43 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int n, m;
+    static int[] order;
+    static int[][][] dp;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine().trim());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int open1 = Integer.parseInt(st.nextToken());
+        int open2 = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(br.readLine().trim());
+        order = new int[m];
+        for (int i = 0; i < m; i++) {
+            order[i] = Integer.parseInt(br.readLine().trim());
+        }
+
+        dp = new int[m + 1][n + 1][n + 1];
+        for (int[][] arr2d : dp) {
+            for (int[] arr1d : arr2d) {
+                Arrays.fill(arr1d, -1);
+            }
+        }
+
+        System.out.println(solve(0, open1, open2));
+    }
+
+    static int solve(int idx, int a, int b) {
+        if (idx == m) return 0;
+        if (dp[idx][a][b] != -1) return dp[idx][a][b];
+
+        int target = order[idx];
+        int moveA = Math.abs(target - a) + solve(idx + 1, target, b);
+        int moveB = Math.abs(target - b) + solve(idx + 1, a, target);
+
+        return dp[idx][a][b] = Math.min(moveA, moveB);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2666

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
n개의 벽장 중 2개만 열려있고, 순서대로 특정 벽장을 사용해야 할 때 문 이동 횟수의 최솟값을 구하는 문제

## 🔍 풀이 방법
dp[idx][a][b] = idx번째 벽장을 사용할 차례이고, 열린 문 위치가 a, b일 때 최소 이동 횟수
열린 문 2개의 위치를 상태로 관리

## ⏳ 회고
약간 어렵네요