### PR TITLE
[20260202] BOJ / G4 / 소트 / 이준희

### DIFF
--- a/JHLEE325/202602/02 BOJ G4 소트.md
+++ b/JHLEE325/202602/02 BOJ G4 소트.md
@@ -1,0 +1,47 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+
+        ArrayList<Integer> list = new ArrayList<>();
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            list.add(Integer.parseInt(st.nextToken()));
+        }
+
+        int s = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i < n && s > 0; i++) {
+            int maxVal = -1;
+            int maxIdx = -1;
+
+            int limit = Math.min(i + s, n - 1);
+
+            for (int j = i; j <= limit; j++) {
+                if (list.get(j) > maxVal) {
+                    maxVal = list.get(j);
+                    maxIdx = j;
+                }
+            }
+
+            list.remove(maxIdx);
+            list.add(i, maxVal);
+
+            s -= (maxIdx - i);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int num : list) {
+            sb.append(num).append(" ");
+        }
+        System.out.println(sb.toString());
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1083

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
서로 다른 숫자들로 이루어진 수열을 소트하려고 합니다.
이 때 소트는 인접한 두 숫자의 위치를 바꾸는 행위 입니다.
수열을 S번 소트할 때 사전순으로 가장 뒤에 있는 수열을 출력하는 문제입니다.

## 🔍 풀이 방법
사전 순 가장 뒤에 있는 수열을 출력하기 위해서는
매 순간 가능한한 큰 숫자를 가져와야 합니다.
따라서 0번 idx 부터 s만큼의 범위까지의 숫자 중 가장 큰 숫자를 찾아서 가져왔습니다.

## ⏳ 회고
그리디는 항상 이게 맞나..? 긴가민가 하게 풀리는데 명확하게 설명을 잘 못하겠습니다.
