### PR TITLE
[20251209] BOJ / G5 / 암호코드 / 강신지

### DIFF
--- a/ksinji/202512/09 BOJ 암호코드.md
+++ b/ksinji/202512/09 BOJ 암호코드.md
@@ -1,0 +1,41 @@
+```java
+import java.io.*;
+
+public class Main {
+    static final int MOD = 1000000;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String s = br.readLine();
+
+        int n = s.length();
+        if (n == 0 || s.charAt(0) == '0') {
+            System.out.println(0);
+            return;
+        }
+
+        int[] dp = new int[n + 1];
+        dp[0] = 1;
+        dp[1] = 1;
+
+        for (int i = 2; i <= n; i++) {
+            char c1 = s.charAt(i - 1);
+            char c0 = s.charAt(i - 2);
+
+            if (c1 != '0') {
+                dp[i] += dp[i - 1];
+                dp[i] %= MOD;
+            }
+
+            int two = (c0 - '0') * 10 + (c1 - '0');
+            if (two >= 10 && two <= 26) {
+                dp[i] += dp[i - 2];
+                dp[i] %= MOD;
+            }
+        }
+
+        System.out.println(dp[n] % MOD);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2011
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
A는 1, B는 2, 그리고 Z는 26와 같은 식으로 대입하여 암호화하는 규칙이 있다.
숫자로 이루어진 문자열을 알파벳으로 해석하는 경우의 수를 구하라.
* ex) 25114를 다시 영어로 바꾸면, "BEAAD", "YAAD", "YAN", "YKD", "BEKD", "BEAN" 총 6가지
## 🔍 풀이 방법
dp. 앞에서부터 i번째 글자까지 해석하는 경우의 수를 dp[i]로 정의하고, 한 글자 해석 가능하면 dp[i-1], 두 글자(10~26) 해석 가능하면 dp[i-2]를 더해 누적.
## ⏳ 회고
