### PR TITLE
[20251221] BOJ / G5 / 현수막 걸기 / 김민진

### DIFF
--- a/zinnnn37/202512/21 BOJ G5 현수막 걸기.md
+++ b/zinnnn37/202512/21 BOJ G5 현수막 걸기.md
@@ -1,0 +1,77 @@
+```java
+import java.io.*;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BJ_30459_현수막_걸기 {
+
+    private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static       StringTokenizer st;
+
+    private static int N, M, R;
+    private static int[] piles, flagpoles;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        R = Integer.parseInt(st.nextToken());
+
+        piles = new int[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            piles[i] = Integer.parseInt(st.nextToken());
+        }
+
+        flagpoles = new int[M];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < M; i++) {
+            flagpoles[i] = Integer.parseInt(st.nextToken());
+        }
+        Arrays.sort(flagpoles);
+    }
+
+    private static void sol() throws IOException {
+        double maxArea = -1;
+        for (int i = 0; i < N; i++) {
+            for (int j = i + 1; j < N; j++) {
+                int    bottom    = Math.abs(piles[i] - piles[j]);
+                double maxHeight = 2.0 * R / bottom;
+
+                int idx = upperBound(maxHeight) - 1;
+                if (idx >= 0) {
+                    double area = flagpoles[idx] * bottom / 2.0;
+                    maxArea = Math.max(maxArea, area);
+                }
+            }
+        }
+        bw.write(maxArea > 0 ? String.format("%.1f", maxArea) : "-1");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static int upperBound(double target) {
+        int left  = 0;
+        int right = flagpoles.length;
+
+        while (left < right) {
+            int mid = left + (right - left) / 2;
+
+            if (flagpoles[mid] > target) {
+                right = mid;
+            } else {
+                left = mid + 1;
+            }
+        }
+        return left;
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[현수막 걸기](https://www.acmicpc.net/problem/30459)

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
말뚝과 깃대가 있고 걸 수 있는 현수막의 최대 넓이가 주어짐
말뚝을 두 개 골라서 그 정가운데 깃대를 세워서 나오는 현수막의 크기 중 최댓값은

## 🔍 풀이 방법
upperBound
말뚝을 두 개 골라서 세울 수 있는 깃대의 최대 높이를 계산
깃대 정렬 후 이분탐색을 돌리면서 깃대 최대 높이 기준으로 upperBound 진행
target보다 큰 가장 첫 번째 인덱스가 반환되므로 그 -1한 위치의 깃대로 현수막을 세우는 것이 최선
말뚝을 선택하는 모든 경우의 수를 확인해서 가장 큰 현수막의 넓이 구하기

## ⏳ 회고
3번 이분탐색이었던 것 같음