### PR TITLE
[20260211] BOJ / G3 / 주사위 굴리기 2 / 이준희

### DIFF
--- a/JHLEE325/202602/11 BOJ G3 주사위 굴리기 2.md
+++ b/JHLEE325/202602/11 BOJ G3 주사위 굴리기 2.md
@@ -1,0 +1,92 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static int N, M, K;
+    static int[][] map;
+    static int r = 0, c = 0, dir = 1; // 북, 동, 남, 서
+    static int[] dr = {-1, 0, 1, 0};
+    static int[] dc = {0, 1, 0, -1};
+
+    static int top = 1, bottom = 6, front = 5, back = 2, left = 4, right = 3;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+        map = new int[N][M];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) map[i][j] = Integer.parseInt(st.nextToken());
+        }
+
+        long totalScore = 0;
+
+        while (K-- > 0) {
+            int nr = r + dr[dir];
+            int nc = c + dc[dir];
+
+            if (nr < 0 || nr >= N || nc < 0 || nc >= M) {
+                dir = (dir + 2) % 4;
+                nr = r + dr[dir];
+                nc = c + dc[dir];
+            }
+            r = nr; c = nc;
+
+            roll(dir);
+
+            totalScore += getScore(r, c);
+
+            int A = bottom;
+            int B = map[r][c];
+            if (A > B) dir = (dir + 1) % 4;
+            else if (A < B) dir = (dir + 3) % 4;
+        }
+
+        System.out.println(totalScore);
+    }
+
+    static void roll(int d) {
+        int temp = top;
+        if (d == 1) { // 동
+            top = left; left = bottom; bottom = right; right = temp;
+        } else if (d == 3) { // 서
+            top = right; right = bottom; bottom = left; left = temp;
+        } else if (d == 2) { // 남
+            top = back; back = bottom; bottom = front; front = temp;
+        } else if (d == 0) { // 북
+            top = front; front = bottom; bottom = back; back = temp;
+        }
+    }
+
+    static int getScore(int startR, int startC) {
+        int B = map[startR][startC];
+        int count = 1;
+        Queue<int[]> q = new ArrayDeque<>();
+        boolean[][] visited = new boolean[N][M];
+
+        q.add(new int[]{startR, startC});
+        visited[startR][startC] = true;
+
+        while (!q.isEmpty()) {
+            int[] cur = q.poll();
+            for (int i = 0; i < 4; i++) {
+                int nr = cur[0] + dr[i];
+                int nc = cur[1] + dc[i];
+                if (nr >= 0 && nr < N && nc >= 0 && nc < M && !visited[nr][nc] && map[nr][nc] == B) {
+                    visited[nr][nc] = true;
+                    count++;
+                    q.add(new int[]{nr, nc});
+                }
+            }
+        }
+        return B * count;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/23288

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
N * M 크기의 지도의 (1,1) 칸에 주사위가 있고 주사위는 아래와 같은 규칙으로 이동합니다

1. 주사위가 이동 방향으로 한 칸 굴러간다. 만약, 이동 방향에 칸이 없다면, 이동 방향을 반대로 한 다음 한 칸 굴러간다.
2. 주사위가 도착한 칸 (x, y)에 대한 점수를 획득한다.
3. 주사위의 아랫면에 있는 정수 A와 주사위가 있는 칸 (x, y)에 있는 정수 B를 비교해 이동 방향을 결정한다.
- A > B인 경우 이동 방향을 90도 시계 방향으로 회전시킨다.
- A < B인 경우 이동 방향을 90도 반시계 방향으로 회전시킨다.
- A = B인 경우 이동 방향에 변화는 없다.

* 칸 (x, y)에 대한 점수는 다음과 같이 구할 수 있다. (x, y)에 있는 정수를 B라고 했을때, (x, y)에서 동서남북 방향으로 연속해서 이동할 수 있는 칸의 수 C를 모두 구한다. 이때 이동할 수 있는 칸에는 모두 정수 B가 있어야 한다. 여기서 점수는 B와 C를 곱한 값이다.

K번 이동을 수행했을 때의 총점을 구하는 문제입니다.

## 🔍 풀이 방법
복잡한 구현 문제였습니다.
주어진 이동 규칙에 맞게 이동시키고, 방향을 전환하는 로직을 구현했습니다.
주사위가 굴러갈 때는 각 방향에 맞게 주사위 숫자들을 이동시켜서 주사위의 현재 모습을 계속 유지했습니다.
마지막으로 점수 계산에는 BFS를 적용하여 총점을 찾았습니다.

## ⏳ 회고
대놓고 구현이었는데 문제 조건에 따라서 순서대로 구현하는 것이 중요했습니다.