### PR TITLE
[20260117] BOJ / G5 / 알약 / 한종욱

### DIFF
--- a/Ukj0ng/202601/17 BOJ G5 알약.md
+++ b/Ukj0ng/202601/17 BOJ G5 알약.md
@@ -1,0 +1,42 @@
+```
+import java.io.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static long[][] dp;
+    private static int N;
+
+    public static void main(String[] args) throws IOException {
+        init();
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        while (true) {
+            N = Integer.parseInt(br.readLine());
+            if (N == 0) return;
+
+            dp = new long[N+1][N+1];
+
+            for (int i = 0; i <= N; i++) {
+                dp[0][i] = 1;
+            }
+
+            for (int i = 1; i <= N; i++) {
+                for (int j = 0; j <= N; j++) {
+
+                    if (j+1 <= N)dp[i][j] += dp[i-1][j+1];
+
+                    if (j > 0) dp[i][j] += dp[i][j-1];
+                }
+            }
+
+            bw.write(dp[N][0] + "\n");
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/4811
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
알약이 N개가 있다. 반 개를 먹거나 한 개를 먹는다. 반 개를 먹을 땐 H, 한 개를 먹을 땐 W를 적는다. 2N일을 먹는다고 가정할 때 가능한 문자열의 개수는?
## 🔍 풀이 방법
1.  **상태 정의 ($dp[w][h]$)**
    * $w$: 병 속에 남은 **온전한 알약**의 개수
    * $h$: 병 속에 남은 **반쪽 알약**의 개수
    * $dp[w][h]$: 현재 $w$개, $h$개가 남은 상태에서 끝까지 알약을 먹는 경우의 수

2.  **점화식**
    현재 상태에서 할 수 있는 행동은 두 가지뿐이다. 이 두 행동의 결과를 더하면 현재의 경우의 수가 된다.
    * **W를 꺼내는 경우:** $W$가 1개 줄고, $H$가 1개 생긴다. $\rightarrow$ `dp[w-1][h+1]`에서 값을 가져옴
    * **H를 꺼내는 경우:** $W$는 그대로고, $H$가 1개 준다. $\rightarrow$ `dp[w][h-1]`에서 값을 가져옴
    
    $$dp[w][h] = dp[w-1][h+1] + dp[w][h-1]$$
    *(단, $w>0, h>0$일 때 유효)*

3.  **초기화**
    * $w=0$인 경우(온전한 알약 소진), 남은 반쪽($h$)을 먹는 방법은 오직 1가지뿐이다.
    * 따라서 $dp[0][0]$부터 $dp[0][N]$까지 모두 `1`로 초기화한 뒤 **Bottom-Up**으로 계산한다.

## ⏳ 회고
처음에는 DP의 상태 전이 방향이 헷갈려서 고생했다.
`dp[i][j]`를 구할 때 "과거의 값($i+1, j-1$)에서 현재로 오는 것"으로 착각하여 인덱스를 반대로 생각했었다.

하지만 **Bottom-Up 방식**의 핵심은 "미래의 결과(W를 먹은 후, H를 먹은 후)를 미리 계산해두고, 현재 상태가 그 값들을 가져와서 합치는 것"임을 깨달았다.

* **인덱스**: 내가 W를 먹으면 알약이 줄어드니까($w-1$), 이미 계산된 작은 문제($w-1$ 행)를 참조해야 한다.
* **초기화**: $w=0$일 때를 1로 깔아두는 것이 단순한 예외 처리가 아니라, $w=1, 2...$를 계산하기 위한 필수적인 재라는 점을 명확히 이해했다.
* **정답 위치**: 출발점이자 가장 큰 문제인 $dp[N][0]$이 최종 정답이다. (끝점인 $dp[0][0]$이 아님)
