### PR TITLE
[20251209] BOJ / G3 / 색상환 / 한종욱

### DIFF
--- a/Ukj0ng/202512/09 BOJ G3 색상환.md
+++ b/Ukj0ng/202512/09 BOJ G3 색상환.md
@@ -1,0 +1,44 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static final int INF = (int)1e9+3;
+    private static int[][] dp;
+    private static int N, K;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        DP();
+
+        int answer = (dp[N-3][K-1] + dp[N-1][K]) % INF;
+        bw.write(answer + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+        K = Integer.parseInt(br.readLine());
+
+        dp = new int[N][K+1];
+
+        for (int i = 0; i < N; i++) {
+            dp[i][0] = 1;
+        }
+
+        dp[1][1] = 1;
+    }
+
+    private static void DP() {
+        for (int i = 2; i < N; i++) {
+            for (int j = 1; j <= K; j++) {
+                dp[i][j] = (dp[i-1][j] + dp[i-2][j-1]) % INF;
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2482
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
바로 옆에 있는 색은 선택하지 못한다. K개의 색을 고르는 경우의 수는?
## 🔍 풀이 방법
원형 DP이기 때문에, 첫번째를 선택하는 경우와 아닌 경우로 나눈다. 
`dp[i][j]`: i번째 색에서 j개를 고른 경우의 수

`dp[i][j] = dp[i-1][j] + dp[i-2][j-1]`
## ⏳ 회고
dp는 꾸준히 풀어야 겠다. 안 풀다 푸니까 상태정의가 헷갈렸다. 