### PR TITLE
[20260129] BOJ / G4 / 개근상 / 이준희

### DIFF
--- a/JHLEE325/202601/29 BOJ G4 개근상.md
+++ b/JHLEE325/202601/29 BOJ G4 개근상.md
@@ -1,0 +1,45 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    
+    static int MOD = 1000000;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+
+        int[][][] dp = new int[N + 1][2][3];
+
+        dp[0][0][0] = 1;
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < 2; j++) {
+                for (int k = 0; k < 3; k++) {
+                    if (dp[i][j][k] == 0) continue;
+
+                    dp[i + 1][j][0] = (dp[i + 1][j][0] + dp[i][j][k]) % MOD;
+
+                    if (j + 1 < 2) {
+                        dp[i + 1][j + 1][0] = (dp[i + 1][j + 1][0] + dp[i][j][k]) % MOD;
+                    }
+
+                    if (k + 1 < 3) {
+                        dp[i + 1][j][k + 1] = (dp[i + 1][j][k + 1] + dp[i][j][k]) % MOD;
+                    }
+                }
+            }
+        }
+
+        int ans = 0;
+        for (int j = 0; j < 2; j++) {
+            for (int k = 0; k < 3; k++) {
+                ans = (ans + dp[N][j][k]) % MOD;
+            }
+        }
+
+        System.out.println(ans);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1563

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
백준 중학교에서 개근상을 주려고 할 때 개근상의 조건이 특이합니다.
출결사항이 기록되는 출결은 출석, 지각, 결석이고,
개근상을 받을 수 없는 사람은 지각을 두 번 이상 했거나, 결석을 세 번 연속으로 한 사람입니다.

N일의 학기를 마치고 개근상을 수여하려고 할 때
개근상이 가능한 경우의 수를 구하는 문제입니다.

## 🔍 풀이 방법
DP를 이용해서 풀었습니다.
3차원 dp로 [날짜][지각 횟수][연속 결석 횟수] 로 두고 계산했습니다.

최종적으로 N일 일 때 지각횟수가 2회 미만이면서 연속 결석 일수가 3 미만은 모든 칸의 수를 합하여
정답을 구했습니다.

## ⏳ 회고
N이 1000으로 그렇게 크지 않았기 때문에 3차원으로 쉽게 풀 수 있었던 것 같습니다.
