### PR TITLE
[20260103] BOJ / G4 / 우체국 / 한종욱

### DIFF
--- a/Ukj0ng/202601/03 BOJ G4 우체국.md
+++ b/Ukj0ng/202601/03 BOJ G4 우체국.md
@@ -1,0 +1,50 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static int[][] villages;
+    private static int N;
+    private static long sum;
+
+    public static void main(String[] args) throws IOException {
+        init();
+
+        long temp = 0;
+        int answer = 0;
+        for (int i = 0; i < N; i++) {
+            temp += villages[i][1];
+
+            if (temp >= (sum+1)/2) {
+                answer = villages[i][0];
+                break;
+            }
+        }
+
+        bw.write(answer + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+
+        villages = new int[N][2];
+
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int x = Integer.parseInt(st.nextToken());
+            int a = Integer.parseInt(st.nextToken());
+            villages[i][0] = x;
+            villages[i][1] = a;
+
+            sum += a;
+        }
+
+        Arrays.sort(villages, (o1, o2) -> Integer.compare(o1[0], o2[0]));
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2141

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
마을마다 사람들의 인원이 다르다. 이 마을들을 위해 우체국을 세우려고 하는데, 우체국은 각 사람들까지의 거리의 합이 최소가 되는 위치에 우체국을 세우기로 결정하였다. 우체국의 위치는?
## 🔍 풀이 방법
우체국의 위치는 마을 사람들의 위치의 중앙값이다. 마을들을 위치에 따라 정렬하고, 첫 마을부터 사람 수를 더해 과반수가 넘어가는 지점이 우체국의 위치이다. 

과반수를 나타낼 때,
1. 홀수라면, $temp/2+1$
2. 짝수라면, $temp/2$
이다. 이를 한 번에 할 수 있는 것은 $(temp+1)/2$이다.
## ⏳ 회고
문제를 보자마자, 난민 문제가 생각났다. 그래서 중앙값을 쉽게 알 수 있었는데, 홀짝의 특성을 고려하지 못했다. 