### PR TITLE
[20251213] BOJ / G5 / 4와 7 / 강신지

### DIFF
--- a/ksinji/202512/13 BOJ 4와 7.md
+++ b/ksinji/202512/13 BOJ 4와 7.md
@@ -1,0 +1,38 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        long k = Long.parseLong(br.readLine());
+
+        long cnt = 2;
+        int len = 1;
+
+        while (k > cnt) {
+            k -= cnt;
+            cnt *= 2;
+            len++;
+        }
+
+        StringBuilder sb = new StringBuilder();
+
+        while (len > 0) {
+            long half = cnt / 2;
+
+            if (k <= half) {
+                sb.append('4');
+            } else {
+                sb.append('7');
+                k -= half;
+            }
+
+            cnt = half;
+            len--;
+        }
+
+        System.out.println(sb);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2877
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
창용이는 4와 7로만 이루어진 수를 좋아한다.
좋아하는 수 중에 k번째 작은 값을 구하라.
## 🔍 풀이 방법
4와 7로만 이루어진 수들을 길이별로 사전순 정렬하면, 같은 길이에서는 앞 절반이 4로 시작하고 뒤 절반이 7로 시작한다.
k번째 수가 어떤 길이인지 먼저 판별한 다음 앞/뒤 절반 중 어디에 속하는지를 반복적으로 판별하며 자릿수를 하나씩 결정.
## ⏳ 회고
