### PR TITLE
[20251212] BOJ / G4 / 인접한 비트의 개수 / 이준희

### DIFF
--- a/JHLEE325/202512/12 BOJ G4 인접한 비트의 개수.md
+++ b/JHLEE325/202512/12 BOJ G4 인접한 비트의 개수.md
@@ -1,0 +1,40 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static long[][][] dp = new long[101][101][2];
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int T = Integer.parseInt(br.readLine());
+
+        dp[1][0][0] = 1;
+        dp[1][0][1] = 1;
+
+        for (int n = 2; n <= 100; n++) {
+            for (int k = 0; k <= 100; k++) {
+                dp[n][k][0] = dp[n - 1][k][0] + dp[n - 1][k][1];
+
+                dp[n][k][1] = dp[n - 1][k][0];
+                if (k > 0) dp[n][k][1] += dp[n - 1][k - 1][1];
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+
+        for (int t = 0; t < T; t++) {
+            st = new StringTokenizer(br.readLine());
+            int N = Integer.parseInt(st.nextToken());
+            int K = Integer.parseInt(st.nextToken());
+
+            sb.append(dp[N][K][0] + dp[N][K][1]).append("\n");
+        }
+
+        System.out.print(sb);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2698

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
0과 1로 이루어진 수열 S에서 인접한 비트의 개수는 아래와 같습니다.
s1*s2 + s2*s3 + s3*s4 + ... + sn-1 * sn = k
N길이의 수열에서 인접한 비트의 개수가 K개가 되는 경우의 수를 구하는 문제입니다.

## 🔍 풀이 방법
DP를 이용해서 풀었습니다.
N길이의 수열에서 K번째 인덱스까지 봤을 때 인접한 비트의 개수를 DP로 구했습니다.
dp[n][k][0] 은 k번째가 0이었을 때이고
dp[n][k][1] 은 k번째가 1이었을 때를 의미합니다.
이를 이용하여 3차원 dp를 사용했습니다.

## ⏳ 회고
수식만 이해해도 풀 수 있는 문제였습니다.
