### PR TITLE
[20260127] BOJ / G3 / 세 용액 / 김민진

### DIFF
--- a/zinnnn37/202601/27 BOJ G3 세 용액.md
+++ b/zinnnn37/202601/27 BOJ G3 세 용액.md
@@ -1,0 +1,70 @@
+```java
+import java.io.*;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BJ_2473_세_용액 {
+
+    private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static       StringTokenizer st;
+
+    private static int N, selected, left, right;
+    private static long sum, min;
+    private static int[] solutions, idx;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+        min = Long.MAX_VALUE;
+
+        idx = new int[3];
+        solutions = new int[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            solutions[i] = Integer.parseInt(st.nextToken());
+        }
+        Arrays.sort(solutions);
+    }
+
+    private static void sol() throws IOException {
+        for (int i = 0; i < N - 2; i++) {
+            selected = solutions[i];
+
+            left = i + 1;
+            right = N - 1;
+            while (left < right) {
+                sum = (long) solutions[left] + solutions[right] + selected;
+                System.out.println(selected + " " + solutions[left] + " " + solutions[right]);
+                System.out.println(sum + " " + min);
+
+                if (Math.abs(sum) < min) {
+                    min = Math.abs(sum);
+                    idx[0] = i;
+                    idx[1] = left;
+                    idx[2] = right;
+                }
+
+                if (sum == 0) {
+                    bw.write(selected + " " + solutions[left] + " " + solutions[right]);
+                    return;
+                } else if (sum < 0) {
+                    left++;
+                } else {
+                    right--;
+                }
+            }
+        }
+        bw.write(solutions[idx[0]] + " " + solutions[idx[1]] + " " + solutions[idx[2]]);
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[세 용액](https://www.acmicpc.net/problem/2473)

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
주어진 용액 중 세 가지를 골라서 합이 0에 가장 가까운 값을 만들 수 있는 용액을 오름차순으로 출력하시오

## 🔍 풀이 방법
투포인터

용액을 순회하면서(하나 고정) 그 이후 범위만큼 투포인터 사용
세 용액의 합은 정수 범위를 넘어가므로 오버플로우 조심

## ⏳ 회고
정수형끼리 더하고 `long`에 넣으려면 정수형을 캐스팅 하자