### PR TITLE
[20251213] BOJ / G5 / 진우의 달 여행 (Large) / 이준희

### DIFF
--- a/JHLEE325/202512/13 BOJ G5 진우의 달 여행 (Large).md
+++ b/JHLEE325/202512/13 BOJ G5 진우의 달 여행 (Large).md
@@ -1,0 +1,58 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static final int INF = 1_000_000_000;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        int[][] cost = new int[N][M];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) {
+                cost[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        int[][][] dp = new int[N][M][3];
+
+        for (int j = 0; j < M; j++) {
+            for (int d = 0; d < 3; d++) {
+                dp[0][j][d] = cost[0][j];
+            }
+        }
+
+        for (int i = 1; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                Arrays.fill(dp[i][j], INF);
+
+                if (j + 1 < M) {
+                    dp[i][j][0] = Math.min(dp[i - 1][j + 1][1], dp[i - 1][j + 1][2]) + cost[i][j];
+                }
+
+                dp[i][j][1] = Math.min(dp[i - 1][j][0], dp[i - 1][j][2]) + cost[i][j];
+
+                if (j - 1 >= 0) {
+                    dp[i][j][2] = Math.min(dp[i - 1][j - 1][0], dp[i - 1][j - 1][1]) + cost[i][j];
+                }
+            }
+        }
+
+        int answer = INF;
+        for (int j = 0; j < M; j++) {
+            for (int d = 0; d < 3; d++) {
+                answer = Math.min(answer, dp[N - 1][j][d]);
+            }
+        }
+
+        System.out.println(answer);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17485

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
진우가 달을 가고 싶은데 달로 가능 방향은
좌하단, 하단, 우하단만 가능하며 연속으로 같은 방향으로는 갈 수 없습니다.
이 때 각 맵에 필요한 연료가 주어질 때
가장 낮은 연료로 갈 수 있는 경우를 구하는 문제입니다.

## 🔍 풀이 방법
DP를 이용해서 풀었습니다.
맵 크기만큼의 DP 배열에 내려가는 경우의 수를 3차원으로 하여 풀었습니다.

## ⏳ 회고
기본적인 DP 문제였습니다.
