### PR TITLE
[20260124] BOJ / P4 / 탈옥 / 김민진

### DIFF
--- a/zinnnn37/202601/24 BOJ P4 탈옥.md
+++ b/zinnnn37/202601/24 BOJ P4 탈옥.md
@@ -1,0 +1,142 @@
+```java
+import java.io.*;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.StringTokenizer;
+
+public class BJ_9376_탈옥 {
+
+    private static final int   INF = 10001;
+    private static final int[] dx  = { -1, 1, 0, 0 };
+    private static final int[] dy  = { 0, 0, -1, 1 };
+
+    private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static final StringBuilder   sb = new StringBuilder();
+    private static       StringTokenizer st;
+
+    private static int H, W;
+    private static int[][]     prisoners;
+    private static int[][][]   dist;
+    private static char[][]    matrix;
+    private static Deque<Node> dq;
+
+    private static class Node {
+        int x;
+        int y;
+        int cnt;
+
+        Node(int x, int y, int cnt) {
+            this.x = x;
+            this.y = y;
+            this.cnt = cnt;
+        }
+
+    }
+
+    public static void main(String[] args) throws IOException {
+        int T = Integer.parseInt(br.readLine());
+
+        while (T-- > 0) {
+            init();
+            sol();
+        }
+
+        bw.write(sb.toString());
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        st = new StringTokenizer(br.readLine());
+        H = Integer.parseInt(st.nextToken());
+        W = Integer.parseInt(st.nextToken());
+
+        prisoners = new int[2][2];
+        int idx = 0;
+
+        matrix = new char[H + 2][W + 2];
+        dist = new int[3][H + 2][W + 2];
+
+        for (int i = 0; i < H + 2; i++) {
+            Arrays.fill(dist[0][i], INF);
+            Arrays.fill(dist[1][i], INF);
+            Arrays.fill(dist[2][i], INF);
+            Arrays.fill(matrix[i], '.');
+        }
+
+        for (int i = 1; i <= H; i++) {
+            String line = br.readLine();
+            for (int j = 1; j <= W; j++) {
+                matrix[i][j] = line.charAt(j - 1);
+
+                if (matrix[i][j] == '$') {
+                    prisoners[idx][0] = i;
+                    prisoners[idx++][1] = j;
+                    matrix[i][j] = '.';
+                }
+            }
+        }
+
+        dq = new ArrayDeque<>();
+    }
+
+    private static void sol() {
+        bfs(0, 0, 0);
+        bfs(1, prisoners[0][0], prisoners[0][1]);
+        bfs(2, prisoners[1][0], prisoners[1][1]);
+
+        int ans = INF;
+        for (int i = 0; i < H + 2; i++) {
+            for (int j = 0; j < W + 2; j++) {
+                if (matrix[i][j] == '*') continue;
+
+                int sum = dist[0][i][j] + dist[1][i][j] + dist[2][i][j];
+                if (matrix[i][j] == '#') sum -= 2;
+
+                ans = Math.min(ans, sum);
+            }
+        }
+
+        sb.append(ans).append('\n');
+    }
+
+    private static void bfs(int id, int x, int y) {
+        dq.clear();
+        dq.offer(new Node(x, y, 0));
+        dist[id][x][y] = 0;
+
+        while (!dq.isEmpty()) {
+            Node cur = dq.poll();
+
+            if (dist[id][cur.x][cur.y] < cur.cnt) continue;
+
+            for (int d = 0; d < 4; d++) {
+                int nx = cur.x + dx[d];
+                int ny = cur.y + dy[d];
+
+                if (OOB(nx, ny) || matrix[nx][ny] == '*') continue;
+
+                int newDist = matrix[nx][ny] == '#' ? cur.cnt + 1 : cur.cnt;
+
+                if (newDist < dist[id][nx][ny]) {
+                    dist[id][nx][ny] = newDist;
+
+                    if (newDist == cur.cnt) {
+                        dq.offerFirst(new Node(nx, ny, newDist));
+                    } else {
+                        dq.offerLast(new Node(nx, ny, newDist));
+                    }
+                }
+            }
+        }
+    }
+
+    private static boolean OOB(int x, int y) {
+        return x < 0 || H + 2 <= x || y < 0 || W + 2 <= y;
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[탈옥](https://www.acmicpc.net/problem/9376)

## 🧭 풀이 시간
110분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
감옥에 있는 두 죄수를 모두 탈옥시키기 위해 열어야하는 문의 최소 갯수는?

## 🔍 풀이 방법
0-1 BFS 그런데 `dist` 배열을 3차원으로 두는..

감옥은 가장자리 문이 어디 달렸을지 모르니까 패딩을 넣어줌
```java
dist = new int[3][H+2][W+2]
```
→ 죄수 1, 죄수 2, `(0, 0)` 각각 세 지점에서 출발했을 때 열 수 있는 최소한의 문의 갯수를 `dist`에 저장

답은 `dist` 순회하면서 나온 최솟값
처음에는 죄수 2명만 가지고 계산했었는데 죄수 2명은 모두 감옥 내에 있기 때문에 둘만 가지고 계산하면 감옥 안에서 만난다고 할 때 열어야하는 문의 최솟값을 구하는 것이 됨
그렇기 때문에 감옥 밖의 제3자가 필요한 것..
답을 구할 때는 빈 칸일 때는 각자가 열고 온 문의 총합을 구하고 문일 때는 문에서 세 명이 모인 것이기 때문에 중복 제거(`-2`)

## ⏳ 회고
`dist`를 3차원으로 둬야겠다는 접근은 나름 해봤는데 감옥 외부의 존재를 넣을 생각은 안남.. 진짜 어려웟다..
GPT가 요즘 똑똑하대서 문제 이해하는데 다시 써봤는데 나를 이해시키지 못함...... 말도 너무 많아.......