### PR TITLE
[20251209] BOJ / G5 / 누가 이길까 / 이종환

### DIFF
--- a/0224LJH/202512/09 BOJ 누가 이길까.md
+++ b/0224LJH/202512/09 BOJ 누가 이길까.md
@@ -1,0 +1,64 @@
+```java
+
+import java.util.StringTokenizer;
+import java.util.*;
+import java.io.*;
+
+public class Main {
+	
+	static int[] total = new int[2];
+	static long[][] people = new long[2][100001];
+	static long[][] cumul = new long[2][100001];
+	static long win,lose,draw;
+
+    public static void main(String[] args) throws IOException {
+    	init();
+    	process();
+    	print();
+
+    }
+    
+    private static void init() throws IOException{
+    	BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    	StringTokenizer st = new StringTokenizer(br.readLine());
+    	total[0] = Integer.parseInt(st.nextToken());
+    	total[1] = Integer.parseInt(st.nextToken());
+    	win = 0;
+    	lose = 0;
+    	draw = 0;
+    	
+    	for (int i = 0 ; i < 2; i++) {
+        	st = new StringTokenizer(br.readLine());
+        	
+        	for (int j = 0; j < total[i]; j++) {
+        		int num = Integer.parseInt(st.nextToken());
+        		people[i][num]++;
+        	}
+    	}
+    	
+   
+    
+    }
+    
+    private static void process() throws IOException {
+    	for (int i = 1; i<= 100000; i++) {
+    		for (int j = 0; j < 2; j++) {
+    			cumul[j][i] = cumul[j][i-1] + people[j][i];
+    		}
+    	}
+    	
+    	for (int i = 1; i <= 100000; i++) {
+    		win += people[0][i] * (cumul[1][i-1]);
+    		lose += people[1][i] * (cumul[0][i-1]);
+    		draw += people[0][i] * people[1][i];
+    	}
+    	
+    	
+    }
+    
+   private static void print() {
+      System.out.println(win + " "+ lose +" " + draw);
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/28449

## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명

첫째 줄에 HI팀의 인원 수 
$N$, ARC팀의 인원 수 
$M$이 공백으로 구분되어 정수로 주어진다. 
$(1 \leq N, M \leq 100\,000)$ 

둘째 줄에 HI팀의 참가자의 코딩실력을 나타내는 길이 
$N$ 수열 
$a$가 공백으로 구분되어 정수로 주어진다. 
$(1 \leq a_i \leq 100\,000)$

셋째 줄에 ARC팀의 참가자의 코딩실력을 나타내는 길이 
$M$ 수열 
$b$가 공백으로 구분되어 정수로 주어진다. 

첫째 줄에 HI팀 참가자의 승리 횟수, ARC팀 참가자의 승리 횟수, 무승부 횟수를 공백으로 구분하여 출력한다.

## 🔍 풀이 방법
애초에 점수가 10만점이 최고이기에, 각 팀마다, 각 점수를 받은 사람이 몇명인지 기록 후, 누적합 방식으로 비교하며 계산하면 간단하게 해결할 수 있다.

## ⏳ 회고
