### PR TITLE
[20251211] BOJ / G2 / 꼬인 전깃줄 / 설진영

### DIFF
--- a/Seol-JY/202512/12 BOJ G2 꼬인 전깃줄.md
+++ b/Seol-JY/202512/12 BOJ G2 꼬인 전깃줄.md
@@ -13,7 +13,6 @@ public class Main {
             arr[i] = Integer.parseInt(st.nextToken());
         }
 
-        // LIS using binary search
         ArrayList<Integer> lis = new ArrayList<>();
 
         for (int a : arr) {


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1365

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
잘라내야 할 전선의 최소 개수를 구하는 프로그램을 작성

## 🔍 풀이 방법
이분탐색 활용

## ⏳ 회고
어렵네요