### PR TITLE
[20260123] BOJ / G2 / 우수 마을 / 한종욱

### DIFF
--- a/Ukj0ng/202601/23 BOJ G2 우수 마을.md
+++ b/Ukj0ng/202601/23 BOJ G2 우수 마을.md
@@ -1,0 +1,58 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static List<Integer>[] graph;
+    private static int[][] dp;
+    private static int[] nodes;
+    private static int N;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        DFS(1, -1);
+
+        bw.write(Math.max(dp[1][0], dp[1][1]) + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        graph = new List[N+1];
+        dp = new int[N+1][2];
+        nodes = new int[N+1];
+
+        for (int i = 1; i <= N; i++) {
+            graph[i] = new ArrayList<>();
+            nodes[i] = Integer.parseInt(st.nextToken());
+        }
+
+        for (int i = 0; i < N-1; i++) {
+            st = new StringTokenizer(br.readLine());
+            int U = Integer.parseInt(st.nextToken());
+            int V = Integer.parseInt(st.nextToken());
+
+            graph[U].add(V);
+            graph[V].add(U);
+        }
+    }
+
+    private static void DFS(int current, int parent) {
+        dp[current][0] = nodes[current];
+        dp[current][1] = 0;
+        for (int next : graph[current]) {
+            if (next == parent) continue;
+            DFS(next, current);
+
+            dp[current][0] += dp[next][1];
+            dp[current][1] += Math.max(dp[next][0], dp[next][1]);
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1949
## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
우수 마을을 선정할 때, 해당 우수 마을들의 주민의 총 합이 제일 높을 때의 주민의 수는?
1. 우수 마을은 서로 인접하면 안된다.
2. 마을은 트리구조로 주어진다.
3. 우수 마을이 아닌 마을은 꼭 우수 마을에 인접해야 한다. 
## 🔍 풀이 방법
DFS로 우수 마을의 리프노드까지 탐색한 다음 마지막에서부터 다시 올라가는 바텀업으로 풀어야 한다. 
## ⏳ 회고
BFS로 처음에 접근했다가 말도 안되게 상태정의를 열심히 해야해서 힘들었다.