### PR TITLE
[20251222] BOJ / P3 / 수열의 개수 NKD / 권혁준

### DIFF
--- a/khj20006/202512/22 BOJ P3 수열의 개수 NKD.md
+++ b/khj20006/202512/22 BOJ P3 수열의 개수 NKD.md
@@ -1,0 +1,77 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+
+    static BufferedReader br;
+    static BufferedWriter bw;
+    static StringTokenizer st;
+
+    static final long MOD = (long)1e9 + 7;
+    static int N, K, D;
+    static long[] dp;
+
+    public static void main(String[] args) throws Exception {
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        input();
+        solve();
+
+        bw.close();
+    }
+
+    public static void input() throws Exception {
+        br = new BufferedReader(new InputStreamReader(System.in));
+
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        D = Integer.parseInt(st.nextToken());
+
+        br.close();
+    }
+
+    public static void solve() throws Exception {
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        if(K > 446) {
+            bw.write("0");
+            return;
+        }
+        if(K == 1) {
+            bw.write(N <= D ? "1" : "0");
+            return;
+        }
+
+        dp = new long[N+2];
+        for(int k=1;k<=K;k++) {
+            long[] pre = new long[N+2];
+            if(k == 1) {
+                for(int i=1;i<=D;i++) {
+                    if(2*i+1 <= N) pre[2*i+1] = (pre[2*i+1] + 1) % MOD;
+                    if(2*i+D+1 <= N) pre[2*i+D+1] = (pre[2*i+D+1] + MOD - 1) % MOD;
+                }
+            }
+            else {
+                int limit = (long)k * D >= (long)N ? N : k * D;
+                for(int i=1;i<=limit;i++) {
+                    if(2*limit+1 <= N) pre[2*limit+1] = (pre[2*limit+1] + dp[i]) % MOD;
+                    if(2*limit+D+1 <= N) pre[2*limit+D+1] = (pre[2*limit+D+1] + MOD - dp[i]) % MOD;
+                }
+            }
+
+            long s = 0;
+            for(int i=1;i<=N;i++) {
+                s = (s + pre[i]) % MOD;
+                pre[i] = s;
+            }
+            for(int i=1;i<=N;i++) dp[i] = pre[i];
+        }
+        bw.write(dp[N] + "\n");
+
+        bw.close();
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1336

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
아래 조건을 만족하는 길이 K인 자연수 수열 A의 개수를 구해보자.
<img width="246" height="129" alt="image" src="https://github.com/user-attachments/assets/89f16c88-9bee-4577-aa47-12225d1bc7b1" />

## 🔍 풀이 방법
K > 446이면? 못 만듬.

dp[k][s] = s번 돌까지 k개의 돌을 지나온 경우의 수라고 정의.
dp[1][x] = 1 (1 <= x <= D)

내가 현재 s번 돌에 있다면, 2s+1부터 2s+D까지 갈 수 있음
-> imos로 다음 스텝의 DP값을 계산하도록.

## ⏳ 회고
아오 왜 틀리는거야