### PR TITLE
[20260208] PGM / LV3 / 풍선 터트리기 / 강신지

### DIFF
--- a/ksinji/202602/08 PGM 풍선 터트리기.md
+++ b/ksinji/202602/08 PGM 풍선 터트리기.md
@@ -1,0 +1,33 @@
+```java
+class Solution {
+    public int solution(int[] a) {
+        int answer = 0;
+        
+        boolean[] survive = new boolean[a.length];
+        
+        int left = Integer.MAX_VALUE;
+        
+        for (int i=0; i<a.length; i++){
+            if (left > a[i]){
+                left = a[i];
+                survive[i] = true;
+            }
+        }
+        
+        int right = Integer.MAX_VALUE;
+        
+        for (int i=a.length-1; i>=0; i--){
+            if (right > a[i]){
+                right = a[i];
+                survive[i] = true;
+            }
+        }
+        
+        for (int i=0; i<a.length; i++){
+            if (survive[i]) answer++;
+        }
+        
+        return answer;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/68646
## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
일렬로 나열된 n개의 풍선이 있으며, 인접한 두 풍선 중 하나를 터뜨리는 과정을 반복한다.
이때 번호가 더 작은 풍선을 터뜨리는 선택은 전체 과정에서 최대 1번만 가능하다.
모든 풍선을 터뜨린 뒤 마지막까지 남을 수 있는 풍선의 개수를 구하는 문제이다.
## 🔍 풀이 방법
풍선 하나가 끝까지 남으려면, 그 풍선이 자기자신 기준 왼쪽 구간 또는 오른쪽 구간 중 한쪽에서라도 최솟값이어야 한다.
두 구간 모두에서 본인이 최솟값이 아니라면 '번호가 더 작은 풍선을 터트리는 건 총 1번만 가능하다'는 조건에 의해 본인이 끝까지 남을 수 없기 때문이다.

따라서 왼쪽부터 최솟값을 갱신하며 가능한 풍선 인덱스를 true 처리해두고 오른쪽부터도 마찬가지로 처리한 뒤 마지막에 true인 풍선의 개수를 세면 된다.
## ⏳ 회고
조건을 잘 생각해보면 쉽게 풀리는 문제였다.