### PR TITLE
[20260206] BOJ / P5 / 비숍 / 이준희

### DIFF
--- a/JHLEE325/202602/06 BOJ P5 비숍.md
+++ b/JHLEE325/202602/06 BOJ P5 비숍.md
@@ -1,0 +1,55 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    
+    static int n;
+    static int[][] board;
+    static boolean[] diag1;
+    static boolean[] diag2;
+    static int[] maxCount = new int[2]; // 0: 검은색, 1: 흰색
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        board = new int[n][n];
+
+        diag1 = new boolean[2 * n];
+        diag2 = new boolean[2 * n];
+
+        for (int i = 0; i < n; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < n; j++) {
+                board[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        backtracking(0, 0, 0, 0);
+        backtracking(0, 1, 0, 1);
+
+        System.out.println(maxCount[0] + maxCount[1]);
+    }
+    
+    static void backtracking(int r, int c, int count, int color) {
+        maxCount[color] = Math.max(maxCount[color], count);
+
+        if (c >= n) {
+            r++;
+            c = (c % 2 == 0) ? 1 : 0;
+        }
+
+        if (r >= n) return;
+
+        if (board[r][c] == 1 && !diag1[r + c] && !diag2[r - c + n]) {
+            diag1[r + c] = true;
+            diag2[r - c + n] = true;
+            backtracking(r, c + 2, count + 1, color);
+            diag1[r + c] = false;
+            diag2[r - c + n] = false;
+        }
+
+        backtracking(r, c + 2, count, color);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1799

## 🧭 풀이 시간
4시간

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
체스판 위에 비숍을 놓을 수 있는 칸과 놓을 수 없는 칸이 주어졌을 때 (놓을 수 없더라도 이동은 가능함)
체스판 위에 놓을 수 있는 비숍의 최대 개수를 구하는 문제입니다.

비숍은 체스 규칙에 따라 이동할 수 있습니다.

## 🔍 풀이 방법
백트래킹을 이용해서 풀었습니다. 체스판의 좌측 상단부터 진행하여 모든 칸을 백트래킹으로 순회하면서
비숍의 이동 규칙과, 놓을 수 없는 곳을 고려하여 비숍을 놓으며 계산했습니다.

초기에 10초라서 풀리는대로 그냥 풀었는데, 시간초과가 났습니다. 이후 계속 생각해봐도 방법이 생각 안나서
제미나이와 함께 풀었습니다.

도출된 결과로 체스판의 특성상 흰칸, 검정칸이 존재하는데(문제에 주어지는 놓을 수 있는 칸, 없는 칸이 아닌 체스판의 격자무늬)
이 때 흰 칸에 놓인 비숍은 그 무슨 수를 쓰더라도 흰칸 끼리만 영향일 미치고, 검정칸도 마찬가지이기 때문에
두개를 분리하는 방법으로 2^n 의 복잡도를 2^(n/2) + 2^(n/2) 로 줄이는 방식이었습니다.

## ⏳ 회고
플레의 벽은 높았습니다.