### PR TITLE
[20251208] BOJ / G5 / 트리 / 이종환

### DIFF
--- a/0224LJH/202512/08 BOJ 트리.md
+++ b/0224LJH/202512/08 BOJ 트리.md
@@ -1,0 +1,75 @@
+```java
+
+import java.util.StringTokenizer;
+import java.util.*;
+import java.io.*;
+
+public class Main {
+	
+	static int nodeCnt,ans;
+	static Node[] nodes;
+	static Node root;
+   
+   static class Node {
+	   Node parent;
+	   boolean alive = true;
+	   Set<Node> children = new HashSet<>();
+	   
+	   public void checkLeaf() {
+		   int childCnt = 0;
+		   for (Node n: children) {
+			   if (!n.alive) continue;
+			   childCnt++;
+			   n.checkLeaf();
+		   }
+		   if (childCnt==0) ans++;
+	   }
+
+   }
+  
+
+    public static void main(String[] args) throws IOException {
+    	init();
+    	process();
+    	print();
+
+    }
+    
+    private static void init() throws IOException{
+    	BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    	nodeCnt = Integer.parseInt(br.readLine());
+    	ans = 0;
+    	
+    	nodes = new Node[nodeCnt];
+    	for (int i = 0; i < nodeCnt; i++) {
+    		nodes[i] = new Node();
+    	}
+    	StringTokenizer st = new StringTokenizer(br.readLine());
+    	for (int i = 0; i < nodeCnt; i++) {
+    		int parent = Integer.parseInt(st.nextToken());
+    		if (parent == -1) {
+    			root = nodes[i];
+    			continue;
+    		}
+    		Node p = nodes[parent];
+    		nodes[i].parent = p;
+    		p.children.add(nodes[i]);
+    	}
+    	
+    	int targetNum = Integer.parseInt(br.readLine());
+    	Node target = nodes[targetNum];
+    	target.alive = false;
+    
+    }
+    
+    private static void process() throws IOException {
+    	if (root.alive) root.checkLeaf();
+
+    }
+    
+   private static void print() {
+      System.out.println(ans);
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1068

## 🧭 풀이 시간
15분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
트리에서 리프 노드란, 자식의 개수가 0인 노드를 말한다.

트리가 주어졌을 때, 노드 하나를 지울 것이다. 그 때, 남은 트리에서 리프 노드의 개수를 구하는 프로그램을 작성하시오. 노드를 지우면 그 노드와 노드의 모든 자손이 트리에서 제거된다.


첫째 줄에 트리의 노드의 개수 N이 주어진다. N은 50보다 작거나 같은 자연수이다. 둘째 줄에는 0번 노드부터 N-1번 노드까지, 각 노드의 부모가 주어진다. 만약 부모가 없다면 (루트) -1이 주어진다. 셋째 줄에는 지울 노드의 번호가 주어진다.

첫째 줄에 입력으로 주어진 트리에서 입력으로 주어진 노드를 지웠을 때, 리프 노드의 개수를 출력한다.

## 🔍 풀이 방법
루트노드만 기억한 후, 그 이후재귀적으로 파고들면서 리프노드인지 확인만하면 되는 간단한 문제이다
## ⏳ 회고
