### PR TITLE
[20260123] BOJ / G4 / 배열 돌리기 4 / 이준희

### DIFF
--- a/JHLEE325/202601/23 BOJ G4 배열 돌리기 4.md
+++ b/JHLEE325/202601/23 BOJ G4 배열 돌리기 4.md
@@ -2,6 +2,7 @@
 import java.io.*;
 import java.util.*;
 
+
 public class Main {
     static int N, M, K;
     static int[][] originalBoard;


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17406

## 🧭 풀이 시간
70분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
회전 연산은 세 정수 (r, c, s)로 이루어져 있고, 가장 왼쪽 윗 칸이 (r-s, c-s), 가장 오른쪽 아랫 칸이 (r+s, c+s)인 정사각형을 시계 방향으로 돌리는 연산이라고 할 때
주어지는 회전연산들을 여러가지 순서로 진행했을 때 배열의 최솟값을 구하는 문제입니다.

여기서 배열의 값이란 각 행에 있는 모든 수의 합 중 최솟값 입니다

## 🔍 풀이 방법
순열을 이용한 구현 문제였습니다.
주어지는 회전연산들을 여러가지 순서로 배열하여 그 값중 최소를 구해야했기 때문에 순열을 이용했습니다.

각 케이스마다 모든 연산을 진행했을 때 값을 비교해서 최솟값을 구햇습니다.

## ⏳ 회고
처음에는 그냥 주어지는 순서대로 연산을 진행해서 시간을 허비했습니다.
