### PR TITLE
[20251211] BOJ / G4 / 트리의 지름 / 이종환

### DIFF
--- a/0224LJH/202512/11 BOJ 트리의 지름.md
+++ b/0224LJH/202512/11 BOJ 트리의 지름.md
@@ -1,0 +1,86 @@
+```java
+
+import java.util.StringTokenizer;
+import java.util.*;
+import java.io.*;
+
+public class Main {
+	
+	static int nodeCnt,ans = 0;
+	static Node[] nodes;
+	
+	static class Node{
+		int idx = 0;
+		Node parent = null;
+		HashSet<Node> set = new HashSet<>();
+		int dis = 0;
+		
+		public Node (int idx) {
+			this.idx = idx;
+		}
+	}
+
+	
+
+    public static void main(String[] args) throws IOException {
+    	init();
+    	process();
+    	print();
+
+    }
+    
+    private static void init() throws IOException{
+    	BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    	nodeCnt = Integer.parseInt(br.readLine());
+    	nodes = new Node[nodeCnt+1];
+    	
+    	for (int i = 1; i<= nodeCnt; i++) {
+    		nodes[i] = new Node(i);
+    	}
+    	
+    	for (int i = 1; i < nodeCnt; i++) {
+    		StringTokenizer st = new StringTokenizer(br.readLine());
+    		int pNum = Integer.parseInt(st.nextToken());
+    		int cNum = Integer.parseInt(st.nextToken());
+    		int dis = Integer.parseInt(st.nextToken());
+    		Node p = nodes[pNum];
+    		Node c = nodes[cNum];
+    		c.parent = p;
+    		p.set.add(c);
+    		c.dis = dis;
+    	}
+    }
+    
+    private static void process() throws IOException {
+    	int rs = recursive(1);
+    	ans = Math.max(ans, rs);
+    	
+    }
+    
+    public static int recursive(int num) {
+    	Node target = nodes[num];
+    	if(target.set.isEmpty()) return target.dis;
+    	
+    	PriorityQueue<Integer> pq = new PriorityQueue<>(Collections.reverseOrder());
+    	
+    	for (Node n: target.set) {
+    		pq.add(recursive(n.idx));
+    	}
+    	int longest = pq.poll();
+    	
+    	if (!pq.isEmpty()) {
+    		int second = pq.poll();
+    		
+    		ans = Math.max(ans, longest+second);
+    	}
+    	
+    	
+    	return longest + target.dis;
+    }
+    
+   private static void print() {
+      System.out.println(ans);
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1967

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [] 하

## ✏️ 문제 설명

파일의 첫 번째 줄은 노드의 개수 n(1 ≤ n ≤ 10,000)이다. 둘째 줄부터 n-1개의 줄에 각 간선에 대한 정보가 들어온다. 간선에 대한 정보는 세 개의 정수로 이루어져 있다. 첫 번째 정수는 간선이 연결하는 두 노드 중 부모 노드의 번호를 나타내고, 두 번째 정수는 자식 노드를, 세 번째 정수는 간선의 가중치를 나타낸다. 간선에 대한 정보는 부모 노드의 번호가 작은 것이 먼저 입력되고, 부모 노드의 번호가 같으면 자식 노드의 번호가 작은 것이 먼저 입력된다. 루트 노드의 번호는 항상 1이라고 가정하며, 간선의 가중치는 100보다 크지 않은 양의 정수이다.


## 🔍 풀이 방법
루트 레벨과 길이가 무관하기에, 재귀방식으로 타고 올라오면서, 매 노드마다 자식노드에서 나온 길이들로 가장 긴 길이를 만들 수 있나 비교하면 된다.

## ⏳ 회고
