### PR TITLE
[20260112] BOJ / G2 / 저울 / 한종욱

### DIFF
--- a/Ukj0ng/202601/12 BOJ G2 저울.md
+++ b/Ukj0ng/202601/12 BOJ G2 저울.md
@@ -1,0 +1,43 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static int[] weight;
+    private static int N, sum, answer;
+
+    public static void main(String[] args) throws IOException {
+        init();
+
+        bw.write(answer+"\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+        weight = new int[N];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            weight[i] = Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.sort(weight);
+
+        sum = 0;
+
+        for (int i = 0; i < N; i++) {
+            if (weight[i] > sum+1) {
+                break;
+            }
+            sum += weight[i];
+        }
+
+        answer = sum+1;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2437
## 🧭 풀이 시간
100분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
추들이 있는데, 이것들을 합해서 나타낼 수 없는 최소 무게는?
## 🔍 풀이 방법
1. 추들을 정렬한다. 
2. 누적합으로 더해가며, `weight[i] > sum+1`인지 체크한다.
3. 2번에 걸리면, sum+1이 정답이다. 
## ⏳ 회고
이어달리기 느낌의 문제였다. 1부터 sum까지 만들 수 있다고 가정하고 `weight`가 들어왔을 때, 어떻게 해야하나? 를 생각하면 되는 문제였다. 