### PR TITLE
[20260121] BOJ / G3 / 소수의 연속합 / 이준희

### DIFF
--- a/JHLEE325/202601/21 BOJ G3 소수의 연속함.md
+++ b/JHLEE325/202601/21 BOJ G3 소수의 연속함.md
@@ -1,0 +1,50 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+
+        if (N == 1) {
+            System.out.println(0);
+            return;
+        }
+
+        boolean[] isPrime = new boolean[N + 1];
+        Arrays.fill(isPrime, true);
+        isPrime[0] = isPrime[1] = false;
+
+        for (int i = 2; i * i <= N; i++) {
+            if (isPrime[i]) {
+                for (int j = i * i; j <= N; j += i) {
+                    isPrime[j] = false;
+                }
+            }
+        }
+
+        List<Integer> primes = new ArrayList<>();
+        for (int i = 2; i <= N; i++) {
+            if (isPrime[i]) primes.add(i);
+        }
+
+        int count = 0;
+        int start = 0, end = 0, sum = 0;
+        int size = primes.size();
+
+        while (true) {
+            if (sum >= N) {
+                if (sum == N) count++;
+                sum -= primes.get(start++);
+            } else if (end == size) {
+                break;
+            } else {
+                sum += primes.get(end++);
+            }
+        }
+
+        System.out.println(count);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1644

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
3 : 3 (한 가지)
41 : 2+3+5+7+11+13 = 11+13+17 = 41 (세 가지)
53 : 5+7+11+13+17 = 53 (두 가지)
위 예시 처럼 어떤 자연수가 연속된 소수들의 덧셈으로 생성할 수 있을 때 그 가짓수를 구하는 문제입니다.

## 🔍 풀이 방법
소수를 계산해서 유지한 후
해당 소수를 유지한 배열에서 투포인터를 사용해서 합을 내가 찾고자 하는 자연수와 비교했습니다.
자연수와 같아질 때 마다 횟수를 세어 답을 냈습니다.

## ⏳ 회고
항상 소수판별 문제는 소수를 어떻게 판별할지 몰랐어서 미뤄놨었는데
에라토스테네스의 체에 대해서 학습 후 풀었습니다.
