### PR TITLE
[20260131] BOJ / G1 / 부분수열의 합 2 / 한종욱

### DIFF
--- a/Ukj0ng/202601/31 BOJ G1 부분수열의 합 2.md
+++ b/Ukj0ng/202601/31 BOJ G1 부분수열의 합 2.md
@@ -1,0 +1,94 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static int[] arr;
+    private static List<Integer> left, right;
+    private static int N, S;
+
+    public static void main(String[] args) throws IOException {
+        init();
+
+        long answer = 0;
+
+        for (int l : left) {
+            answer += upperBound(l) - lowerBound(l);
+        }
+
+        if (S == 0) answer--;
+
+        bw.write(answer + "");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        S = Integer.parseInt(st.nextToken());
+
+        arr = new int[N];
+        left = new ArrayList<>();
+        right = new ArrayList<>();
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        subSum(0, N/2, 0, left);
+        subSum(N/2, N, 0, right);
+
+        Collections.sort(left);
+        Collections.sort(right);
+    }
+
+    private static void subSum(int index, int end, int sum, List<Integer> list) {
+        if (index == end) {
+            list.add(sum);
+            return;
+        }
+
+        subSum(index+1, end, sum, list);
+        subSum(index+1, end, sum+arr[index], list);
+    }
+
+    private static int upperBound(int target) {
+        int start = 0;
+        int end = right.size()-1;
+
+        while (start <= end) {
+            int mid = start + (end - start) / 2;
+
+            if (target + right.get(mid) > S) {
+                end = mid-1;
+            } else {
+                start = mid+1;
+            }
+        }
+
+        return start;
+    }
+
+    private static int lowerBound(int target) {
+        int start = 0;
+        int end = right.size()-1;
+
+        while (start <= end) {
+            int mid = start + (end - start) / 2;
+
+            if (target + right.get(mid) >= S) {
+                end = mid-1;
+            } else {
+                start = mid+1;
+            }
+        }
+
+        return start;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1208
## 🧭 풀이 시간
120분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
부분 수열의 합이 S가 되는 경우의 수의 개수는?
## 🔍 풀이 방법
N이 최대 40이라 부분수열을 하나씩 다 구하면 시간초과가 발생한다.
수열을 두 개로 나눠서 각각 부분수열을 구하고 각 집합의 합을 비교해서 경우의 수를 계산한다.
이때, 이분 탐색을 사용하고 S가 0일 경우엔 양쪽에서 모두 안 뽑는 경우가 있기 때문에 1빼준다.
## ⏳ 회고
G선생이 없었다면 절대 못 풀었다. 특히 S가 0일 경우? 실전에서 생각할 수 있으려나