### PR TITLE
[20251219] BOJ / P5 / 레몬컵 출제하기 / 권혁준

### DIFF
--- a/khj20006/202512/19 BOJ P5 레몬컵 출제하기.md
+++ b/khj20006/202512/19 BOJ P5 레몬컵 출제하기.md
@@ -1,0 +1,70 @@
+```java
+import java.sql.Array;
+import java.util.*;
+import java.io.*;
+
+public class Main {
+
+    static BufferedReader br;
+    static BufferedWriter bw;
+    static StringTokenizer st;
+
+    static int N, K;
+    static String[] arr;
+    static boolean[] exist;
+
+    public static void main(String[] args) throws Exception {
+
+        input();
+        solve();
+
+    }
+
+    public static void input() throws Exception {
+        br = new BufferedReader(new InputStreamReader(System.in));
+
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        arr = new String[N];
+        exist = new boolean[1<<K];
+        for(int i=0;i<N;i++) arr[i] = br.readLine();
+
+        br.close();
+    }
+
+    public static void solve() throws Exception {
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        int Z = 0;
+        for(int i=0;i<N;i++) {
+            if(Z == 1) {
+                String rev = "";
+                for(int j=K-1;j>=0;j--) rev += arr[i].charAt(j);
+                arr[i] = rev;
+            }
+            int a = Integer.parseInt(arr[i], 2);
+            if(exist[a]) {
+                bw.write("WellKnown\n");
+                Z = 0;
+            }
+            else {
+                bw.write("AdHoc\n");
+                Z = 1;
+            }
+            bck(a);
+        }
+
+        bw.close();
+    }
+
+    public static void bck(int a) {
+        if(exist[a]) return;
+        exist[a] = true;
+        for(int i=0;i<K;i++) if((a & (1<<i)) != 0) {
+            bck(a ^ (1<<i));
+        }
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/34253

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
문제 N개가 출제된 순서대로 주어진다. 각 문제는 길이 K인 이진수 형태이다.
문제 A가 문제 B보다 먼저 출제되었고, A에서 사용하는 알고리즘이 B에서 사용하는 알고리즘을 모두 포함한다면 B를 **웰논**이라고 하고, 그렇지 않으면 **애드혹**이라 정의한다.

문제 A의 직전 문제가 **웰논**이었다면,
문제 A의 이진수에서 i번째 비트가 1인 경우에 i번 알고리즘을 사용한다는 의미이다.
직전 문제가 **애드혹**이었다면,
문제 A의 이진수에서 i번째 비트가 1인 경우에 (K-j+1)번 알고리즘을 사용한다는 의미이다.

## 🔍 풀이 방법
`exist[a] = 이진수 a가 웰논이면 true, 아니면 false`라는 boolean 배열을 관리한다.
문제가 주어질 때마다 exist를 갱신해 나간다. 어떤 이진수 a가 주어지면, a & b = b를 만족하는 모든 b들은 이후에 **웰논**이 된다.

갱신 한 번에는 최대 O(KlogK)이지만, 갱신 과정을 활성 비트를 하나씩 끄는 방식의 재귀 함수로 짜면 갱신 N번에도 amortized O(KlogK)이다.
-> 결국 그냥 `Bitmask DP` 기본 형태가 된다.

## ⏳ 회고
흠