### PR TITLE
[20260112] BOJ / G3 / 트리를 복잡하게 색칠하는 최소 비용 / 이강현

### DIFF
--- a/lkhyun/202601/12 BOJ G3 트리를 복잡하게 색칠하는 최소 비용.md
+++ b/lkhyun/202601/12 BOJ G3 트리를 복잡하게 색칠하는 최소 비용.md
@@ -1,0 +1,50 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static int N;
+    static List<Integer>[] adjList;
+    static long[][] dp;
+    static int[] whiteCost;
+    static int[] blackCost;
+    static StringTokenizer st;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        adjList = new List[N];
+        for (int i = 0; i < N; i++) {
+            adjList[i] = new ArrayList<>();
+        }
+        dp = new long[N][2];
+        whiteCost = new int[N];
+        blackCost = new int[N];
+
+        for (int i = 1; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+            adjList[from].add(to);
+        }
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            whiteCost[i] = Integer.parseInt(st.nextToken());
+            blackCost[i] = Integer.parseInt(st.nextToken());
+        }
+
+        dfs(0);
+        System.out.println(Math.min(dp[0][0],dp[0][1]));
+    }
+    public static void dfs(int cur){
+        dp[cur][0] = whiteCost[cur];
+        dp[cur][1] = blackCost[cur];
+        for (Integer next : adjList[cur]) {
+            dfs(next);
+            dp[cur][0] += Math.min(dp[next][0],dp[next][1]);
+            dp[cur][1] += dp[next][0];
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/25690
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
트리의 정점을 색칠할거임.
이웃한 두 정점이 white,white 혹은 white,black이 되게끔 색칠해야하는데 정점마다 white,black 색칠하는 비용이 서로다름
조건을 만족하면서 최소비용으로 트리내 정점을 모두 색칠하는 비용을 출력하자.
## 🔍 풀이 방법
트리 dp
dfs로 진입하면서 색칠하기
## ⏳ 회고
트리 dp를 저번에 처음 접해봐서 하나 더 풀어봤는데 감이 잡히는 듯 하다.