### PR TITLE
[20251228] BOJ / P5 / 인경호의 나무 / 권혁준

### DIFF
--- a/khj20006/202512/28 BOJ P5 인경호의 나무.md
+++ b/khj20006/202512/28 BOJ P5 인경호의 나무.md
@@ -1,0 +1,47 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+using ll = long long;
+
+const ll MOD = 1e9 + 7;
+
+int N, M;
+int a[1001]{}, l[1001]{}, r[1001]{};
+ll c[2001][1001]{};
+
+vector<int> res;
+
+void inorder(int n) {
+    if(l[n] != -1) inorder(l[n]);
+    res.push_back(a[n]);
+    if(r[n] != -1) inorder(r[n]);
+}
+
+int main() {
+    cin.tie(0)->sync_with_stdio(0);
+
+    for(int k=1;k<=2000;k++) {
+        c[k][1] = k;
+        for(int i=2;i<=min(k,1000);i++) c[k][i] = (c[k-1][i-1] + c[k-1][i]) % MOD;
+    }
+
+    cin>>N>>M;
+    for(int i=1;i<=N;i++) cin>>a[i]>>l[i]>>r[i];
+
+    inorder(1);
+    res.push_back(M+1);
+    ll ans = 1, prev = 0;
+    for(int i=0;i<res.size();i++) {
+        if(res[i] == -1) {
+            int cnt = 0;
+            while(i<res.size() && res[i] == -1) i++, cnt++;
+            if(res[i] <= prev) return cout<<0,0;
+            if(cnt > res[i] - prev - 1) return cout<<0,0;
+            ans = (ans * c[res[i]-prev-1][cnt]) % MOD;
+        }
+        prev = res[i];
+    }
+    cout<<ans;
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/28080

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
정점 N개인 이진 트리가 주어지며, 각 정점에는 1 이상 M이하의 정수가 하나씩 적혀있다.
일부 정점에는 수가 지워져 있다.
수가 지워진 정점들에 1이상 M이하의 정수를 채워넣어 트리를 BST로 만드는 경우의 수를 구해보자.

## 🔍 풀이 방법
BST가 되려면 트리를 중위 순회했을 때 오름차순이 되어야 한다.
주어진 트리를 중위 순회하면 -1들이 섞여 나오게 되는데, **-1이 연속한 구간**을 묶어서 (-1의 개수, 사용 가능한 수의 개수) = (n, k)로 나타낸다.
이 때 -1에 수를 적절히 배치하는 경우의 수는 kCn이다.
생기는 구간들에 수를 배치할 때는 구간별로 서로 영향을 주지 않으니까 경우의 수를 싹 다 곱하면 된다.

## ⏳ 회고
예외 처리 주의