### PR TITLE
[20260127] BOJ / G4 / 약수의 합 / 한종욱

### DIFF
--- a/Ukj0ng/202601/27 BOJ G4 약수의 합.md
+++ b/Ukj0ng/202601/27 BOJ G4 약수의 합.md
@@ -1,0 +1,43 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static final int MAX = 1000000;
+    private static long[] f, g;
+    private static int N;
+
+    public static void main(String[] args) throws IOException {
+        int T = Integer.parseInt(br.readLine());
+        f = new long[MAX+1];
+        g = new long[MAX+1];
+
+        Arrays.fill(f, 1);
+
+        for (int i = 2; i <= MAX; i++) {
+            for (int j = 1; i*j <= MAX; j++) {
+                f[i*j] += i;
+            }
+        }
+
+        for (int i = 1; i <= MAX; i++) {
+            g[i] = g[i-1]+f[i];
+        }
+
+        while (T-->0) {
+            init();
+            bw.write(g[N] + "\n");
+        }
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17425
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
f(x): x의 약수들의 합
g(x): 1~x들의 f(x)의 합
자연수 N이 주어졌을 때, g(N)을 구하라
## 🔍 풀이 방법
1. 약수를 구하기
약수들의 합을 직접 구하고 f(x)를 구하면 메모이제이션으로 풀었다. -> 시간 초과

2. 배수로 구하기
i면, i의 배수에 i를 더하는 방식으로 풀었다. N의 최댓값이 1000000이기 때문에 미리 다 구해놓고 누적합으로 구했다.
## ⏳ 회고
약수를 구하는 게 아니라 배수로 더하는 게 매우 참신한 풀이였다.