### PR TITLE
[20260108] BOJ / P5 / 안대 낀 스피드러너 / 이강현

### DIFF
--- a/lkhyun/202601/08 BOJ P5 안대 낀 스피드러너.md
+++ b/lkhyun/202601/08 BOJ P5 안대 낀 스피드러너.md
@@ -1,0 +1,109 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static class State {
+        int x1, y1, dir1;
+        int x2, y2, dir2;
+        int steps;
+
+        State(int x1, int y1, int dir1, int x2, int y2, int dir2, int steps) {
+            this.x1 = x1;
+            this.y1 = y1;
+            this.dir1 = dir1;
+            this.x2 = x2;
+            this.y2 = y2;
+            this.dir2 = dir2;
+            this.steps = steps;
+        }
+    }
+
+    static int N;
+    static char[][] map;
+    static int[] dx = {-1, 0, 1, 0};
+    static int[] dy = {0, 1, 0, -1};
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        map = new char[N][N];
+
+        for (int i = 0; i < N; i++) {
+            String line = br.readLine();
+            for (int j = 0; j < N; j++) {
+                map[i][j] = line.charAt(j);
+            }
+        }
+
+        System.out.println(bfs());
+    }
+
+    public static int bfs() {
+        Queue<State> q = new LinkedList<>();
+        boolean[][][][][][] visited = new boolean[N][N][4][N][N][4];
+
+        State start = new State(N-1, 0, 0, N-1, 0, 1, 0);
+        q.offer(start);
+        visited[N-1][0][0][N-1][0][1] = true;
+
+        while (!q.isEmpty()) {
+            State cur = q.poll();
+
+            if (cur.x1 == 0 && cur.y1 == N-1 && cur.x2 == 0 && cur.y2 == N-1) {
+                return cur.steps;
+            }
+
+            int nx1 = cur.x1;
+            int ny1 = cur.y1;
+            int nx2 = cur.x2;
+            int ny2 = cur.y2;
+
+            if (!(cur.x1 == 0 && cur.y1 == N-1)) {
+                nx1 = cur.x1 + dx[cur.dir1];
+                ny1 = cur.y1 + dy[cur.dir1];
+                if (!isValid(nx1, ny1)) {
+                    nx1 = cur.x1;
+                    ny1 = cur.y1;
+                }
+            }
+
+            if (!(cur.x2 == 0 && cur.y2 == N-1)) {
+                nx2 = cur.x2 + dx[cur.dir2];
+                ny2 = cur.y2 + dy[cur.dir2];
+                if (!isValid(nx2, ny2)) {
+                    nx2 = cur.x2;
+                    ny2 = cur.y2;
+                }
+            }
+
+            if (!visited[nx1][ny1][cur.dir1][nx2][ny2][cur.dir2]) {
+                visited[nx1][ny1][cur.dir1][nx2][ny2][cur.dir2] = true;
+                q.offer(new State(nx1, ny1, cur.dir1, nx2, ny2, cur.dir2, cur.steps + 1));
+            }
+
+            int newDir1 = (cur.dir1 + 3) % 4;
+            int newDir2 = (cur.dir2 + 3) % 4;
+
+            if (!visited[cur.x1][cur.y1][newDir1][cur.x2][cur.y2][newDir2]) {
+                visited[cur.x1][cur.y1][newDir1][cur.x2][cur.y2][newDir2] = true;
+                q.offer(new State(cur.x1, cur.y1, newDir1, cur.x2, cur.y2, newDir2, cur.steps + 1));
+            }
+
+            newDir1 = (cur.dir1 + 1) % 4;
+            newDir2 = (cur.dir2 + 1) % 4;
+
+            if (!visited[cur.x1][cur.y1][newDir1][cur.x2][cur.y2][newDir2]) {
+                visited[cur.x1][cur.y1][newDir1][cur.x2][cur.y2][newDir2] = true;
+                q.offer(new State(cur.x1, cur.y1, newDir1, cur.x2, cur.y2, newDir2, cur.steps + 1));
+            }
+        }
+
+        return -1;
+    }
+
+    static boolean isValid(int x, int y) {
+        return x >= 0 && x < N && y >= 0 && y < N && map[x][y] == 'E';
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14451
## 🧭 풀이 시간
90분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
러너가 왼쪽 맨 아래에서 오른쪽 맨 위로 이동할거임.
러너는 직진, 우회전, 좌회전 세가지 행동이 가능함.
초기 러너는 어디를 바라볼지 모름. 하지만 위 또는 오른쪽 둘 중 하나임.
어떻게 있든 같은 명령어 시퀀스로 도착지에 도착할때, 최소 행동으로 도착하도록 해야함.
이때 명령어 횟수를 출력.
## 🔍 풀이 방법
BFS
상태 자체를 위를 바라보고 시작하는 경우와 오른쪽을 바라보고 시작하는 경우로 정의함.
이후 상태에 따라 직진, 좌회전, 우회전을 실시하며 두 경우 모두 도착지로 도착했을때, 그때의 step을 출력
## ⏳ 회고
위를 바라보든 오른쪽을 바라보든 상관없다고 처음에 생각했다.
위를 바라보면서 우회전을 하는 경우와 오른쪽을 바라보면서 좌회전을 하는경우에 둘다 같은 명령어 횟수로 도달 가능했기 때문이었다.
그래서 위치와 방향만 상태에 저장하고 둘다 큐에 넣어두는 방식으로 구현했었다.
하지만 핵심은 어떤 상태이든지 같은 명령어를 따르기만하면 도착지에 도착해야한다는 것이 핵심이었다.
따라서 두 경우를 하나의 상태로 합쳐서 이동해야했다.

그리고 두 경우중 하나가 미리 도착하면 컷신이 발동해서 명령에 영향을 받지 않는다는 것을 간과했는데, 이를 처리하여 풀 수 있었다.