### PR TITLE
[20251215] BOJ / G5 / 넴모넴모 (Easy) / 설진영

### DIFF
--- a/Seol-JY/202512/15 BOJ G5 넴모넴모 (Easy).md
+++ b/Seol-JY/202512/15 BOJ G5 넴모넴모 (Easy).md
@@ -1,0 +1,42 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int N, M;
+    static boolean[][] grid;
+    static long count = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        grid = new boolean[N][M];
+        
+        backtrack(0);
+        System.out.println(count);
+    }
+
+    static void backtrack(int pos) {
+        if (pos == N * M) {
+            count++;
+            return;
+        }
+
+        int row = pos / M;
+        int col = pos % M;
+
+        grid[row][col] = false;
+        backtrack(pos + 1);
+
+        grid[row][col] = true;
+        if (row > 0 && col > 0 && grid[row-1][col] && grid[row][col-1] && grid[row-1][col-1]) {
+            grid[row][col] = false;
+            return;
+        }
+        backtrack(pos + 1);
+        grid[row][col] = false;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14712

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
N×M 격자판에 "넴모"를 배치하는 게임
2×2 정사각형을 이루는 네 칸 모두에 넴모가 있으면 안 됨
이 조건을 만족하는 모든 배치의 가짓수를 구하는 문제

## 🔍 풀이 방법
백트래킹을 활용한 브루트포스 탐색
2×2 검사를 현재 칸 기준 좌상단 방향으로만 확인하면 됨

## ⏳ 회고
낫뱃