### PR TITLE
[20260114] BOJ / P5 / 소방서의 고민 / 한종욱

### DIFF
--- a/Ukj0ng/202601/14 BOJ P5 소방서의 고민.md
+++ b/Ukj0ng/202601/14 BOJ P5 소방서의 고민.md
@@ -1,0 +1,54 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static final int MOD = 40000;
+    private static PriorityQueue<Task> pq;
+    private static int N;
+    private static long t;
+
+    public static void main(String[] args) throws IOException {
+        init();
+
+        while (!pq.isEmpty()) {
+            Task temp = pq.poll();
+            t += temp.a*t+temp.b;
+            t %= MOD;
+        }
+
+        bw.write(t + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+
+        pq = new PriorityQueue<>((o1, o2) -> {
+            if (o1.a == 0 && o2.a == 0) return 0;
+            if (o1.a == 0) return 1;
+            if (o2.a == 0) return -1;
+            return Long.compare(o2.a*o1.b, o1.a*o2.b);
+        });
+
+        for (int i = 1; i <= N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            pq.add(new Task(Long.parseLong(st.nextToken()), Long.parseLong(st.nextToken())));
+        }
+    }
+
+    static class Task {
+        long a;
+        long b;
+
+        public Task(long a, long b) {
+            this.a = a;
+            this.b = b;
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2180
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
화재의 종류에 따라서, 화재 발생 후 소방차가 t초 후에 도착하면 화재를 진압하는데 걸리는 시간은 at +b와 같이 1차 함수의 형태로 나타나게 된다. 모든 화재 사건은 시각 0에서 발생하였다. 당신은 모든 화재를 진압하는데 걸리는 최소 시간이 얼마인지를 알고 싶다.
## 🔍 풀이 방법
$t$초일 경우, ($a_1, b_1$)과 ($a_2, b_2$)이 있다고 가정해보자. 
1번 작업 후 2번 작업을 한다고 했을 때, ${(a_1 + 1)t + b_1}(a_2+1) + b_2$이고
2번 작업 후 1번 작업을 한다고 했을 때, ${(a_2 + 1)t + b_2}(a_1+1) + b_1$이다.
${a_2}{b_1} < {a_1}{b_2}$이다. 

하지만, a, b가 0이면 저 부등호에 문제가 생긴다. 따라서, $a_1, a_2$가 0인 경우를 각각 예외처리 해줘야 한다. 
## ⏳ 회고
compare 함수
| 리턴값 | 의미 | 동작 (Action) |
| :--- | :--- | :--- |
| **음수 (-)** | `o1`이 더 작다 (우선순위 높음) | **`o1`을 `o2`보다 앞에 세운다.** (그대로 둠) |
| **0** | 둘이 같다 | 순서를 바꾸지 않는다. |
| **양수 (+)** | `o1`이 더 크다 (우선순위 낮음) | **`o1`을 `o2` 뒤로 보낸다.** (**자리를 바꿈**) |