### PR TITLE
[20251216] BOJ / G1 / 벽 부수고 이동하기 3 / 김민진

### DIFF
--- a/zinnnn37/202512/16 BOJ G1 벽 부수고 이동하기 3.md
+++ b/zinnnn37/202512/16 BOJ G1 벽 부수고 이동하기 3.md
@@ -1,0 +1,106 @@
+```java
+import java.io.*;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class BJ_16933_벽_부수고_이동하기_3 {
+
+    private static final int[] dx = { 0, -1, 0, 1 };
+    private static final int[] dy = { -1, 0, 1, 0 };
+
+    private static BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+    private static BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static StringTokenizer st;
+
+    private static int N, M, K;
+    private static char[][]    matrix;
+    private static int[][]     visited;
+    private static Queue<Node> q;
+
+    private static class Node {
+        int     x;
+        int     y;
+        int     k;
+        int     cnt;
+        boolean isDay;
+
+        public Node(int x, int y, int k, int cnt, boolean isDay) {
+            this.x = x;
+            this.y = y;
+            this.k = k;
+            this.cnt = cnt;
+            this.isDay = isDay;
+        }
+
+    }
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+        matrix = new char[N][M];
+        for (int i = 0; i < N; i++) {
+            matrix[i] = br.readLine().toCharArray();
+        }
+
+        visited = new int[N][M];
+        for (int i = 0; i < N; i++) {
+            Arrays.fill(visited[i], Integer.MAX_VALUE);
+        }
+
+        q = new ArrayDeque<>();
+    }
+
+    private static void sol() throws IOException {
+        q.offer(new Node(0, 0, 0, 1, true));
+        visited[0][0] = 0;
+
+        while (!q.isEmpty()) {
+            Node cur = q.poll();
+
+            if (cur.x == N - 1 && cur.y == M - 1) {
+                bw.write(cur.cnt + "");
+                return;
+            }
+
+            for (int d = 0; d < 4; d++) {
+                int nx = cur.x + dx[d];
+                int ny = cur.y + dy[d];
+
+                if (OOB(nx, ny) || visited[nx][ny] <= cur.k) continue;
+
+                if (matrix[nx][ny] == '0') {
+                    visited[nx][ny] = cur.k;
+                    q.offer(new Node(nx, ny, cur.k, cur.cnt + 1, !cur.isDay));
+                } else if (cur.k < K && visited[nx][ny] > cur.k + 1) {
+                    if (cur.isDay) {
+                        visited[nx][ny] = cur.k + 1;
+                        q.offer(new Node(nx, ny, cur.k + 1, cur.cnt + 1, false));
+                    } else {
+                        q.offer(new Node(cur.x, cur.y, cur.k, cur.cnt + 1, true));
+                    }
+                }
+            }
+        }
+        bw.write("-1");
+    }
+
+    private static boolean OOB(int x, int y) {
+        return x < 0 || N <= x || y < 0 || M <= y;
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[벽 부수고 이동하기 3](https://www.acmicpc.net/problem/16933)

## 🧭 풀이 시간
15분 + 20분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
벽 부수고 이동하기 2와 동일한데 낮에만 벽을 부술 수 있음
밤에 대기하는 것도 방문거리가 늘어나는 것으로 간주함

## 🔍 풀이 방법
처음에는 2의 풀이방법에서 벽이 나오면 낮에는 부수고 밤에는 `cnt + 2`함
근데 오래걸려서 `visited`를 2차원 `int` 배열로 바꾸고 벽을 얼마나 부쉈는지 저장하게 수정
더 적은 횟수로 벽을 부수고 칸에 도달한 경우가 있으면 거르는 로직 추가함

## ⏳ 회고
골1은 확실히 어렵네