### PR TITLE
[20260203] BOJ / G5 / 수열과 현팅 / 이인희

### DIFF
--- a/LiiNi-coder/202602/03 BOJ 수열과 헌팅.md
+++ b/LiiNi-coder/202602/03 BOJ 수열과 헌팅.md
@@ -1,0 +1,69 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int n = Integer.parseInt(br.readLine());
+		long[] ms = new long[n];
+		long[] ps = new long[n];
+		long[] sortedMs = new long[n];
+		long[] sortedPs = new long[n];
+		for (int i = 0; i < n; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			long a = Long.parseLong(st.nextToken());
+			long b = Long.parseLong(st.nextToken());
+			ms[i] = a - b;
+			ps[i] = a + b;
+			sortedMs[i] = ms[i];
+			sortedPs[i] = ps[i];
+		}
+		Arrays.sort(sortedMs);
+		Arrays.sort(sortedPs);
+
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < n; i++) {
+			long low = ms[i];
+			long high = ps[i];
+
+			int minIdx = lowerBound(sortedPs, low) + 1;
+			int maxIdx = upperBound(sortedMs, high);
+			sb.append(minIdx).append(" ").append(maxIdx).append("\n");
+		}
+		System.out.println(sb.toString());
+	}
+
+	private static int lowerBound(long[] arr, long target) {
+		int l = 0;
+		int r = arr.length;
+		while (l < r) {
+			int mid = (l + r) / 2;
+			if (arr[mid] < target) {
+				l = mid + 1;
+			} else {
+				r = mid;
+			}
+		}
+		return l;
+	}
+
+	private static int upperBound(long[] arr, long target) {
+		int l = 0;
+		int r = arr.length;
+		while (l < r) {
+			int mid = (l + r) / 2;
+			if (arr[mid] <= target) {
+				l = mid + 1;
+			} else {
+				r = mid;
+			}
+		}
+		return l;
+	}
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/20495
## 🧭 풀이 시간
65 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
수열이 주어지는데, 각 원소마다 +-값이 적혀있어서 원소에 마이너스한값과 플러스한값의 사이 중 한가지가 랜덤으로 원소로 정해지는 수열이 있다. 각각의 원소마다 있을수있는 인덱스 범위를 출력
## 🔍 풀이 방법
최댓값 수열과, 최솟값수열을 각각구하고 정렬하고 어퍼바운드 로워바운드를 구함
## ⏳ 회고
이진탐색 연습하는데 다소 생소한 문제여서 생각에서 많이 걸림