### PR TITLE
[20251223] BOJ / G3 / 준오는 심술쟁이!! / 한종욱

### DIFF
--- a/Ukj0ng/202512/23 BOJ G3 준오는 심술쟁이!!.md
+++ b/Ukj0ng/202512/23 BOJ G3 준오는 심술쟁이!!.md
@@ -1,0 +1,51 @@
+```
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static final int MOD = (int) 1e9+7;
+    private static int[][] dp;
+    private static int s;
+    private static String str;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        DP();
+
+        bw.write(dp[str.length()][s] + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        s = Integer.parseInt(br.readLine());
+        str = br.readLine();
+
+        dp = new int[str.length()+1][s+1];
+
+        dp[0][0] = 1;
+        for (int i = 1; i <= str.length(); i++) {
+            dp[i][0] = 1;
+        }
+        for (int i = 1; i <= s && i <= 25; i++) {
+            dp[1][i] = 1;
+        }
+    }
+
+    private static void DP() {
+        for (int i = 2; i <= str.length(); i++) {
+            for (int j = 1; j <= s; j++) {
+                if (j >= 26) {
+                    int val = (dp[i][j-1] + dp[i-1][j]) % MOD;
+                    dp[i][j] = (val - dp[i-1][j-26] + MOD) % MOD;
+                } else {
+                    dp[i][j] = (dp[i][j-1] + dp[i-1][j]) % MOD;
+                }
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14437
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
문제를 재해석하면, N개의 칸에 0~25까지의 수를 채워 넣을 때, 그 합이 s인 경우의 수는?
## 🔍 풀이 방법
`dp[i][j]`: i번째 칸까지의 합이 j인 경우의 수
로 상태를 정의했다. 
그렇게 해보면, $dp[i][j] = dp[i-1][j] + dp[i-1][j-1] + ... + dp[i-1][j-25]$ 가 된다. 

그런데 이렇게 문제를 풀면 3중 for문이 나와 시간초과가 발생한다. 
- $dp[i][j] = dp[i-1][j] + dp[i-1][j-1] + ... + dp[i-1][j-25]$
- $dp[i][j-1] = dp[i-1][j-1] + dp[i-1][j-2] + ... + dp[i-1][j-26]$
두 점화식으로 미루어 보았을 때, $dp[i][j] = dp[i-1][j] + dp[i][j-1] - dp[i-1][j-26]$으로 두 식을 합칠 수 있다. 
다음과 같은 누적합을 통해서 답을 구하면 된다. 
## ⏳ 회고
MOD를 나눌 때, 위 식에선 음수가 될 수 도 있다. 따라서 MOD를 더한 다음 나머지를 구했는데, 이 식을 한꺼번에 계산하면 overflow가 발생할 수 있다. 이걸 몰라서 틀렸다. 더할 때, 한꺼번에 더하는 걸 습관화하지말고 자료형에 유의해서 계산하는 습관을 들이자. 