### PR TITLE
[20260103] BOJ / P2 / 최대공약수 게임 / 권혁준

### DIFF
--- a/khj20006/202601/03 BOJ P2 최대공약수 게임.md
+++ b/khj20006/202601/03 BOJ P2 최대공약수 게임.md
@@ -1,0 +1,41 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+
+int N, X;
+vector<int> primes;
+bool ex[301][512]{};
+bitset<512> base;
+
+int main() {
+    cin.tie(0)->sync_with_stdio(0);
+
+    cin>>N>>X;
+    for(int i=2;i*i<=X;i++) if(X%i == 0) {
+        primes.push_back(i);
+        while(X%i == 0) X /= i;
+    }
+    if(X != 1) primes.push_back(X);
+
+    ex[0][(1<<primes.size())-1] = 1;
+    for(int i=1,a;i<=N;i++) {
+        cin>>a;
+        int mask = 0;
+        for(int j=0;j<primes.size();j++) if(a%primes[j] == 0) mask |= (1<<j);
+        
+        for(int j=i-1;j>=0;j--) for(int k=1;k<512;k++) if(ex[j][k] && (k&mask)) {
+            ex[j+1][k&mask] = 1;
+            if(k != mask) base[k] = 1;
+        }
+    }
+    
+    for(int k=1;k<512;k++) if(!base[k]) {
+        for(int j=N;j>=0;j--) if(ex[j][k]) {
+            if(j&1) return cout<<"First",0;
+            break;
+        }
+    }
+    cout<<"Second";
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/31424

## 🧭 풀이 시간
80분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
칠판에 수 X가 적혀있다. 두 명의 사람이 N개의 카드 뭉치에서 번갈아가며 한 장씩 고른다. 고른 수와 X의 최대공약수가 1이 아니어야 하며, X를 그 최대공약수로 바꾼다.
더 이상 고를 수 없는 사람이 패배할 때, 선공이 이기는지 후공이 이기는지 알아보자.

## 🔍 풀이 방법
X를 소인수분해한 결과를 p1^q1 * p2^q2 * ... 라고 하자.

각 소수가 몇 번 곱해졌는지는 어차피 중요하지 않고, 그 소수를 포함하는지의 여부만이 게임의 상태를 바꾼다.

여기에 포함된 소수의 종류 집합을 S라고 하면,
X <= 10^9이기 때문에 |S| <= 9가 된다.
따라서, 가능한 상태는 2^9가지 경우로 좁혀진다.

ex[i][k] = 카드 뭉치에서 중복 없이 i개를 골랐을 때 상태가 k가 될 수 있으면 1, 아니면 0으로 둔다.
상태의 기저들에 대한 최대 깊이가 홀수인 경우가 존재하면 선공 승, 아니면 후공 승으로 판정했다.

## ⏳ 회고
근데 틀렸다. 그냥 로직이 잘못된 거 같은데 못 고치겠음