### PR TITLE
[20251208] BOJ / P5 / 광부 호석 / 권혁준

### DIFF
--- a/khj20006/202512/08 BOJ P5 광부 호석.md
+++ b/khj20006/202512/08 BOJ P5 광부 호석.md
@@ -1,0 +1,40 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+using ll = long long;
+
+int N, C;
+vector<tuple<int, int, int>> arr;
+priority_queue<pair<int, int>> q;
+
+int main(){
+    cin.tie(0)->sync_with_stdio(0);
+    
+    cin>>N>>C;
+    arr.resize(N);
+    for(auto &[x,y,v] : arr) cin>>x>>y>>v;
+    sort(arr.begin(), arr.end());
+    
+    ll ans = 0, cur = 0;
+    for(int i=0;i<arr.size();) {
+        int x = get<0>(arr[i]);
+        while(i<arr.size() && get<0>(arr[i]) == x) {
+            cur += get<2>(arr[i]);
+            q.emplace(get<1>(arr[i]), get<2>(arr[i]));
+            i++;
+        }
+        while(q.size() > C) {
+            auto [y, v] = q.top(); q.pop();
+            cur -= v;
+            while(!q.empty() && q.top().first == y) {
+                cur -= q.top().second;
+                q.pop();
+            }
+        }
+        ans = max(ans, cur);
+    }
+    
+    cout<<ans;
+    
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/21279

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
2차원 좌표평면의 1사분면과 그 경계의 영역에 N개의 광물이 있다.
i번째 광물을 캐는 비용은 1이고, 광물의 아름다운 정도는 V[i]이다.

원점 (0,0)에서 **광산 뒤집기**를 사용할 수 있다. 사용하면 (0,0)을 왼쪽 아래 꼭짓점으로 하는 H*W 영역의 광물을 모두 캔다.
광물을 C개 이하 캐면서 얻을 수 있는 아름다움의 합을 최대화해보자.

## 🔍 풀이 방법
x좌표 기준으로 광물을 정렬시키고, 어떤 x좌표에 있는 광물들을 모두 `우선순위 큐`에 넣는다.
이때 광물의 수가 C이하가 되도록 y좌표가 큰 순서대로 **우선순위 큐**에서 빼낸다.
이 과정을 반복하면서 아름다움의 합 중 최댓값을 구해줬다.

## ⏳ 회고
지문에 스킬을 한 번만 써야된다는 얘기가 없어서 이해하는데 한참 걸렸다