### PR TITLE
[20260203] BOJ / G5 / 랭퍼든 수열쟁이야!! / 김민진

### DIFF
--- a/zinnnn37/202602/03 BOJ G5 랭퍼든 수열쟁이야!!.md
+++ b/zinnnn37/202602/03 BOJ G5 랭퍼든 수열쟁이야!!.md
@@ -1,0 +1,60 @@
+```java
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class BJ_15918_랭퍼든_수열쟁이야 {
+
+    private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static       StringTokenizer st;
+
+    private static int n, x, y, fixed, ans;
+    private static int[] arr;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        x = Integer.parseInt(st.nextToken()) - 1;
+        y = Integer.parseInt(st.nextToken()) - 1;
+
+        arr = new int[2 * n];
+        fixed = y - x - 1;
+        arr[x] = arr[y] = fixed;
+    }
+
+    private static void sol() throws IOException {
+        rec(n);
+        bw.write(ans + "");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void rec(int num) {
+        if (num < 1) {
+            ans++;
+            return;
+        }
+
+        if (num == fixed) {
+            rec(num - 1);
+            return;
+        }
+
+        for (int idx = 0; idx < 2 * n; idx++) {
+            if (idx + num + 1 >= 2 * n || arr[idx] != 0 || arr[idx + num + 1] != 0) {
+                continue;
+            }
+            arr[idx] = arr[idx + num + 1] = num;
+            rec(num - 1);
+            arr[idx] = arr[idx + num + 1] = 0;
+        }
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[랭퍼든 수열쟁이야!!](https://www.acmicpc.net/problem/15918)

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
`n`까지의 숫자를 두 개씩 가지는 수열이 있음
같은 수 사이에는 해당하는 수만큼의 요소가 있어야 함 (e.g. 1 O 1, 2 O O 2, ...)
`x`번째 인덱스와 `y`번째 인덱스에 들어있는 수가 같을 때 이 조건을 만족하는 수열의 갯수는?

## 🔍 풀이 방법
1. `x`와 `y`에는 `y - x - 1`을 넣고 시작
2. `n`부터 시작해서 재귀 돌림
3. 인덱스를 순회하면서 해당 숫자만큼의 갭을 두면서 값을 채울 수 있으면 채우고 다음 수로 넘어감
4. 만약 `x` `y`에 들어있는 수인 경우 하나 건너뛰기

## ⏳ 회고
어려운거 ㅇㅈ..
큰 수가 채우기 어려운 경우라서 큰 수부터 채우면 분기를 줄일 수 있어서 더 빨리 구할 수 있음