### PR TITLE
[20260120] BOJ / G3 / 종이조각 / 이준희

### DIFF
--- a/JHLEE325/202601/20 BOJ G3 종이조각.md
+++ b/JHLEE325/202601/20 BOJ G3 종이조각.md
@@ -1,0 +1,76 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int N, M;
+    static int[][] board;
+    static boolean[][] visited;
+    static int maxScore = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        board = new int[N][M];
+        visited = new boolean[N][M];
+
+        for (int i = 0; i < N; i++) {
+            String line = br.readLine();
+            for (int j = 0; j < M; j++) {
+                board[i][j] = line.charAt(j) - '0';
+            }
+        }
+
+        dfs(0, 0, 0);
+        System.out.println(maxScore);
+    }
+
+    static void dfs(int r, int c, int sum) {
+        if (r >= N) {
+            maxScore = Math.max(maxScore, sum);
+            return;
+        }
+
+        if (c >= M) {
+            dfs(r + 1, 0, sum);
+            return;
+        }
+
+        if (visited[r][c]) {
+            dfs(r, c + 1, sum);
+            return;
+        }
+
+        int current = 0;
+        for (int len = 0; c + len < M; len++) {
+            if (visited[r][c + len]) break;
+
+            for (int i = 0; i <= len; i++) visited[r][c + i] = true;
+            current = current * 10 + board[r][c + len];
+            
+            dfs(r, c + len + 1, sum + current);
+            
+            for (int i = 0; i <= len; i++) visited[r][c + i] = false;
+        }
+
+        current = board[r][c];
+        for (int len = 1; r + len < N; len++) {
+            if (visited[r + len][c]) break;
+
+            for (int i = 1; i <= len; i++) visited[r + i][c] = true;
+            
+            int tempVal = 0;
+            for (int i = 0; i <= len; i++) {
+                tempVal = tempVal * 10 + board[r + i][c];
+            }
+            
+            dfs(r, c + 1, sum + tempVal);
+            
+            for (int i = 1; i <= len; i++) visited[r + i][c] = false;
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14391

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
격자로 되어 있는 숫자 판을 겹치지 않게 자르려고 합니다.
자르는 것은 가로 또는 세로 일자로만 자를 수 있습니다.
가로로 자른 경우 왼쪽부터 세어 수가 되고, 세로로 자른 경우 위에서부터 아래로 수를 만듭니다.
각 조각들의 수를 모두 더했을 때 최댓값을 구하는 문제입니다.

## 🔍 풀이 방법
dfs를 이용해서 모든 지점들을 돌면서 최댓값을 갱신하는 방식으로 풀었습니다.
방문처리를 활용하였고, 각 계산이 끝나면 원상태로 돌려가면서 모든 경우의 수를 찾았습니다.

## ⏳ 회고
문제를 다 풀고 확인했는데 문제 유형이 비트마스킹이라고 되어 있어서 찾아봤는데
비트마스킹에 익숙해졌다면 어렵게 방문처리, 복구 하지 않고 풀 수 있었을 것 같습니다.
근데 현재는 비트마스킹이 익숙하지 않아서 공부해야할 것 같습니다.
