### PR TITLE
[20251213] BOJ / G2 / 반도체 설계 / 한종욱

### DIFF
--- a/Ukj0ng/202512/13 BOJ G2 반도체 설계.md
+++ b/Ukj0ng/202512/13 BOJ G2 반도체 설계.md
@@ -1,0 +1,67 @@
+```
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static int[] arr, lis;
+    private static int N;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        int answer = DP();
+
+        bw.write(answer + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        arr = new int[N];
+        lis = new int[N];
+
+        for (int i = 0; i < N; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+    }
+
+    private static int DP() {
+        int len = 0;
+
+        for (int i = 0; i < N; i++) {
+            int key = arr[i];
+
+            if (len == 0 || lis[len-1] < key) {
+                lis[len] = key;
+                len++;
+            } else {
+                int index = binarySearch(len-1, key);
+                lis[index] = key;
+            }
+        }
+
+        return len;
+    }
+
+    private static int binarySearch(int right, int key) {
+        int left = 0;
+
+        while (left < right) {
+            int mid = left + (right-left)/2;
+
+            if (lis[mid] >= key) {
+                right = mid;
+            } else {
+                left = mid+1;
+            }
+        }
+
+        return right;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2352
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
반도체 포트가 안 교차하고 제일 많이 연결할 수 있는 개수는?
## 🔍 풀이 방법
lis배열의 상태를 '길이가 i+1인 증가 부분 수열 중에서, 가장 작은 끝나는 값'으로 설정하고, 가장 작은 끝나는 값의 위치를 구할 때 이분 탐색을 사용했다.
## ⏳ 회고
3번째 푸는데 이제야 좀 이해가 된다. 