### PR TITLE
[20251223] BOJ / G5 / 두 개의 탑 / 김민진

### DIFF
--- a/zinnnn37/202512/23 BOJ G5 두 개의 탑.md
+++ b/zinnnn37/202512/23 BOJ G5 두 개의 탑.md
@@ -1,0 +1,54 @@
+```java
+import java.io.*;
+
+public class BJ_2118_두_개의_탑 {
+
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+    private static int N, ans, half;
+    private static int[] dist;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+        ans = 0;
+        dist = new int[2 * N];
+
+        for (int i = 0; i < N; i++) {
+            dist[i] = Integer.parseInt(br.readLine());
+            dist[i + N] = dist[i];
+            half += dist[i];
+        }
+        half /= 2;
+    }
+
+    private static void sol() throws IOException {
+        int left    = 0;
+        int right   = 0;
+        int curDist = 0;
+
+        while (left < N) {
+            while (true) {
+                curDist += dist[right++];
+                if (curDist > half) {
+                    curDist -= dist[--right];
+                    break;
+                }
+            }
+
+            ans = Math.max(ans, curDist);
+            curDist -= dist[left++];
+        }
+        bw.write(ans + "");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[두 개의 탑](https://www.acmicpc.net/problem/2118)

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
원형으로 놓인 탑이 있고 바로 옆 탑과의 사이 거리가 주어짐
임의의 두 탑 사이의 거리는 시계방향, 반시계방향으로 잰 거리 중 짧은 것
임의의 두 탑 사이의 거리 중 최댓값은?

## 🔍 풀이 방법
투포인터
원형으로 구성되니까 그냥 배열 길이를 `2N`으로 둬서 일직선상에 탑이 중복으로 놓였다고 가정하고 풀이함
시계방향, 반시계방향으로 잰 거리 중 짧은 것이라서 `전체 거리 / 2`를 넘을 수 없으니까 `left`를 증가시키는 조건을 이걸로 사용

## ⏳ 회고
일일이 현재 거리 안 구하고 누적합 넣어도 되겠네..