### PR TITLE
[20260116] BOJ / G5 / 무한 수열 / 한종욱

### DIFF
--- a/Ukj0ng/202601/16 BOJ G5 무한 수열.md
+++ b/Ukj0ng/202601/16 BOJ G5 무한 수열.md
@@ -1,0 +1,40 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static Map<Long, Long> map;
+    private static int P, Q;
+    private static long N;
+
+    public static void main(String[] args) throws IOException {
+        init();
+
+        long answer = backTracking(N);
+        bw.write(answer + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Long.parseLong(st.nextToken());
+        P = Integer.parseInt(st.nextToken());
+        Q = Integer.parseInt(st.nextToken());
+
+        map = new HashMap<>();
+    }
+
+    private static long backTracking(long n) {
+        if (n == 0) return 1;
+        if (map.containsKey(n)) return map.get(n);
+
+        long temp = backTracking(n/P) + backTracking(n/Q);
+        map.put(n, temp);
+        return temp;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1351
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
무한 수열 A는 다음과 같다.
- $A_0 = 1$
- $A_i = A_{⌊i/P⌋} + A_{⌊i/Q⌋}$ (i ≥ 1)
N, P와 Q가 주어질 때, $A_N$을 구하라
## 🔍 풀이 방법
N이 최대 $10^{12}$다. $A_i$ 점화식은 이진트리로 볼 수 있고, 최대 40번을 계산할 수 있다. ($2_{40} = 10^{12}$) 나머지는 재귀로 구하고, map을 통해 필요한 index만 처리한다. 
## ⏳ 회고
이준희 이걸 보고 바로 떠올리누