### PR TITLE
[20251221] BOJ / G5 / 옥상 정원 꾸미기 / 이인희

### DIFF
--- a/LiiNi-coder/202512/21 BOJ 옥상 정원 꾸미기.md
+++ b/LiiNi-coder/202512/21 BOJ 옥상 정원 꾸미기.md
@@ -1,0 +1,26 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		long answer = 0L;
+		
+		Deque<Integer> stack = new ArrayDeque<>();
+
+		for(int i = 0; i < N; i++){
+			int height = Integer.parseInt(br.readLine());
+			while(!stack.isEmpty() && stack.peekLast() <= height){
+				stack.pollLast();
+			}
+
+			answer += stack.size();
+			stack.offerLast(height);
+		}
+		System.out.println(answer);
+	}
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/6198
## 🧭 풀이 시간
50 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 일렬로 건물 높이가 주어지고, 각 건물마다 자신의 오른쪽으로만 보는데, 자신의 건물 높이보다 큰것이 나올때까지의 건물 천장을 볼수있을때, 각 건물마다 볼수있는 천장 개수 합
## 🔍 풀이 방법
- 스택
## ⏳ 회고
- 스택이라는 힌트가 없었다면 떠오르기 쉽지않은 문제