### PR TITLE
[20260131] BOJ / G5 / 줄어드는 수 / 이준희

### DIFF
--- a/JHLEE325/202601/31 BOJ G5 줄어드는수.md
+++ b/JHLEE325/202601/31 BOJ G5 줄어드는수.md
@@ -1,0 +1,44 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int N = Integer.parseInt(br.readLine());
+
+        if (N == 1) {
+            System.out.println(0);
+            return;
+        }
+
+        Queue<Long> queue = new LinkedList<>();
+        for (int i = 1; i <= 9; i++) {
+            queue.add((long) i);
+        }
+
+        int count = 1;
+
+        while (!queue.isEmpty()) {
+            long current = queue.poll();
+            count++;
+
+            if (count == N) {
+                System.out.println(current);
+                return;
+            }
+
+            long lastDigit = current % 10;
+            
+            for (int i = 0; i < lastDigit; i++) {
+                long nextNum = (current * 10) + i;
+                queue.add(nextNum);
+            }
+        }
+
+        System.out.println("-1");
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1174

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
음이 아닌 정수를 십진법으로 표기했을 때 왼쪽부터 자릿수가 감소할 때 (ex: 321, 540 등) 이 수를 감소하는 수라고 합니다.
N번째로 작은 줄어드는 수를 구하는 문제입니다.

## 🔍 풀이 방법
BFS를 이용해서 풀었습니다.
큐에 1~9를 넣으면서 만들 수 있는 모든 줄어드는 수를 구했습니다.
이 때 줄어드는 수 마다 count를 이용해서 갯수를 세고, N에 도착하면 그 수를 출력했습니다.
이 때 큐가 빌 때 까지 N에 다다르지 않으면 -1을 출력했습니다.

## ⏳ 회고
풀면서 이 방식이 맞나..? 생각 했었는데 0123456789 로 만들 수 있는 줄어드는 수의 갯수가 약 1000개로 많지 않아서 통했던 것 같습니다.
