### PR TITLE
[20251215] BOJ / G5 / 넴모넴모 (Easy) / 이준희

### DIFF
--- a/JHLEE325/202512/15 BOJ G5 넴모넴모 (Easy).md
+++ b/JHLEE325/202512/15 BOJ G5 넴모넴모 (Easy).md
@@ -1,0 +1,60 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static int N, M;
+    static boolean[][] map;
+    static int answer = 0;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        map = new boolean[N][M];
+
+        dfs(0, 0);
+
+        System.out.println(answer);
+    }
+
+    static void dfs(int r, int c) {
+        if (r == N) {
+            answer++;
+            return;
+        }
+
+        int nr = r;
+        int nc = c + 1;
+        if (nc == M) {
+            nr = r + 1;
+            nc = 0;
+        }
+
+        dfs(nr, nc);
+
+        map[r][c] = true;
+
+        if (!hasFull2x2()) {
+            dfs(nr, nc);
+        }
+
+        map[r][c] = false;
+    }
+
+    static boolean hasFull2x2() {
+        for (int i = 0; i < N - 1; i++) {
+            for (int j = 0; j < M - 1; j++) {
+                if (map[i][j] && map[i + 1][j] && map[i][j + 1] && map[i + 1][j + 1]) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14712

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
격자 모양의 각 칸에 넴모를 놓거나 안놓거나 할 수 있습니다.
이 때 2*2가 뭉치지 않게 놓을 수 있는 모든 경우의 수를 구하는 문제입니다.

## 🔍 풀이 방법
백트래킹을 이용해서 모든 경우의 수를 채워가면서
2*2가 아닌 경우만 더해줬습니다.
어차피 현재 상태에서 검증만 하면 됐기 때문에 모든 경우를 다 세도 됐습니다.

## ⏳ 회고
처음에 예제를 머리로 풀어봤는데 이상하다고 생각했었는데
대각선인 경우를 생각을 안했었습니다
