### PR TITLE
[20251218] BOJ / G5 / 도넛 행성 / 이준희

### DIFF
--- a/JHLEE325/202512/18 BOJ G5 도넛 행성.md
+++ b/JHLEE325/202512/18 BOJ G5 도넛 행성.md
@@ -1,0 +1,73 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    
+    static class Point {
+        int r, c;
+        public Point(int r, int c) {
+            this.r = r;
+            this.c = c;
+        }
+    }
+    
+    static int N, M;
+    static int[][] map;
+    static boolean[][] visited;
+
+    static int[] dr = {-1, 1, 0, 0};
+    static int[] dc = {0, 0, -1, 1};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        map = new int[N][M];
+        visited = new boolean[N][M];
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        int area = 0;
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                if (map[i][j] == 0 && !visited[i][j]) {
+                    bfs(i, j);
+                    area++;
+                }
+            }
+        }
+
+        System.out.println(area);
+    }
+
+    static void bfs(int sr, int sc) {
+        Queue<Point> queue = new LinkedList<>();
+        queue.add(new Point(sr, sc));
+        visited[sr][sc] = true;
+
+        while (!queue.isEmpty()) {
+            Point current = queue.poll();
+
+            for (int i = 0; i < 4; i++) {
+                int nr = (current.r + dr[i] + N) % N;
+                int nc = (current.c + dc[i] + M) % M;
+
+                if (!visited[nr][nc] && map[nr][nc] == 0) {
+                    visited[nr][nc] = true;
+                    queue.add(new Point(nr, nc));
+                }
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/27211

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
끝이 없이 회전되는 맵에서 0이면 빈칸, 1이면 숲일 때 빈칸끼리 묶이면 구역입니다.
이 때 순회하면서 총 구역의 갯수를 구하는 문제입니다.

## 🔍 풀이 방법
BFS를 이용해서 순회하면서 빈칸을 돌면서 방문처리 합니다.
1이 아닌 빈칸을 모두 돌았을 때 구역이 한개 추가됩니다.
전부 순회했을 경우에 구역 갯수를 출력하였습니다.

## ⏳ 회고
간단한 BFS문제였는데 원형이다보니 인덱스 생각을 했어야 했습니다.
