### PR TITLE
[20260122] BOJ / G5 / 트리와 쿼리 / 한종욱

### DIFF
--- a/Ukj0ng/202601/22 BOJ G5 트리와 쿼리.md
+++ b/Ukj0ng/202601/22 BOJ G5 트리와 쿼리.md
@@ -1,0 +1,63 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static List<Integer>[] graph;
+    private static int[] nodes;
+    private static boolean[] visited;
+    private static int N, R, Q;
+
+    public static void main(String[] args) throws IOException {
+        init();
+
+        countSubNodes(R);
+        while (Q-->0) {
+            int q = Integer.parseInt(br.readLine());
+            bw.write(nodes[q] + "\n");
+        }
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        R = Integer.parseInt(st.nextToken());
+        Q = Integer.parseInt(st.nextToken());
+
+        graph = new List[N+1];
+        nodes = new int[N+1];
+        visited = new boolean[N+1];
+
+        for (int i = 1; i <= N; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        Arrays.fill(nodes, 1);
+
+        for (int i = 0; i < N-1; i++) {
+            st = new StringTokenizer(br.readLine());
+            int U = Integer.parseInt(st.nextToken());
+            int V = Integer.parseInt(st.nextToken());
+
+            graph[U].add(V);
+            graph[V].add(U);
+        }
+    }
+
+    private static void countSubNodes(int start) {
+        visited[start] = true;
+
+        for (int next : graph[start]) {
+            if (visited[next]) continue;
+            countSubNodes(next);
+            nodes[start] += nodes[next];
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/15681
## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
각 트리의 서브쿼리의 노드 개수를 구하시오.
## 🔍 풀이 방법
처음엔 BFS로 구하려고 했는데, 모든 상태를 전이하는 것이 말이 안됐다. 

DFS로 바텀업 형식으로 구현했다.

```
for (int next : graph[start]) {
        if (visited[next]) continue;
        countSubNodes(next);
        nodes[start] += nodes[next];
}
```
## ⏳ 회고
트리부분을 하기 싫었는데 이제 시작한다.