### PR TITLE
[20260206] BOJ / G2 / 꼬인 전깃줄 / 김민진

### DIFF
--- a/zinnnn37/202602/6 BOJ G2 꼬인 전깃줄.md
+++ b/zinnnn37/202602/6 BOJ G2 꼬인 전깃줄.md
@@ -1,0 +1,70 @@
+```java
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class BJ_1365_꼬인_전깃줄 {
+
+    private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static       StringTokenizer st;
+
+    private static int           N;
+    private static int[]         pairs;
+    private static List<Integer> list;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+
+        pairs = new int[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            pairs[i] = Integer.parseInt(st.nextToken());
+        }
+
+        list = new ArrayList<>();
+        list.add(0);
+    }
+
+    private static void sol() throws IOException {
+        for (int pair : pairs) {
+            int size = list.size();
+            if (list.get(size - 1) < pair) {
+                list.add(pair);
+            } else {
+                int target = lowerBound(pair, size);
+
+                list.set(target, pair);
+            }
+        }
+        int forward = N - list.size() + 1;
+
+        bw.write(forward + "");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static int lowerBound(int target, int right) {
+        int left = 0;
+
+        while (left < right) {
+            int mid = left + (right - left) / 2;
+
+            if (list.get(mid) >= target) {
+                right = mid;
+            } else {
+                left = mid + 1;
+            }
+        }
+        return right;
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[꼬인 전깃줄](https://www.acmicpc.net/problem/1365)

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
전깃줄이 어떻게 연결되었는지 저장하는 수열이 있음
`i`번째 전깃줄은 해당 인덱스의 값에 해당하는 위치의 전깃줄과 연결됨
전깃줄이 꼬이면 위험해서 전깃줄을 잘라 꼬이지 않게 하려고 할 때 잘라야하는 전깃줄의 최소 갯수는?

## 🔍 풀이 방법
가장 긴 증가하는 부분수열을 구해서 `N - list.size() + 1`
`+1`을 하는 이유는 `list`에 `0`을 넣고 시작하기 때문

## ⏳ 회고
아오 `list.get(mid)` 해야하는 거 `pairs[mid]`하고 난리
근데 백준 서버 왜이래