### PR TITLE
[20260207] BOJ / P5 / IQ Test / 한종욱

### DIFF
--- a/Ukj0ng/202602/07 BOJ P5 IQ Test.md
+++ b/Ukj0ng/202602/07 BOJ P5 IQ Test.md
@@ -1,0 +1,44 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static Set<Long> visited;
+    private static long N;
+
+    public static void main(String[] args) throws IOException {
+        init();
+
+        DFS(N);
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        N = Long.parseLong(br.readLine());
+        visited = new HashSet<>();
+
+        visited.add(0L);
+        visited.add(1L);
+        visited.add(2L);
+    }
+
+    private static void DFS(long target) throws IOException{
+        if (visited.contains(target)) return;
+
+        long x = (long)Math.sqrt(target);
+        if (x*x < target) x++;
+
+        long y = x*x - target;
+
+        DFS(x);
+        DFS(y);
+
+        bw.write(x + " " + y + "\n");
+        visited.add(target);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/18665
## 🧭 풀이 시간
70분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
초기 집합에 0, 1, 2가 있다. 집합 내의 수로 $x^{2}-y$ 연산을 통해 집합에 수를 추가할 수 있다. n을 43번 이내로 만들려고 한다. 그 과정을 출력하라.
## 🔍 풀이 방법
n을 기준으로 n보다 큰 $x^{2}$의 x의 최솟값을 찾고, 거기에 대한 y값도 찾는다. 그리고 재귀함수를 진행한다. 
## ⏳ 회고
되게 간단한 문제였는데, 정말 잘못 생각했다. 어려운 재귀를 아직 못 푸는 것 같아서 더 연습해야겠다. 