### PR TITLE
[20260130] BOJ / G3 / 소형기관차 / 이준희

### DIFF
--- a/JHLEE325/202601/30 BOJ G3 소형기관차.md
+++ b/JHLEE325/202601/30 BOJ G3 소형기관차.md
@@ -1,0 +1,35 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int N = Integer.parseInt(br.readLine());
+
+        int[] train = new int[N + 1];
+        int[] sum = new int[N + 1];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= N; i++) {
+            train[i] = Integer.parseInt(st.nextToken());
+            sum[i] = sum[i - 1] + train[i];
+        }
+
+        int K = Integer.parseInt(br.readLine());
+
+        int[][] dp = new int[4][N + 1];
+
+        for (int i = 1; i <= 3; i++) {
+            for (int j = i * K; j <= N; j++) {
+                dp[i][j] = Math.max(dp[i][j - 1], dp[i - 1][j - K] + (sum[j] - sum[j - K]));
+            }
+        }
+
+        System.out.println(dp[3][N]);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2616

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
N개의 칸을 수송하는 기차의 기관차가 고장났을 때
N/3 보다 작은 K개의 칸을 수송할 수 있는 3개의 소형기관차를 사용하여
가장 많은 사람을 수송할 수 있는 경우의 수를 구하는 문제입니다.

## 🔍 풀이 방법
dp를 이용해서 풀었습니다.
초기에 N까지의 기관차를 누적합을 통해서 수송할 수 있는 사람의 명수를 구해놓습니다.
이후 2차원 dp를 활용해서 dp[사용한 소형기관차 수][N번째 칸 까지 본 수] 를 사용했습니다.
그래서 dp[i][j] = dp[i][j-1] 과 dp[i-1][j-k] + 이전부터 K개 칸의 사람수의 합 을 식으로 사용했습니다.

## ⏳ 회고
dp에 누적합을 합쳐야 하는 문제였습니다.
초반에 생각나지 않았으면 오래걸렸을 것 같습니다.
