### PR TITLE
[20260205] BOJ / P4 / NP-hard / 권혁준

### DIFF
--- a/khj20006/202602/05 BOJ P4 NP-hard.md
+++ b/khj20006/202602/05 BOJ P4 NP-hard.md
@@ -1,0 +1,32 @@
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+
+const int INF = 1e9 + 7;
+int N;
+int cost[1500][1500]{}, dp[1500][1500]{};
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin >> N;
+	for (int i = 0; i < N; i++) for (int j = 0; j < N; j++) {
+		cin >> cost[i][j];
+		dp[i][j] = INF;
+	}
+
+	dp[0][1] = dp[1][0] = cost[0][1];
+	for (int x = 1; x < N - 1; x++) {
+		for (int i = 0; i < x; i++) {
+			dp[x + 1][x] = min(dp[x + 1][x], dp[i][x] + cost[i][x + 1]);
+			dp[i][x + 1] = min(dp[i][x + 1], dp[i][x] + cost[x][x + 1]);
+			dp[x + 1][i] = min(dp[x + 1][i], dp[x][i] + cost[x][x + 1]);
+			dp[x][x + 1] = min(dp[x][x + 1], dp[x][i] + cost[i][x + 1]);
+		}
+	}
+	int ans = INF;
+	for (int i = 0; i < N - 1; i++) ans = min({ ans, dp[N - 1][i], dp[i][N - 1] });
+	cout << ans;
+	
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/9520

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N개의 도시가 있고, 2차원 배열로 도시 사이의 이동 비용이 주어진다.
모든 도시를 한 번씩 방문하는 데,
번호가 K인 도시를 방문하려면 K보다 작은 번호를 가진 모든 도시를 K번을 방문하기 전에 모두 방문하거나, 방문한 후에 모두 방문해야 한다.
위의 조건을 만족하면서 모든 도시를 방문하는데 드는 시간의 최솟값을 구해보자.

## 🔍 풀이 방법
조건을 잘 분석하면 1번 도시에서 시작해서 번호의 오름차순으로 **경로 두 개**를 찾아 그 시간의 합의 최솟값을 구하는 문제가 된다.

dp[x][y] = 두 경로의 끝이 각각 x, y일 때의 최솟값으로 정의한다.
max(x, y) = z라고 하면, dp[x][y] 에서 dp[z][y], dp[x][z]로 전파가 가능하다.
바텀업으로 해결했다.

## ⏳ 회고
재활 훈련 시작