### PR TITLE
[20260122] BOJ / G4 / 트리 순회 / 이인희

### DIFF
--- a/LiiNi-coder/202601/22 BOJ 트리 순회.md
+++ b/LiiNi-coder/202601/22 BOJ 트리 순회.md
@@ -1,0 +1,92 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Main {
+	private static int[] BiTree;
+	private static Map<Integer, Integer> TreeIdxAtValue;
+	private static int answer = 0;
+	private static Deque<Integer> InnerFind;
+	private static Map<Integer, int[]> ChildsAtParent;
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int n = Integer.parseInt(br.readLine());
+		BiTree = new int[200_010];
+		InnerFind = new ArrayDeque<>();
+		TreeIdxAtValue = new HashMap<>();
+		ChildsAtParent = new HashMap<>();
+		BiTree[1] = 1;
+		TreeIdxAtValue.put(1, 1);
+		int i = n;
+		while(i-->0) {
+			String[] temp = br.readLine().split(" ");
+			int parent = Integer.parseInt(temp[0]);
+			int a = Integer.parseInt(temp[1]);
+			int b = Integer.parseInt(temp[2]);
+
+			ChildsAtParent.put(parent, new int[] {a, b});
+		}
+		dfsTree(1, 1);
+		// System.out.println(Arrays.toString(BiTree));
+		//중위순회 마지막 노드 알아내기
+		findLast(1);
+		answer--;
+		dfs(1);
+		System.out.println(answer);
+		br.close();
+	}
+
+	private static void dfsTree(int value, int idx){
+		BiTree[idx] = value;
+		int[] childValues = ChildsAtParent.get(value);
+		BiTree[idx*2] = childValues[0];
+		BiTree[idx*2+1] = childValues[1];
+		if(childValues[0] != -1)
+			dfsTree(childValues[0], idx*2);
+		if(childValues[1] != -1)
+			dfsTree(childValues[1], idx*2+1);
+	}
+
+	private static void findLast(int cur) {
+		int a = cur*2;
+		int b = cur*2+1;
+		// 왼쪽자식 갈수있으면
+		if(BiTree[a] != 0 && BiTree[a] != -1){
+			findLast(a);
+		}
+		InnerFind.offerLast(cur);
+		// 오른쪽자식 갈수있으면
+		if(BiTree[b] != 0 && BiTree[b] != -1){
+			findLast(b);
+		}
+	}
+	private static void dfs(int cur) {
+		answer++;
+		int a = cur*2;
+		int b = cur*2+1;
+		// 왼쪽자식 갈수있으면
+		if(BiTree[a] != 0 && BiTree[a] != -1){
+			dfs(a);
+			answer++;
+		}
+
+		// 오른쪽자식 갈수있으면
+		if(BiTree[b] != 0 && BiTree[b] != -1){
+			dfs(b);
+			answer++;
+		}
+
+		// 유사중위 순회의 끝이라면
+		if(InnerFind.getLast() == cur){
+			System.out.println(answer);
+			System.exit(0);
+		}
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/22856
## 🧭 풀이 시간
80 분

## 👀 체감 난이도
- [ ] 상
- [X] 중
- [ ] 하
## ✏️ 문제 설명
- 이진 트리 주어지고, 부모-자식2개 관계가 트리 노드개수만큼 주어질 때, 중위순회하면서 노드를 갈아탄 횟수 출력
## 🔍 풀이 방법
- 배열기반 이진트리 사용 및 DFS하며 중위순회끝 노드를 알아내고, 한번다시 DFS돌려서 중위순회끝이면 프로그램 꺼지게(RECUR 탈출)
## ⏳ 회고
- 무지성 `이진 트리 -> 배열로!` 을 하면 안된다는 것을 알아내준 좋은 문제였다.
- 해당 문제는 전혀 `이진완전트리` 라는 말이없다. 이진완전트리일때만 배열을 생각하자 제발. 한쪽으로 치우쳐진 트리인경우때문에 배열  ArrayOutBound가 난다.
- 이 문제를 내일 다시 노드기반 트리자료구조로 바꿔서 풀것임