### PR TITLE
[20260105] BOJ / G2 / 오타 / 한종욱

### DIFF
--- a/Ukj0ng/202601/05 BOJ G2 오타.md
+++ b/Ukj0ng/202601/05 BOJ G2 오타.md
@@ -1,0 +1,63 @@
+```
+import java.io.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static boolean flag;
+    private static int[] sum;
+    private static char[] input;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        int answer = solve(flag);
+
+        bw.write(answer + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        input = br.readLine().toCharArray();
+        sum = new int[input.length+1];
+        int a = 0;
+        int b = 0;
+
+        for (int i = 0; i < input.length; i++) {
+            if (input[i] == '(') a++;
+            else b++;
+        }
+
+        // true -> '('가 더 많은 경우
+        if (a > b) flag = true;
+        // false -> ')'가 더 많은 경우
+    }
+
+    private static int solve(boolean flag) {
+        int result = 0;
+
+        if (flag) {
+            for (int i = 1; i <= input.length; i++) {
+                if (input[input.length-i] == ')') sum[i] = sum[i-1]+1;
+                else sum[i] = sum[i-1]-1;
+                if (sum[i] == -1) {
+                    result = (i+1)/2;
+                    break;
+                }
+            }
+        } else {
+            for (int i = 1; i <= input.length; i++) {
+                if (input[i-1] == '(') sum[i] = sum[i-1]+1;
+                else sum[i] = sum[i-1]-1;
+                if (sum[i] == -1) {
+                    result = (i+1)/2;
+                    break;
+                }
+            }
+        }
+
+        return result;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/5875
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
오타를 냈다. 한 문자만 고쳐서 올바른 괄호쌍이 될 수 있는 경우의 수를 출력하라.
## 🔍 풀이 방법
문제에선 '('가 ')'보다 2개 많거나, ')'가 '('보다 2개 많은 경우만 주어진다. 
둘 중 어떤 것을 고쳐야 하는지 한번 계산한다. 
그 다음, ')'가 더 많은 걸 기준으로 설명하겠다. 
'('는 1, ')'는 -1로 계산해서 누적합을 계산하고 처음 -1이 될 때, 그 앞의 ')'의 개수를 센다. 
## ⏳ 회고
처음엔 -2가 되는 순간 그 한 칸 앞들인 줄 알았다. 근데 이건 괄호쌍이기 때문에, 합이 0인 것도 중요하지만 누적합이 음수가 되지 않아야 한다는 걸 인지하지 못하고 있었다. g선생이 알려주지 않았다면 계속 틀렸을 것이다. 