### PR TITLE
[20251222] BOJ / G4 / 오큰수 / 이인희

### DIFF
--- a/LiiNi-coder/202512/22 BOJ 오큰수.md
+++ b/LiiNi-coder/202512/22 BOJ 오큰수.md
@@ -1,0 +1,36 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(
+			new InputStreamReader(System.in)
+		);
+		int N = Integer.parseInt(br.readLine());
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int[] arr = new int[N];
+		for(int i = 0; i < N; i++){
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		int[] answer = new int[N];
+		Arrays.fill(answer, -1);
+		Deque<Integer> stack = new ArrayDeque<>();
+
+		for(int i = 0; i < N; i++){
+			while(!stack.isEmpty() && arr[stack.peekLast()] < arr[i]){
+				int index = stack.pollLast();
+				answer[index] = arr[i];
+			}
+			stack.offerLast(i);
+		}
+		StringBuilder sb = new StringBuilder();
+		for(int v : answer){
+			sb.append(v).append(" ");
+		}
+
+		System.out.println(sb.toString());
+	}
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17298
## 🧭 풀이 시간
40 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 수열이 주어지고, 특정 수의 오큰수란, 해당 수의 오른쪽 있는 숫자 중에서 특정숫자보다 크면서 가장 가까이 있는 것을 말하는데, 수열의 각 원소마다의 오큰수를 모두 출력
## 🔍 풀이 방법
- stack
## ⏳ 회고
- 약간 N탐색하면서 오른쪽에있는 부분중에서 어떤걸 계속 구해나간다는것은 stack을 의심하자