### PR TITLE
[20260130] BOJ / G5 / 개똥벌레 / 김민진

### DIFF
--- a/zinnnn37/202601/30 BOJ G5 개똥벌레.md
+++ b/zinnnn37/202601/30 BOJ G5 개똥벌레.md
@@ -1,0 +1,64 @@
+```java
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class BJ_3020_개똥벌레 {
+
+    private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static       StringTokenizer st;
+
+    private static int N, H;
+    private static int[] stalactite, stalagmite, prefix1, prefix2;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        H = Integer.parseInt(st.nextToken());
+
+        stalactite = new int[H + 2];
+        stalagmite = new int[H + 2];
+        for (int i = 0; i < N / 2; i++) {
+            stalagmite[Integer.parseInt(br.readLine())] += 1;
+            stalactite[H - Integer.parseInt(br.readLine()) + 1] += 1;
+        }
+
+        prefix1 = new int[H + 2];
+        for (int i = 1; i <= H; i++) {
+            prefix1[i] += prefix1[i - 1] + stalactite[i];
+        }
+
+        prefix2 = new int[H + 2];
+        for (int i = H; i > 0; i--) {
+            prefix2[i] += prefix2[i + 1] + stalagmite[i];
+        }
+    }
+
+    private static void sol() throws IOException {
+        int cnt = 0;
+        int sum = 0;
+        int min = Integer.MAX_VALUE;
+        for (int i = 1; i <= H; i++) {
+            sum = prefix1[i] + prefix2[i];
+
+            if (sum == min) {
+                cnt++;
+            }
+            if (sum < min) {
+                min = sum;
+                cnt = 1;
+            }
+        }
+        bw.write(min + " " + cnt);
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[개똥벌레](https://www.acmicpc.net/problem/3020)

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
동굴에 석순과 종유석이 번갈아가면서 나타남
개똥벌레가 동굴을 지나갈 때 파괴해야하는 석순과 종유석 수가 가장 적은 경우에 몇 개를 파괴해야하는지와 그 구간의 수는?

## 🔍 풀이 방법
누적합
석순은 밑에서부터, 종유석은 위에서부터 자라니까 배열을 두 개 두고 석순은 역방향으로 누적합, 종유석은 정방향으로 누적합
두 개의 배열을 순회하면서 누적합의 합의 최솟값 업데이트 및 최솟값 갯수 카운트

## ⏳ 회고
역방향으로도 누적합을 진행하니까 패딩을 양 옆에 두 개 두기