### PR TITLE
[20260111] BOJ / G5 / 맨해튼에서의 모임 / 한종욱

### DIFF
--- a/Ukj0ng/202601/11 BOJ G5 맨해튼에서의 모임.md
+++ b/Ukj0ng/202601/11 BOJ G5 맨해튼에서의 모임.md
@@ -1,0 +1,56 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static List<Long>[] dimensions;
+    private static long[] median;
+    private static long dist;
+    private static int N, M;
+
+    public static void main(String[] args) throws IOException {
+        init();
+
+        bw.write(dist + "\n");
+        for (long temp : median) {
+            bw.write(temp + " ");
+        }
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        dimensions = new List[N];
+        median = new long[N];
+        for (int i = 0; i < N; i++) {
+            dimensions[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                long input = Long.parseLong(st.nextToken());
+                dimensions[j].add(input);
+            }
+        }
+
+        for (List<Long> dimension : dimensions) {
+            Collections.sort(dimension);
+        }
+
+        for (int i = 0; i < N; i++) {
+            median[i] = dimensions[i].get(M/2);
+            for (long temp : dimensions[i]) {
+                dist += Math.abs(median[i]-temp);
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/27297
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N차원 좌표에서 맨해튼 거리의 합이 최소가 되는 맨해튼-포인트 포인트를 찾아라.
## 🔍 풀이 방법
각 차원에서 중앙값 좌표를 구해야 한다. 정렬을 하고 중앙값을 찾아서 좌표를 표현하면 된다. 
## ⏳ 회고
N차원에서 중앙값을 어떻게 표현해야 하는지를 생각하는 게 제일 어려웠다. 