### PR TITLE
[20260130] BOJ / G3 / 소형기관차 / 한종욱

### DIFF
--- a/Ukj0ng/202601/30 BOJ G3 소형기관차.md
+++ b/Ukj0ng/202601/30 BOJ G3 소형기관차.md
@@ -1,0 +1,41 @@
+```
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static int[][] dp;
+    private static int[] arr;
+    private static int N, V;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        int answer = dp[3][N];
+
+        bw.write(answer + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        arr = new int[N+1];
+        dp = new int[4][N+1];
+
+        for (int i = 1; i <= N; i++) {
+            arr[i] = arr[i-1] + Integer.parseInt(st.nextToken());
+        }
+
+        V = Integer.parseInt(br.readLine());
+
+        for (int i = 1; i <= 3; i++) {
+            for (int j = V; j <= N; j++) {
+                dp[i][j] = Math.max(dp[i][j-1], arr[j] - arr[j-V] + dp[i-1][j-V]);
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2616
## 🧭 풀이 시간
1600분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
소형기관차에 사람들을 태우는데 최대 인원수는?
## 🔍 풀이 방법
dp[i][j]: i번째 기관차에 j번째 칸수를 고려했을 때 담을 수 있는 최대 인원수
로 상태 정의를 해서 풀었다. 기존에는 arr는 누적합으로 표현했다.
## ⏳ 회고
2일동안 고민해서 푼 문제. dp 상태 정의 너무 어려웡