### PR TITLE
[20260122] BOJ / G3 / 소수 경로 / 이준희

### DIFF
--- a/JHLEE325/202601/22 BOJ G4 소수 경로.md
+++ b/JHLEE325/202601/22 BOJ G4 소수 경로.md
@@ -1,0 +1,80 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static boolean[] isPrime = new boolean[10000];
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        Arrays.fill(isPrime, true);
+        isPrime[0] = isPrime[1] = false;
+        for (int i = 2; i * i < 10000; i++) {
+            if (isPrime[i]) {
+                for (int j = i * i; j < 10000; j += i) isPrime[j] = false;
+            }
+        }
+
+        int T = Integer.parseInt(br.readLine());
+        for (int t = 0; t < T; t++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int start = Integer.parseInt(st.nextToken());
+            int end = Integer.parseInt(st.nextToken());
+
+            int result = bfs(start, end);
+            System.out.println(result == -1 ? "Impossible" : result);
+        }
+    }
+
+    static int bfs(int start, int end) {
+        Queue<Integer> q = new LinkedList<>();
+        int[] dist = new int[10000];
+        Arrays.fill(dist, -1);
+
+        q.add(start);
+        dist[start] = 0;
+
+        while (!q.isEmpty()) {
+            int curr = q.poll();
+            if (curr == end) return dist[curr];
+
+            for (int i = 0; i < 4; i++) {
+                int[] digits = getDigits(curr);
+
+                for (int d = 0; d <= 9; d++) {
+                    if (i == 3 && d == 0) continue;
+
+                    int next = changeDigit(digits, i, d);
+
+                    if (isPrime[next] && dist[next] == -1) {
+                        dist[next] = dist[curr] + 1;
+                        q.add(next);
+                    }
+                }
+            }
+        }
+        return -1;
+    }
+
+    static int[] getDigits(int num) {
+        int[] digits = new int[4];
+        for (int i = 0; i < 4; i++) {
+            digits[i] = num % 10;
+            num /= 10;
+        }
+        return digits;
+    }
+
+    static int changeDigit(int[] digits, int idx, int d) {
+        int res = 0;
+        int p = 1;
+        for (int i = 0; i < 4; i++) {
+            if (i == idx) res += d * p;
+            else res += digits[i] * p;
+            p *= 10;
+        }
+        return res;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1963

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
4자리 소수로 정해져 있는 비밀번호를 바꾸려고 합니다.
비밀번호를 바꿀 때는 각 자릿 수 중 1개씩만 바꿀 수 있고, 소수로만 바꿀 수 있습니다.
이 때 특정 비밀번호로 바꾸고자 할 때, 총 몇번에 걸쳐서 바꿀 수 있는지 구하는 문제입니다.

## 🔍 풀이 방법
소수판별과 BFS를 이용해서 풀었습니다.
일단 4자리로 되어있는 소수를 전부 구했습니다.
이후 현재 비밀번호로부터 시작하여 각 자리의 숫자들을 바꿔가면서
해당 숫자가 소수이면서, 아직 방문하지 않은 경우에 큐에 새로 추가하고, 몇번에 걸쳐있는지를 입력했습니다.
큐를 전부 비운 후 목적지 숫자의 거리를 출력했습니다.

## ⏳ 회고
어제에 이어서 소수와 관련된 문제를 풀었는데, 소수 판별을 할 수 있었으면 간단하게 BFS를 이용하여 풀 수 있었습니다.
