### PR TITLE
[20251226] BOJ / P5 / Clubbing / 권혁준

### DIFF
--- a/khj20006/202512/26 BOJ P5 Clubbing.md
+++ b/khj20006/202512/26 BOJ P5 Clubbing.md
@@ -1,0 +1,47 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+
+int N;
+bitset<131072> v;
+int cnt[17]{};
+
+void bck(int state) {
+    if(v[state]) return;
+    v[state].flip();
+    for(int i=0;i<17;i++) if(!(state & (1<<i))) {
+        bck(state | (1<<i));
+    }
+}
+
+int main() {
+    cin.tie(0)->sync_with_stdio(0);
+
+    v[131071].flip();
+
+    cin>>N;
+    for(int i=0;i<N;i++) {
+        string a;
+        cin>>a;
+        int state = 0;
+        for(char c : a) state |= (1<<(c-'a'));
+        bck(state);
+    }
+    
+    string str;
+    cin>>str;
+    long long ans = 0;
+    int state = 0;
+    for(int i=0,j=-1;i<str.size();i++) {
+        while(j<(int)str.size()-1 && !v[state]) {
+            j++;
+            if(!cnt[str[j]-'a']++) state |= (1<<(str[j]-'a'));
+        }
+        if(v[state]) ans += str.size() - j;
+        if(!--cnt[str[i]-'a']) state ^= (1<<(str[i]-'a'));
+    }
+    
+    cout<<ans;
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/30573

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
17명의 학생을 각각 알파벳 a부터 q까지로 나타낸다.
N개의 동아리가 주어지고, 각 동아리에 속한 학생들이 문자열 p[i]로 주어진다.
학생들의 상담 일정을 나타내는 문자열 Q가 주어진다.

Q의 구간 [a,b]에 속한 모든 학생들을 모아서 상담을 할 때, N개의 동아리 중 적어도 하나의 동아리에 속한 학생들이 모두 포함되도록 하는 구간의 개수를 구해보자.

## 🔍 풀이 방법
어떤 학생 집합 s가 적어도 하나의 동아리에 속한 학생들이 모두 포함되어 있다고 가정하자. 그리고 이를 f[s] = 1이라고 두자.
그러면 s & t = s인 모든 t에 대해 f[t] = 1이다.
-> `백트래킹`으로 f값이 1이 되는 모든 집합들을 구한다.

이후, 일정 문자열에서 `투 포인터`로 f가 1인 구간을 세준다.

## ⏳ 회고
ez