### PR TITLE
[20251227] BOJ / G4 / 오렌지 출하 / 한종욱

### DIFF
--- a/Ukj0ng/202512/27 BOJ G4 오렌지 출하.md
+++ b/Ukj0ng/202512/27 BOJ G4 오렌지 출하.md
@@ -1,0 +1,51 @@
+```
+import java.io.*;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static final long INF = (long)2e14;
+    private static long[] dp;
+    private static int[] oranges;
+    private static int N, M, K;
+
+    public static void main(String[] args) throws IOException {
+        init();
+
+        bw.write(dp[N] + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+        oranges = new int[N+1];
+        dp = new long[N+1];
+        for (int i = 1; i <= N; i++) {
+            oranges[i] = Integer.parseInt(br.readLine());
+        }
+
+        Arrays.fill(dp, INF);
+        dp[0] = 0;
+
+        for (int i = 1; i <= N; i++) {
+            long max = Long.MIN_VALUE;
+            long min = Long.MAX_VALUE;
+
+            for (int j = i; j >= Math.max(1, i-M+1); j--) {
+                max = Math.max(max, oranges[j]);
+                min = Math.min(min, oranges[j]);
+                long cost = K+(i-j+1)*(max-min);
+                dp[i] = Math.min(dp[i], dp[j-1]+cost);
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11985
## 🧭 풀이 시간
120분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
오렌지를 M개 이하로 묶어서 넣을 수 있는데 이 때, 최소 비용은?
## 🔍 풀이 방법
dp 상태 정의: i번째 오렌지를 넣었을 때 최소 비용
$dp[i]$는 $dp[i]$와 $dp[j-1]+cost$로 비교해야 한다. j는 i부터 i-M+1까지 탐색하면서 이전 상태에 다음 상자를 만든다는 개념으로 가야 한다.
## ⏳ 회고
일단 최대값 설정을 잘못해서 틀렸고, i-M+1까지 비교해야 했는데 계속 i-M까지 비교했다.