### PR TITLE
[20260109] BOJ / G3 / 사회망 서비스(SNS) / 이강현

### DIFF
--- a/lkhyun/202601/09 BOJ G3 사회망 서비스(SNS).md
+++ b/lkhyun/202601/09 BOJ G3 사회망 서비스(SNS).md
@@ -1,0 +1,43 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static int N;
+    static List<Integer>[] adjList;
+    static StringTokenizer st;
+    static int[][] dp;
+    static boolean[] visited;
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        adjList = new ArrayList[N+1];
+        for (int i = 0; i <= N; i++) {
+            adjList[i] = new ArrayList<>();
+        }
+        dp = new int[N+1][2];
+        visited = new boolean[N+1];
+
+        for (int i = 1; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+            adjList[u].add(v);
+            adjList[v].add(u);
+        }
+        dfs(1);
+        System.out.println(Math.min(dp[1][0],dp[1][1]));
+    }
+    public static void dfs(int cur){
+        visited[cur] = true;
+        dp[cur][1] = 1;
+
+        for (int next : adjList[cur]) {
+            if(visited[next]) continue;
+            dfs(next);
+            dp[cur][0] += dp[next][1];
+            dp[cur][1] += Math.min(dp[next][0],dp[next][1]);
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2533
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
트리 구조의 그래프에서 모든 인원이 정보를 습득하는 것이 목표
인원들을 각각 얼리어댑터거나 일반인임.
정보를 습득하는 인원은 얼리어댑터들이고 일반인들은 자신과 연결관계를 맺은 모든 인원들이 얼리어댑터이어야 정보를 습득할 수 있음.
모든 인원들이 정보를 습득할 수 있도록 하는 최소 얼리어댑터의 수를 출력하자.
## 🔍 풀이 방법
트리 dp
dp[현재 인원][인원 타입]으로 정의하고 이는 현재 인원을 포함하고 이 인원의 자식 트리가 모두 정보를 습득할 수 있게끔하는 최소 얼리어댑터의 수를 나타냄.
현재 인원이 일반인이라면 이와 연결관계를 맺은 모든 인원들은 얼리어댑터여야함.
하지만 얼리어댑터라면 연결관계를 맺은 모든 인원이 일반인이거나 얼리어댑터일 수 있음.
0을 일반인, 1을 얼리어댑터라고 판단했을때,
dp[현재 인원][0] += dp[다음 인원][1]이고
dp[현재 인원][1] += Math.min(dp[다음 인원][0], dp[다음 인원][1])로 정의하면 조건을 만족할 수 있음.
## ⏳ 회고
처음에는 같은 depth에 있는 인원들은 모두 얼리어댑터거나 일반인이라고 생각하고 문제를 풀었는데,
현재 인원이 얼리어댑터일때, 다음 인원이 꼭 일반인인게 최적해를 보장하지 않는다는 반례를 알게 되었다.
트리 dp라는 유형을 처음 풀어봐서 다소 어려웠다.
