### PR TITLE
[20260128] BOJ / G4 / 트리의 지름(물음표) / 이인희

### DIFF
--- a/LiiNi-coder/202601/28 BOJ 트리의 지름(물음표).md
+++ b/LiiNi-coder/202601/28 BOJ 트리의 지름(물음표).md
@@ -1,0 +1,42 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+import java.util.Queue;
+import java.util.LinkedList;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+
+        solve(n, k);
+    }
+
+    private static void solve(int n, int k) {
+        Queue<Integer> q = new LinkedList<Integer>();
+        q.offer(1);
+        int next = 2;
+        int edgeCount = 0;
+        while (!q.isEmpty() && next <= n) {
+            int current = q.poll();
+            for (int i = 0; i < k && next <= n; i++) {
+                System.out.println(current + " " + next);
+                q.offer(next);
+                next++;
+                edgeCount++;
+
+                
+                if (edgeCount == n - 1) {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/30391
## 🧭 풀이 시간
50 분

## 👀 체감 난이도
- [ ] 상
- [X] 중
- [ ] 하
## ✏️ 문제 설명
- 1부터 n까지의 정점을 가지는 그래프에 n-1개의 간선으로 트리를 만들때, 차수 K개 이하룰 가지면서 가장 짧은 트리의 지름을 가지도록하는 트리를 출력
## 🔍 풀이 방법
- 풀다 시간없어서 올립니다
## ⏳ 회고
- 풀다 시간없어서 올립니다