### PR TITLE
[20251208] BOJ / G3 / 욕심쟁이 판다 / 이강현

### DIFF
--- a/lkhyun/202512/08 BOJ G3 욕심쟁이 판다.md
+++ b/lkhyun/202512/08 BOJ G3 욕심쟁이 판다.md
@@ -1,0 +1,63 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+
+    static int N;
+    static int[][] forest;
+    static int[][] dp;
+    
+    // 상하좌우
+    static int[] di = {-1, 1, 0, 0};
+    static int[] dj = {0, 0, -1, 1};
+
+    static int ans = 0;
+
+    public static void main(String[] args) throws Exception {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+
+        forest = new int[N][N];
+        dp = new int[N][N];
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                forest[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                ans = Math.max(ans, DFS(i, j));
+            }
+        }
+        
+        bw.write(ans + "");
+        bw.close();
+    }
+
+    public static int DFS(int i, int j) {
+        if (dp[i][j] != 0) {
+            return dp[i][j];
+        }
+        
+        dp[i][j] = 1;
+        
+        for (int k = 0; k < 4; k++) {
+            int ni = i + di[k];
+            int nj = j + dj[k];
+            
+            if (ni >= 0 && ni < N && nj >= 0 && nj < N && forest[ni][nj] > forest[i][j]) {
+                dp[i][j] = Math.max(dp[i][j], DFS(ni, nj) + 1);
+            }
+        }
+        
+        return dp[i][j];
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1937
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
판다는 상하좌우로 이동하며 대나무를 먹음.
대나무는 현재 먹은거보다 더 많은 양을 먹어야함.
이동하면서 가장 많은 칸으로 이동하며 먹을때 해당 칸을 출력.
## 🔍 풀이 방법
DFS, dp
DFS에 visited를 dp로 구현
## ⏳ 회고
dp는 현재 지점에 앞으로 얼마만큼 먹을 수 있는가를 저장해두어야 함.
그리고 모든 지점에서 DFS를 하는데, dp값이 있으면 그걸 사용하도록 구현함.
이때 한가지 생각이 들었음.
dp 값이 5라고 한다면 현재 지점에서 4칸을 더 가면서 대나무를 먹는다는 건데, 그 지점을 거쳐서 온 경우라면?
하지만 이런 경우는 존재하지 않음.
무조건 대나무를 증가하면서 먹기때문에, 현재지점에 도달했을때는 이 지점보다 무조건 적은 대나무를 먹으면서 온 경우이고 이후 앞으로 먹을 4칸들은 현재 지점보다 무조건 큰 지점들이기에 절대로 겹칠 수 없다는 것이 문제의 핵심이었음.