### PR TITLE
[20260121] BOJ / G4 / 수들의 합 4 / 한종욱

### DIFF
--- a/Ukj0ng/202601/21 BOJ G4 수들의 합 4.md
+++ b/Ukj0ng/202601/21 BOJ G4 수들의 합 4.md
@@ -1,0 +1,50 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static Map<Integer, Integer> map;
+    private static int[] arr;
+    private static int N, K;
+    private static long answer;
+
+    public static void main(String[] args) throws IOException {
+        init();
+
+        bw.write(answer + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+        arr = new int[N];
+        map = new HashMap<>();
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int currentSum = 0;
+
+        for (int n : arr) {
+            currentSum += n;
+
+            if (currentSum == K) answer++;
+
+            if (map.containsKey(currentSum-K)) {
+                answer += map.get(currentSum-K);
+            }
+
+            map.put(currentSum, map.getOrDefault(currentSum, 0) + 1);
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2015
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
배열 A의 부분합 중 합이 K인 것이 몇 개나 있는지 구하시오.
## 🔍 풀이 방법
누적 합을 map에 저장한다.
그리고 현재 누적 합을 currentSum에 저장한다. 

1. currentSum이 K일 경우 -> `answer++`
2. `currentSum-K`가 map에 포함되어 있을 때 -> `answer += map.get(currentSum-K)`
## ⏳ 회고
N의 최댓값이 200,000이라서 answer가 long이어야 했는데 그걸 체크하지 못했다. 