### PR TITLE
[20260212] BOJ / G3 / 욕심쟁이 판다 / 한종욱

### DIFF
--- a/Ukj0ng/202602/12 BOJ G3 욕심쟁이 판다.md
+++ b/Ukj0ng/202602/12 BOJ G3 욕심쟁이 판다.md
@@ -1,0 +1,66 @@
+```
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static final int[] dx = {1, 0, -1, 0};
+    private static final int[] dy = {0, 1, 0, -1};
+    private static int[][] map;
+    private static int[][] dp;
+    private static int N, answer;
+
+    public static void main(String[] args) throws IOException {
+        init();
+
+        for (int i = 1; i <= N; i++) {
+            for (int j = 1; j <= N; j++) {
+                answer = Math.max(answer, DFS(i, j));
+            }
+        }
+
+        bw.write(answer + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+
+        map = new int[N+1][N+1];
+        dp = new int[N+1][N+1];
+
+        for (int i = 1; i <= N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 1; j <= N; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+    }
+
+    private static int DFS(int x, int y) {
+        if (dp[x][y] != 0) return dp[x][y];
+
+        dp[x][y] = 1;
+
+        for (int i = 0; i < 4; i++) {
+            int nx = x + dx[i];
+            int ny = y + dy[i];
+
+            if (OOB(nx, ny)) continue;
+
+            if (map[nx][ny] > map[x][y]) {
+                dp[x][y] = Math.max(dp[x][y], DFS(nx, ny) + 1);
+            }
+        }
+        
+        return dp[x][y];
+    }
+
+    private static boolean OOB(int nx, int ny) {
+        return nx < 1 || nx > N || ny < 1 || ny > N;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1937
## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
n x n의 크기의 대나무 숲이 있는데, 판다는 대나무를 먹고 자리를 옮기면 그 옮긴 지역에 그 전 지역보다 대나무가 많이 있어야 한다. 이 판다가 최대한 많은 칸을 이동한다면 가장 많이 이동한 횟수는?
## 🔍 풀이 방법
처음엔 DFS+DP로 풀었는데, push 방식으로 푸니 시간초과가 발생했다. 상위 노드가 하위 노드에게 "내가 도달한 횟수 + 1"로 밀어 넣는 방식이었다. 하지만 이 방식은 중간에 다른 경로로 갱신되면, 이미 계산한 모든 방식으로 또 계산해야 해서, 시간복잡도가 $2^{N}$이다. 

다음은 DFS+DP인데, pull 방식으로 풀었다. 내가 갈 수 있는 모든 방향에 대해 DFS를 호출하고, 그 반환값들 중 최댓값+1을 내 값으로 저장하는 방식을 사용했다. 
## ⏳ 회고
재귀에 대해서 좀 잘한다고 생각했는데 아직 멀었네.