### PR TITLE
[20260203] BOJ / G5 / 랭퍼든 수열쟁이야!! / 이준희

### DIFF
--- a/JHLEE325/202602/03 BOJ G5 랭퍼든 수열쟁이야!!.md
+++ b/JHLEE325/202602/03 BOJ G5 랭퍼든 수열쟁이야!!.md
@@ -1,0 +1,57 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static int n, x, y, count;
+    static int[] arr;
+    static boolean[] used;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        x = Integer.parseInt(st.nextToken());
+        y = Integer.parseInt(st.nextToken());
+
+        arr = new int[2 * n + 1];
+        used = new boolean[n + 1];
+
+        int fixedNum = y - x - 1;
+        arr[x] = arr[y] = fixedNum;
+        used[fixedNum] = true;
+
+        check(1);
+
+        System.out.println(count);
+    }
+
+    static void check(int pos) {
+        if (pos == 2 * n + 1) {
+            count++;
+            return;
+        }
+
+        if (arr[pos] != 0) {
+            check(pos + 1);
+            return;
+        }
+
+        for (int i = 1; i <= n; i++) {
+            if (used[i]) continue;
+
+            if (pos + i + 1 <= 2 * n && arr[pos + i + 1] == 0) {
+                arr[pos] = arr[pos + i + 1] = i;
+                used[i] = true;
+
+                check(pos + 1);
+
+                arr[pos] = arr[pos + i + 1] = 0;
+                used[i] = false;
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/15918

## 🧭 풀이 시간
70분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
랭퍼드 수열은 다음 조건을 만족하는 길이 2n의 수열입니다.
1 이상 n 이하의 자연수가 각각 두 개씩 들어 있다.
두 개의 1 사이에는 정확히 1개의 수가 있다.
두 개의 2 사이에는 정확히 2개의 수가 있다.
...
두 개의 n 사이에는 정확히 n개의 수가 있다.

n이 주어졌을 때 길이 2n의 랭퍼드 수열의 개수를 구하는 문제입니다.
이 때 n과 x, y가 주어지는데 x번째와 y번째의 순서는 같다는 조건이 추가되었습니다.

## 🔍 풀이 방법
백트래킹을 통해서 풀었습니다.
1번째 칸부터 2n번째 칸까지 순회하며 값을 넣었습니다.
이 때의 규칙은 i 번째에 2를 넣는다면 i + 2 + 1 번째에 2가 들어가야 합니다.(랭퍼드 수열의 조건)
이러한 규칙을 따라서 입력 -> 백트래킹을 반복하다보면 답을 구할 수 있습니다.

## ⏳ 회고
문제 푸는 방법을 떠올리는 데 시간이 많이 걸렸습니다.
처음보는 유형의 문제였던 것 같습니다.