### PR TITLE
[20260202] BOJ / P5 / 중앙 트리 / 이강현

### DIFF
--- a/lkhyun/202602/02 BOJ P5 중앙 트리.md
+++ b/lkhyun/202602/02 BOJ P5 중앙 트리.md
@@ -1,0 +1,79 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static class Node{
+        int to, weight;
+        Node(int to, int weight){
+            this.to = to;
+            this.weight = weight;
+        }
+    }
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static List<Node>[] adjList;
+    static int[] subTreeCnt;
+    static long[] totalDistance;
+    static boolean[] visited;
+
+
+    public static void main(String[] args) throws Exception {
+        while(true){
+            int n = Integer.parseInt(br.readLine());
+            long ans = Long.MAX_VALUE;
+            if(n == 0) break;
+
+            adjList = new List[n];
+            for (int i = 0; i < n; i++) {
+                adjList[i] = new ArrayList<>();
+            }
+            for (int i = 1; i < n; i++) {
+                st = new StringTokenizer(br.readLine());
+                int from = Integer.parseInt(st.nextToken());
+                int to = Integer.parseInt(st.nextToken());
+                int weight = Integer.parseInt(st.nextToken());
+                adjList[from].add(new Node(to,weight));
+                adjList[to].add(new Node(from,weight));
+            }
+
+            subTreeCnt = new int[n];
+            totalDistance = new long[n];
+
+            visited = new boolean[n];
+            dfs(0);
+            visited = new boolean[n];
+            reRooting(0, n);
+
+            for (int i = 0; i < n; i++) {
+                ans = Math.min(ans,totalDistance[i]);
+            }
+            System.out.println(ans);
+        }
+    }
+    public static void dfs(int start){
+        if(visited[start]) return;
+
+        visited[start] = true;
+
+        for (Node next : adjList[start]) {
+            if(visited[next.to]) continue;
+            dfs(next.to);
+            subTreeCnt[start] += subTreeCnt[next.to] + 1;
+            totalDistance[start] += totalDistance[next.to] + ((long) (subTreeCnt[next.to] + 1) * next.weight);
+        }
+    }
+
+    public static void reRooting(int start, int n){
+        if(visited[start]) return;
+
+        visited[start] = true;
+
+        for (Node next : adjList[start]) {
+            if(visited[next.to]) continue;
+            totalDistance[next.to] = totalDistance[start] + ((n - (subTreeCnt[next.to]+1)* 2L) * next.weight);
+            reRooting(next.to,n);
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/7812
## 🧭 풀이 시간
2일

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
중앙 정점은 모든 정점으로 이르는 비용의 합이 가장 작은 정점임.
트리가 주어질때, 모든 정점에서 중앙 정점까지의 비용의 합을 구하자.
## 🔍 풀이 방법
dfs, rerooting
무작위 정점을 하나 정하고 dfs를 한 후에, 루트 노드를 바꿔가며 비용을 재계산함.
## ⏳ 회고
rerooting이라는 기법을 알지 못해서 공부하고 풀었는데, 현재 두 노드간 관계를 계산하는 과정에서 첫 dfs의 루트를 고정하고 진행했기에 매 순간 dfs를 해야하는거 아닌가라고 생각해서 막혀있었다. 하지만, 전체 노드의 개수를 알기 때문에 전체 노드의 수에서 다음 노드의 하위 노드 수를 빼고 현재 노드와 하위 노드는 서로 상쇄되기때문에 2를 뺀 것이 나머지 노드라는 것을 알게되어 해결할 수 있었다.