### PR TITLE
[20251215] BOJ / G2 / 벽 부수고 이동하기 4 / 김민진

### DIFF
--- a/zinnnn37/202512/15 BOJ G2 벽 부수고 이동하기 4.md
+++ b/zinnnn37/202512/15 BOJ G2 벽 부수고 이동하기 4.md
@@ -2,7 +2,6 @@
 import java.awt.*;
 import java.io.*;
 import java.util.*;
-import java.util.List;
 import java.util.Queue;
 
 public class BJ_16946_벽_부수고_이동하기_4 {
@@ -19,7 +18,7 @@ public class BJ_16946_벽_부수고_이동하기_4 {
     private static int[][]               matrix;
     private static boolean[][]           visited;
     private static Queue<Point>          q;
-    private static List<Integer>         list;
+    private static Set<Integer>          set;
     private static Map<Integer, Integer> groups;
 
     public static void main(String[] args) throws IOException {
@@ -42,7 +41,7 @@ public class BJ_16946_벽_부수고_이동하기_4 {
         }
         visited = new boolean[N][M];
         q = new ArrayDeque<>();
-        list = new ArrayList<>();
+        set = new HashSet<>();
         groups = new HashMap<>();
     }
 
@@ -97,14 +96,14 @@ public class BJ_16946_벽_부수고_이동하기_4 {
                     sb.append(0);
                 } else {
                     cnt = 1;
-                    list.clear();
+                    set.clear();
                     for (int d = 0; d < 4; d++) {
                         int nx = i + dx[d];
                         int ny = j + dy[d];
 
-                        if (OOB(nx, ny) || matrix[nx][ny] == 1 || list.contains(matrix[nx][ny])) continue;
+                        if (OOB(nx, ny) || matrix[nx][ny] == 1 || set.contains(matrix[nx][ny])) continue;
 
-                        list.add(matrix[nx][ny]);
+                        set.add(matrix[nx][ny]);
                         cnt += groups.get(matrix[nx][ny]);
                     }
                     sb.append(cnt % 10);


### PR DESCRIPTION
## 🧷 문제 링크
[벽 부수고 이동하기 4](https://www.acmicpc.net/problem/16946)

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
벽이 있는 셀의 벽을 부술 때 그 위치에서 접근할 수 있는 셀의 갯수를 계산해서 맵으로 출력하기
벽이 없었다면 0으로 출력

## 🔍 풀이 방법
벽이 아닌 부분들을 그룹핑해서 벽인 부분의 사방만 확인해도 도달 가능한 범위를 구할 수 있도록 함
1은 벽이라 2부터 부여함

```
e.g.
00220
33000
30405
06070
```

벽 주변에 같은 그룹이 중복되어 인접할 수 있기 때문에 set으로 거름

## ⏳ 회고
2보다 쉬웠음
bfs 돌리면서 벽을 따로 저장하는 방법도 있네
bfs 한 번 돌 때마다 해당 그룹과 인접하는 모든 벽에 그룹 크기만큼 더해주기.. 좋은데?