### PR TITLE
[20251224] BOJ / G2 / 수열과 개구리 / 김민진

### DIFF
--- a/zinnnn37/202512/24 BOJ G2 수열과 개구리.md
+++ b/zinnnn37/202512/24 BOJ G2 수열과 개구리.md
@@ -1,0 +1,97 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class BJ_32294_수열과_개구리 {
+
+    private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static final StringBuilder   sb = new StringBuilder();
+    private static       StringTokenizer st;
+
+    private static int   N;
+    private static int[] pos, sec;
+    private static long[]          dist;
+    private static List<Integer>[] graph;
+    private static Queue<Node>     pq;
+
+    private static class Node implements Comparable<Node> {
+        int  val;
+        long cost;
+
+        public Node(int val, long cost) {
+            this.val = val;
+            this.cost = cost;
+        }
+
+        @Override
+        public int compareTo(Node o) {
+            return Long.compare(cost, o.cost);
+        }
+
+    }
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+
+        graph = new ArrayList[N + 2];
+        for (int i = 0; i <= N + 1; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        pos = new int[N + 2];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= N; i++) {
+            pos[i] = Integer.parseInt(st.nextToken());
+            graph[Math.min(i + pos[i], N + 1)].add(i);
+            graph[Math.max(i - pos[i], 0)].add(i);
+        }
+
+        sec = new int[N + 2];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= N; i++) {
+            sec[i] = Integer.parseInt(st.nextToken());
+        }
+
+        dist = new long[N + 2];
+        Arrays.fill(dist, Long.MAX_VALUE);
+        dist[0] = 0;
+        dist[N + 1] = 0;
+        pq = new PriorityQueue<>();
+    }
+
+    private static void sol() throws IOException {
+        pq.offer(new Node(0, 0));
+        pq.offer(new Node(N + 1, 0));
+
+        while (!pq.isEmpty()) {
+            Node cur = pq.poll();
+
+            if (cur.cost > dist[cur.val]) continue;
+
+            for (int next : graph[cur.val]) {
+                long newDist = sec[next] + cur.cost;
+
+                if (newDist < dist[next]) {
+                    dist[next] = newDist;
+                    pq.offer(new Node(next, dist[next]));
+                }
+            }
+        }
+
+        for (int i = 1; i <= N; i++) {
+            sb.append(dist[i]).append(" ");
+        }
+        bw.write(sb.toString());
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[수열과 개구리](https://www.acmicpc.net/problem/32294)

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
수열이 두 개 주어짐
`a`는 해당 인덱스에서 어디로 이동가능한지
`b`는 이동하는데 걸리는 시간이 저장됨

`1 ~ N`까지가 범위임
임의의 인덱스에서 위 범위를 벗어나는데 걸리는 최소시간 모두 출력하기

## 🔍 풀이 방법
다익스트라
`1 ~ N`까지가 범위이니까 역으로 `0`과 `N + 1`부터 다익스트라 시작함
`N + 1`까지 참조해야해서 배열 길이 `N + 2`로 초기화 필요
다익스트라 방법은 똑같은데 가중치가 정수 범위를 넘어가므로 `long`으로 계산해야함

## ⏳ 회고
`PriorityQueue`인데 `ArrayDeque` 써놓고 왜 시간초과지 이러고 있었음