### PR TITLE
[20260102] BOJ / G5 / 4와 7 / 이인희

### DIFF
--- a/LiiNi-coder/202601/02 BOJ 4와 7.md
+++ b/LiiNi-coder/202601/02 BOJ 4와 7.md
@@ -1,0 +1,35 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        long K = Long.parseLong(br.readLine());
+
+        long length = 1;
+        long countInGroup = 2;  //길이 1그룹에선 2개(4, 7)
+        while (K > countInGroup) {
+            K -= countInGroup;
+            length++;
+            countInGroup = 1L << length;
+        }
+        long index = K - 1;
+
+        StringBuilder result = new StringBuilder();
+        for (int i = (int) length - 1; i >= 0; i--) {
+            long bit = (index >> i) & 1;
+            if (bit == 0) {
+                result.append('4');
+            } else {
+                result.append('7');
+            }
+        }
+        System.out.println(result.toString());
+        br.close();
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2877
## 🧭 풀이 시간
50 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 4와 7로 이루어진 수열에서 N번째로 작은 숫자 리턵
## 🔍 풀이 방법
- _ , __, ___, 이렇게 그룹나눠서 개수 세고, 이진수를 이용해 작은 숫자 가려내기
## ⏳ 회고
- 이진수 이용 및 그룹나누는 헷갈리는 그룹나누기 연습