### PR TITLE
[20250131] BOJ / G1 / 부분수열의 합 2 / 김민진

### DIFF
--- a/zinnnn37/202601/31 BOJ G1 부분수열의 합 2.md
+++ b/zinnnn37/202601/31 BOJ G1 부분수열의 합 2.md
@@ -1,0 +1,82 @@
+```java
+import java.io.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+public class BJ_1208_부분수열의_합_2 {
+
+    private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static       StringTokenizer st;
+
+    private static int N, S;
+    private static int[]                 arr;
+    private static Map<Integer, Integer> left, right;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        S = Integer.parseInt(st.nextToken());
+
+        arr = new int[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+        Arrays.sort(arr);
+
+        left = new HashMap<>();
+        right = new HashMap<>();
+    }
+
+    private static void sol() throws IOException {
+        int mid = N / 2;
+        int bit = (1 << mid);
+        for (int mask = 0; mask < bit; mask++) {
+            int sum = 0;
+            for (int idx = 0; idx < mid; idx++) {
+                if ((mask & (1 << idx)) != 0) {
+                    sum += arr[idx];
+                }
+            }
+            left.put(sum, left.getOrDefault(sum, 0) + 1);
+        }
+
+        int rightSize = N - mid;
+        bit = (1 << rightSize);
+        for (int mask = 0; mask < bit; mask++) {
+            int sum = 0;
+            for (int idx = 0; idx < rightSize; idx++) {
+                if ((mask & (1 << idx)) != 0) {
+                    sum += arr[mid + idx];
+                }
+            }
+            right.put(sum, right.getOrDefault(sum, 0) + 1);
+        }
+
+        long ans = 0;
+        for (int key : left.keySet()) {
+            if (right.containsKey(S - key)) {
+                ans += (long) left.get(key) * (right.get(S - key));
+            }
+        }
+
+        if (S == 0) {
+            ans--;
+        }
+
+        bw.write(ans + "");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[부분수열의 합 2](https://www.acmicpc.net/problem/1208)

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
주어진 수열의 부분수열의 합으로 `S`를 만들 수 있는 경우의 수는?

## 🔍 풀이 방법
`N >= 40`이라 브루트포스는 시간초과
→ 왼쪽 절반과 오른쪽 절반을 나누어 부분수열의 합을 맵에다 저장

`왼쪽 배열의 임의의 값 x * 오른쪽 배열의 S - x`를 반복문을 이용해 모두 더해주기
→ 최대 `2^20 * 2^20`가지의 경우가 나올 수 있으므로 `long`으로 구해야함

## ⏳ 회고
음 골1치고 쉬운 것 같기도..
유달리 이분탐색 태그에서 다르게 풀 수 있는 경우가 많은듯?