### PR TITLE
[20251211] BOJ / G2 / 꼬인 전깃줄 / 이준희

### DIFF
--- a/JHLEE325/202512/11 BOJ G2 꼬인 전깃줄.md
+++ b/JHLEE325/202512/11 BOJ G2 꼬인 전깃줄.md
@@ -1,0 +1,33 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int N = Integer.parseInt(br.readLine());
+        int[] arr = new int[N];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int[] lis = new int[N];
+        int len = 0;
+
+        for (int x : arr) {
+            int pos = Arrays.binarySearch(lis, 0, len, x);
+            if (pos < 0) pos = -(pos + 1);
+
+            lis[pos] = x;
+            if (pos == len) len++;
+        }
+
+        System.out.println(N - len);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1365

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
길을 사이에 두고 양쪽의 전봇대가 전깃줄로 이어져 있습니다.
이 때 전깃줄이 교차하는 경우 화재위험이 있어 몇개의 전깃줄을 잘라서 화재 위험을 줄이고자 할 때
최소 갯수를 자르는 경우를 구하는 문제입니다.

## 🔍 풀이 방법
LIS를 구해서 풀었습니다.
처음에는 간단하게 DP로 풀었는데 시간초과가 발생했습니다.
그래서 LIS를 구하는 다른 방법에 대해 찾아서 이분탐색을 통한 LIS를 구했습니다.

## ⏳ 회고
한가지 문제 유형에 하나의 방식만 알고있다보니 이런 문제는 풀기가 어려웠던 것 같습니다.
