### PR TITLE
[20251209] BOJ / G1 / K번째 수 / 이준희

### DIFF
--- a/JHLEE325/202512/09 BOJ G1 K번째 수.md
+++ b/JHLEE325/202512/09 BOJ G1 K번째 수.md
@@ -1,0 +1,35 @@
+```java
+import java.io.*;
+
+public class Main {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+        long K = Long.parseLong(br.readLine());
+
+        long left = 1;
+        long right = K;
+        long answer = 0;
+
+        while (left <= right) {
+            long mid = (left + right) / 2;
+            long count = 0;
+
+            for (int i = 1; i <= N; i++) {
+                count += Math.min(N, mid / i);
+            }
+
+            if (count >= K) {
+                answer = mid;
+                right = mid - 1;
+            } else {
+                left = mid + 1;
+            }
+        }
+
+        System.out.println(answer);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1300

## 🧭 풀이 시간
80분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
N*N 짜리 배열 A 에서 A[i][j] = i*j 일 때
이 배열을 일차원으로 만들고 오름차순 정렬했을 때
K번째 숫자를 찾는 문제입니다.

## 🔍 풀이 방법
이분탐색을 이용해서 풀었습니다.
K번째 수를 찾아야하기 때문에 중간값(mid)보다 작은 값이 K개와 비교하여 작은지, 큰지에 따라서 갱신했습니다.

## ⏳ 회고
호기롭게 도전했다가 고전했던 문제입니다.
N이 10만으로 크기 때문에 실제 배열을 정의하지 못하는 문제였습니다.