### PR TITLE
[20260102] BOJ / G5 / 간판 만들기 / 권혁준

### DIFF
--- a/khj20006/202601/02 BOJ G5 간판 만들기.md
+++ b/khj20006/202601/02 BOJ G5 간판 만들기.md
@@ -1,0 +1,29 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+using ll = long long;
+
+const ll INF = 1e18;
+const string S = "UOSPC";
+
+int N;
+string s;
+ll arr[300000]{};
+
+int main() {
+    cin.tie(0)->sync_with_stdio(0);
+
+    cin>>N>>s;
+    for(int i=0;i<N;i++) cin>>arr[i];
+
+    vector<ll> res(5, INF);
+    for(int i=0;i<N;i++) {
+        for(int j=0;j<5;j++) if(s[i] == S[j]) {
+            if(!j) res[j] = min(res[j], arr[i]);
+            else res[j] = min(res[j], res[j-1] + arr[i]);
+        }
+    }
+    cout<<(res[4] == INF ? -1 : res[4]);
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/34894

## 🧭 풀이 시간
10분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
길이 N인 문자열 s가 주어진다.
i번째 글자를 전광판에 띄우는 비용은 S[i]이다.
전광판에 "UOSPC"를 띄우는 최소 비용을 구해보자.

## 🔍 풀이 방법
dp[i][j] = i번째 글자까지 사용해서 UOSPC중 j번째 인덱스까지 완성하는 경우의 수로 정의한다.
s[i] == "UOSPC"[j]이면 dp[i][j] = min(dp[i][j], dp[i-1][j-1] + S[i]) 이다.

## ⏳ 회고
HNY