### PR TITLE
[20251214] BOJ / G4 / 출근 경로 / 이준희

### DIFF
--- a/JHLEE325/202512/14 BOJ G4 출근 경로.md
+++ b/JHLEE325/202512/14 BOJ G4 출근 경로.md
@@ -1,0 +1,46 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int W = Integer.parseInt(st.nextToken());
+        int H = Integer.parseInt(st.nextToken());
+
+        int[][][][] dp = new int[W + 1][H + 1][2][2];
+
+        if (W >= 2) dp[2][1][0][0] = 1;
+        if (H >= 2) dp[1][2][1][0] = 1;
+
+        for (int x = 1; x <= W; x++) {
+            for (int y = 1; y <= H; y++) {
+
+                if (x > 1) {
+                    dp[x][y][0][0] = (dp[x][y][0][0] + dp[x - 1][y][0][0] + dp[x - 1][y][0][1]) % 100000;
+
+                    dp[x][y][0][1] = (dp[x][y][0][1] + dp[x - 1][y][1][0]) % 100000;
+                }
+
+                if (y > 1) {
+                    dp[x][y][1][0] = (dp[x][y][1][0] + dp[x][y - 1][1][0] + dp[x][y - 1][1][1]) % 100000;
+
+                    dp[x][y][1][1] = (dp[x][y][1][1] + dp[x][y - 1][0][0]) % 100000;
+                }
+            }
+        }
+
+        int answer = 0;
+        for (int d = 0; d < 2; d++) {
+            for (int t = 0; t < 2; t++) {
+                answer = (answer + dp[W][H][d][t]) % 100000;
+            }
+        }
+
+        System.out.println(answer);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/5569

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
상근이가 (1,1) 에서 (w,h)로 출근하려고 할 때
위 또는 오른쪽으로만 갈 수 있고, 한번 방향전환하면 연속으로는 못할 때
출근할 수 있는 경우의 수를 구하는 문제입니다.

## 🔍 풀이 방법
DP를 이용해서 풀었습니다.
조금 특이한 경우의 케이스로 한번 방향을 바꾸면 연속으로 못하기 때문에 플래그용과
진행 방향을 나타내는 배열을 각각 추가해서 총 4차원 DP를 사용했습니다.

## ⏳ 회고
처음엔 그래프인줄 알았는데 DP였고, 또 4개나 체크해야되서 귀찮았습니다.
