### PR TITLE
[20251217] PGM / Lv2 / 카펫 / 이종환

### DIFF
--- a/0224LJH/202512/17 PGM 카펫.md
+++ b/0224LJH/202512/17 PGM 카펫.md
@@ -1,0 +1,28 @@
+```java
+import java.io.*;
+import java.util.*;
+
+class Solution {
+    public int[] solution(int brown, int yellow) {
+        int len = brown+4;
+        int half = len/2;
+        int ans1 = -1;
+        int ans2 = -1;
+        int[] answer = new int[2];
+        
+        for (int width = half-3; width >= 3 ; width--){
+            int height = half-width;
+            int temp = 0;
+            if ((width-2)*(height-2) == yellow){
+                answer[0] = width;
+                answer[1] = height;
+                return answer;
+            }
+        }
+        
+        
+        
+        return answer;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/42842

## 🧭 풀이 시간
10분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
Leo는 카펫을 사러 갔다가 아래 그림과 같이 중앙에는 노란색으로 칠해져 있고 테두리 1줄은 갈색으로 칠해져 있는 격자 모양 카펫을 봤습니다.

Leo가 본 카펫에서 갈색 격자의 수 brown, 노란색 격자의 수 yellow가 매개변수로 주어질 때 카펫의 가로, 세로 크기를 순서대로 배열에 담아 return 하도록 solution 함수를 작성해주세요.

## 🔍 풀이 방법
높이와 너비의 합을 구한후, 하나씩 대입하면 끝

## ⏳ 회고
