### PR TITLE
[20251219] BOJ / G3 / 소가 길을 건너간 이유 6 / 한종욱

### DIFF
--- a/Ukj0ng/202512/19 BOJ G3 소가 길을 건너간 이유 6.md
+++ b/Ukj0ng/202512/19 BOJ G3 소가 길을 건너간 이유 6.md
@@ -1,0 +1,112 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static final int[] dx = {1, 0, -1, 0};
+    private static final int[] dy = {0, 1, 0, -1};
+    private static boolean[][] map, visited;
+    private static boolean[][][] block;
+    private static int[][] cows;
+    private static int N, K, R, answer;
+
+    public static void main(String[] args) throws IOException {
+        init();
+
+        int temp = 0;
+        for (int i = 0; i < K; i++) {
+            temp += BFS(cows[i][0], cows[i][1]);
+            map[cows[i][0]][cows[i][1]] = false;
+        }
+
+        bw.write(answer-temp + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        R = Integer.parseInt(st.nextToken());
+        answer = K*(K-1)/2;
+
+        map = new boolean[N+1][N+1];
+        visited = new boolean[N+1][N+1];
+        block = new boolean[N+1][N+1][4];
+        cows = new int[K][2];
+
+        for (int i = 0; i < R; i++) {
+            st = new StringTokenizer(br.readLine());
+            int r1 = Integer.parseInt(st.nextToken());
+            int c1 = Integer.parseInt(st.nextToken());
+            int r2 = Integer.parseInt(st.nextToken());
+            int c2 = Integer.parseInt(st.nextToken());
+
+            if (r1-r2 == 0) {
+                if (c1-c2 == 1) {
+                    block[r1][c1][3] = true;
+                    block[r2][c2][1] = true;
+                } else {
+                    block[r1][c1][1] = true;
+                    block[r2][c2][3] = true;
+                }
+            } else {
+                if (r1-r2 == 1) {
+                    block[r1][c1][2] = true;
+                    block[r2][c2][0] = true;
+                } else {
+                    block[r1][c1][0] = true;
+                    block[r2][c2][2] = true;
+                }
+            }
+        }
+
+        for (int i = 0; i < K; i++) {
+            st = new StringTokenizer(br.readLine());
+            int r = Integer.parseInt(st.nextToken());
+            int c = Integer.parseInt(st.nextToken());
+
+            map[r][c] = true;
+            cows[i][0] = r;
+            cows[i][1] = c;
+        }
+    }
+
+    private static int BFS(int x, int y) {
+        Queue<int[]> q = new ArrayDeque<>();
+        for (int i = 1; i <= N; i++) {
+            Arrays.fill(visited[i], false);
+        }
+        visited[x][y] = true;
+        int count = 0;
+        q.add(new int[]{x, y});
+
+        while (!q.isEmpty()) {
+            int[] current = q.poll();
+            int cx = current[0];
+            int cy = current[1];
+
+            for (int i = 0; i < 4; i++) {
+                int nx = cx + dx[i];
+                int ny = cy + dy[i];
+
+                if (OOB(nx, ny) || block[cx][cy][i] || visited[nx][ny]) continue;
+                if (map[nx][ny]) count++;
+                visited[nx][ny] = true;
+                q.add(new int[] {nx, ny});
+            }
+        }
+
+        return count;
+    }
+
+    private static boolean OOB(int nx, int ny) {
+        return nx < 1 || nx > N || ny < 1 || ny > N;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14466
## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
소가 길을 건너지 않고 만날 수 있는 쌍의 개수는?
## 🔍 풀이 방법
주어진 길은 사실 건너면 안되는 것이기 때문에, 각 목초지마다 배열을 만들어 진행 방향을 `true`, `false`로 풀었다. 

그 설정만 하고 소들을 하나씩 탐색하면서 다른 소들과 만나는 개수를 측정한다. 
한번 탐색한 소를 사라지게 하면 중복 측정을 막을 수 있다. 
## ⏳ 회고
오랜만에 간단한 BFS에 생각 한 스푼의 문제라 재밌었다.