### PR TITLE
[20251211] BOJ / G4 / 알고리즘 수업 - 행렬 경로 문제 4 / 김민진

### DIFF
--- a/zinnnn37/202512/11 BOJ G4 알고리즘 수업 - 행렬 경로 문제 4.md
+++ b/zinnnn37/202512/11 BOJ G4 알고리즘 수업 - 행렬 경로 문제 4.md
@@ -1,0 +1,77 @@
+```java
+import java.io.*;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BJ_24427_알고리즘_수업_행렬_경로_문제_4 {
+
+    private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static       StringTokenizer st;
+
+    private static int N, P;
+    private static int[][]     matrix;
+    private static int[][][]   dp;
+    private static boolean[][] target;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+
+        matrix = new int[N + 1][N + 1];
+        for (int i = 1; i <= N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 1; j <= N; j++) {
+                matrix[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        P = Integer.parseInt(br.readLine());
+        target = new boolean[N + 1][N + 1];
+        while (P-- > 0) {
+            st = new StringTokenizer(br.readLine());
+
+            int x = Integer.parseInt(st.nextToken());
+            int y = Integer.parseInt(st.nextToken());
+
+            target[x][y] = true;
+        }
+
+        dp = new int[N + 1][N + 1][2];
+        for (int i = 0; i <= N; i++) {
+            for (int j = 0; j <= N; j++) {
+                Arrays.fill(dp[i][j], -987654321);
+            }
+        }
+        dp[1][1][target[1][1] ? 0 : 1] = matrix[1][1];
+    }
+
+    private static void sol() throws IOException {
+        for (int i = 1; i <= N; i++) {
+            for (int j = 1; j <= N; j++) {
+                if (i == 1 && j == 1) continue;
+
+                if (target[i][j]) {
+                    dp[i][j][0] = matrix[i][j] + Math.max(
+                            Math.max(dp[i - 1][j][1], dp[i][j - 1][1]),
+                            Math.max(dp[i - 1][j][0], dp[i][j - 1][0])
+                    );
+                } else {
+                    dp[i][j][0] = matrix[i][j] + Math.max(dp[i - 1][j][0], dp[i][j - 1][0]);
+                    dp[i][j][1] = matrix[i][j] + Math.max(dp[i - 1][j][1], dp[i][j - 1][1]);
+                }
+            }
+        }
+
+        bw.write(dp[N][N][0] + "");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[알고리즘 수업 - 행렬 경로 문제 4](https://www.acmicpc.net/problem/24427)

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
주어진 좌표를 하나라도 거치며 `(N, N)`에 도달할 때 얻을 수 있는 가장 높은 점수

## 🔍 풀이 방법
3차원 dp
```java
dp[i][j][0] = 주어진 좌표 중 하나라도 거쳤을 때의 최댓값
dp[i][j][1] = 주어진 좌표를 하나도 거치지 않았을 때의 최댓값
```

## ⏳ 회고
초기화 과정이 조금 헷갈렸음,,
`dp[1][1]` 초기화는 계산을 쉽게 하기 위한 패딩이 아님
계산의 일부이기 때문에 계산에서 제외해야 제대로 된 값이 나옴
→ 포함시키는 경우 `dp[1][1]`이 P에 속하는지 여부 따져서 초기화 한 것이 무용지물이 됨

dp 두 번 쓴 사람들이 많네..