### PR TITLE
[20260123] BOJ / P5 / 도로포장 / 김민진

### DIFF
--- a/zinnnn37/202601/23 BOJ P5 도로포장.md
+++ b/zinnnn37/202601/23 BOJ P5 도로포장.md
@@ -1,0 +1,108 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class BJ_1162_도로포장 {
+
+    private static final long INF = 50_000_000_001L;
+
+    private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static       StringTokenizer st;
+
+    private static int N, M, K;
+    private static long[][]     dist;
+    private static List<Node>[] graph;
+    private static Queue<Node>  pq;
+
+    private static class Node implements Comparable<Node> {
+        int  to;
+        long cost;
+        int  cnt;
+
+        public Node(int to, long cost, int cnt) {
+            this.to = to;
+            this.cost = cost;
+            this.cnt = cnt;
+        }
+
+        @Override
+        public int compareTo(Node o) {
+            return Long.compare(this.cost, o.cost);
+        }
+
+    }
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+        graph = new List[N + 1];
+        for (int i = 1; i <= N; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            int c = Integer.parseInt(st.nextToken());
+
+            graph[a].add(new Node(b, c, 0));
+            graph[b].add(new Node(a, c, 0));
+        }
+
+        dist = new long[N + 1][K + 1];
+        for (int i = 1; i <= N; i++) {
+            Arrays.fill(dist[i], INF);
+        }
+
+        pq = new PriorityQueue<>();
+    }
+
+    private static void sol() throws IOException {
+        pq.offer(new Node(1, 0, 0));
+        dist[1][0] = 0;
+
+        while (!pq.isEmpty()) {
+            Node cur = pq.poll();
+
+            if (cur.cost > dist[cur.to][cur.cnt]) {
+                continue;
+            }
+
+            for (Node next : graph[cur.to]) {
+                long nextCost = dist[cur.to][cur.cnt] + next.cost;
+
+                // not exclude
+                if (nextCost < dist[next.to][cur.cnt]) {
+                    dist[next.to][cur.cnt] = nextCost;
+                    pq.offer(new Node(next.to, nextCost, cur.cnt));
+                }
+
+                if (cur.cnt < K && cur.cost < dist[next.to][cur.cnt + 1]) {
+                    dist[next.to][cur.cnt + 1] = cur.cost;
+                    pq.offer(new Node(next.to, cur.cost, cur.cnt + 1));
+                }
+            }
+        }
+
+        long ans = INF;
+        for (int i = 0; i <= K; i++) {
+            ans = Math.min(ans, dist[N][i]);
+        }
+        bw.write(ans + "");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[도로포장](https://www.acmicpc.net/problem/1162)

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
임의의 `K`개 간선의 가중치를 0으로 만들 수 있을 때 `1`부터 `N`까지의 최단거리를 구하시오

## 🔍 풀이 방법
다익스트라 + dp

`dist`를 2차원으로 두어서 간선을 `j`번 0으로 만들었을 때의 최단거리 저장
`1`과 `N`을 연결하는 간선의 갯수가 `K`가 되지 않을 수 있기 때문에 무조건 `K`번 다 사용한다고 최단거리가 보장되는 것이 아님
→ 이 경우 `dist[N][간선 수]`에 0이 저장되고 그 이후로는 `INF`가 저장됨

## ⏳ 회고
가중치가 long인지 여부를 꼭 확인하자^^