### PR TITLE
[20260113] BOJ / G1 / 자르기 / 권혁준

### DIFF
--- a/khj20006/202601/13 BOJ G1 자르기.md
+++ b/khj20006/202601/13 BOJ G1 자르기.md
@@ -1,0 +1,34 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+
+int N;
+int arr[1000002]{};
+int left_max1[1000002]{}, left_max2[1000002]{};
+int right_max1[1000002]{}, right_max2[1000002]{};
+
+int main() {
+    cin.tie(0)->sync_with_stdio(0);
+
+    cin>>N;
+    for(int i=1;i<=N;i++) cin>>arr[i];
+    for(int i=1;i<=N;i++) {
+        left_max1[i] = max(left_max1[i-1], arr[i]);
+        if(i>1) left_max2[i] = max(left_max2[i-1], arr[i]);
+    }
+    for(int i=N;i>=1;i--) {
+        right_max1[i] = max(right_max1[i+1], arr[i]);
+        if(i<N) right_max2[i] = max(right_max2[i+1], arr[i]);
+    }
+
+    int ans = 1e9;
+    for(int i=2;i<=N-2;i++) {
+        int left_result = min(arr[1] + left_max2[i], left_max1[i-1] + arr[i]);
+        int right_result = min(arr[i+1] + right_max1[i+2], right_max2[i+1] + arr[N]);
+        ans = min(ans, left_result + right_result);
+    }
+
+    cout<<ans;
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/35113

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N개의 양의 정수로 이루어진 배열 A가 주어진다.
1 <= i < j < k < N인 i, j, k에 대해, 
f(i, j, k) = max(A[1], ..., A[i]) + max(A[i+1], ..., A[j]) + max(A[j+1], ..., A[k]) + max(A[k+1], ..., A[N])이라 하자.

가능한 f(i, j, k)의 값 중 최솟값을 구해보자.

## 🔍 풀이 방법
j를 고정시키면 배열이 두 개로 쪼개지게 된다.
구간 [1, j]와 [j+1, N]을 각각 다시 한 번 쪼개야 한다.

구간 [1,j]를 [1,i], [i+1,j]로 쪼갤 때,
이 구간의 최댓값이 [1,i]에 속하게 되는 경우에는 max(A[i+1], ..., A[j])를 최소화해야 한다. -> i = j-1이어야 한다.
반대로, 이 구간의 최댓값이 [i+1,j]에 속하게 되는 경우에는 max(A[1], ..., A[i])를 최소화해야 한다. -> i = 1이어야 한다.

즉, 구간 [1,j]를 쪼개는 최적의 방법은 항상 [1,1], [2,j] 혹은 [1,j-1], [j,j] 이다.
마찬가지로, 구간 [j+1,N]을 쪼개는 최적의 방법은 항상 [j+1,j+1], [j+2,N] 혹은 [j+1,N-1], [N,N] 이다.

j를 이동시키며 위 값들을 확인해주었다.
누적 max를 관리하는 배열을 통해 정답을 갱신해나갔다.

## ⏳ 회고
누적 max, min은 항상 단조성을 지닌다는 것을 자연스럽게 떠올릴 수 있는 좋은 문제인 것 같다