### PR TITLE
[20260107] BOJ / G5 / 감소하는 수 / 이강현

### DIFF
--- a/lkhyun/202601/07 BOJ G5 감소하는 수.md
+++ b/lkhyun/202601/07 BOJ G5 감소하는 수.md
@@ -1,0 +1,28 @@
+```java
+
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+
+        List<Long> list = new ArrayList<>();
+
+        for (int i = 1; i < 1024; i++) {
+            long num = 0;
+            for (int j = 9; j >= 0; j--) {
+                if ((i & (1 << j)) != 0) {
+                    num = num * 10 + j;
+                }
+            }
+            list.add(num);
+        }
+
+        Collections.sort(list);
+
+        System.out.println(N >= list.size() ? -1 : list.get(N));
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1038
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [X] 중
- [ ] 하
## ✏️ 문제 설명
음이아닌 정수를 앞자리부터 봤을때, 숫자가 감소하는 경우 감소하는 수라고 함.
N번째 감소하는 수를 구하자.
## 🔍 풀이 방법
비트마스킹
매 자릿수가 감소하려면 0~9까지의 숫자가 모두 사용되는 경우까지가 한계이므로
어떤 숫자를 사용할지 비트마스킹으로 표현함.
어떤 숫자를 사용할지가 선택되면 이후에는 내림차순 정렬을 한 것이 유일한 감소하는 수가 됨.
## ⏳ 회고
비트마스킹은 주어진 것 중에 어떤 것을 사용할지를 비트단위로 표현한 것이라는 생각을 문제 풀때 해보자.