### PR TITLE
[20251224] BOJ / G3 / 가장높은탑쌓기 / 한종욱

### DIFF
--- a/Ukj0ng/202512/24 BOJ G3 가장높은탑쌓기.md
+++ b/Ukj0ng/202512/24 BOJ G3 가장높은탑쌓기.md
@@ -1,0 +1,69 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static Deque<Integer> deque = new ArrayDeque<>();
+    private static int[][] towers;
+    private static int[] dp, history;
+    private static int N;
+
+    public static void main(String[] args) throws IOException {
+        init();
+
+        bw.write(deque.size() + "\n");
+        while (!deque.isEmpty()) {
+            bw.write(deque.pollFirst() + "\n");
+        }
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+        towers = new int[N][4];
+        dp = new int[N];
+        history = new int[N];
+
+        Arrays.fill(history, -1);
+
+        int len = 0;
+        int index = -1;
+
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            towers[i][0] = Integer.parseInt(st.nextToken());
+            towers[i][1] = Integer.parseInt(st.nextToken());
+            towers[i][2] = Integer.parseInt(st.nextToken());
+            towers[i][3] = i + 1;
+        }
+
+        Arrays.sort(towers, (o1, o2) -> Integer.compare(o2[0], o1[0]));
+
+        for (int i = 0; i < N; i++) {
+            dp[i] = towers[i][1];
+
+            for (int j = 0; j < i; j++) {
+                if (towers[j][2] > towers[i][2]) {
+                    if (dp[j] + towers[i][1] > dp[i]) {
+                        dp[i] = dp[j] + towers[i][1];
+                        history[i] = j;
+                    }
+                }
+            }
+            if (dp[i] > len) {
+                len = dp[i];
+                index = i;
+            }
+        }
+
+        while (index != -1) {
+            deque.addLast(towers[index][3]);
+            index = history[index];
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2655
## 🧭 풀이 시간
100분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
벽돌마다 밑면, 무게, 높이가 주어지는데, 벽돌을 쌓을 때 제일 높게 쌓는 경우의 벽돌 사용 개수와 각 인덱스를 순서대로 출력하라. 
- 벽돌은 밑면이 넓은 것에서 좁은 것 순으로 쌓여야 한다.
- 벽돌은 무게가 무거운 것에서 가벼운 것 순으로 쌓여야 한다. 
## 🔍 풀이 방법
일단 밑면의 넓이를 기준으로 내림차순으로 정렬했다. 
그렇게 순차적으로 탐색해야 밑면은 무시할 수 있기 때문이다. 
`dp[i]` = i번째 벽돌을 가장 위에 쌓았을 때의 최대 높이 로 상태정의하고
i번째보다 작은 벽돌들을 순차적으로 탐색하면서 무게 조건을 확인해 dp[i]보다 큰 것이 있으면 그것으로 갱신한다. 
## ⏳ 회고
LIS 어려워~. 비슷한 문제를 계속 풀어봐야겠어.