### PR TITLE
[20251219] BOJ / G5 / 흙길 보수하기 / 이인희

### DIFF
--- a/LiiNi-coder/202512/19 BOJ 흙길 보수하기.md
+++ b/LiiNi-coder/202512/19 BOJ 흙길 보수하기.md
@@ -1,0 +1,43 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int N = Integer.parseInt(st.nextToken());
+		int L = Integer.parseInt(st.nextToken());
+
+		int[][] sections = new int[N][2];
+		for(int i = 0; i < N; i++){
+			st = new StringTokenizer(br.readLine());
+			sections[i][0] = Integer.parseInt(st.nextToken());
+			sections[i][1] = Integer.parseInt(st.nextToken());
+		}
+		Arrays.sort(sections, (a, b) -> a[0] - b[0]);
+		int coveredEnd = 0;
+		int answer = 0;
+
+		for(int i = 0; i < N; i++){
+			int start = sections[i][0];
+			int end = sections[i][1];
+			if(coveredEnd >= end){
+				continue;
+			}
+
+			int realStart = Math.max(coveredEnd, start);
+			int remain = end - realStart;
+			int count = remain / L;
+			if(remain % L != 0){
+				count++;
+			}
+			answer += count;
+			coveredEnd = realStart + count * L;
+		}
+
+		System.out.println(answer);
+	}
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1911
## 🧭 풀이 시간
40 분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
- 웅덩이가 주어지고, 널빤지 규격이 주어질때, 가장 모든 웅덩이를 가리기위한 널빤지 최소 개수
## 🔍 풀이 방법
- 그리디(웅덩이 시작점 오름차순)
## ⏳ 회고
- easy