### PR TITLE
[20260212] PGM / LV3 / 스티커모으기(2) / 강신지

### DIFF
--- a/ksinji/202602/12 PGM 스티커모으기(2).md
+++ b/ksinji/202602/12 PGM 스티커모으기(2).md
@@ -1,0 +1,32 @@
+```java
+class Solution {
+    public int solution(int sticker[]) {
+        int n = sticker.length;
+
+        if (n == 1) {
+            return sticker[0];
+        }
+        if (n == 2) {
+            return Math.max(sticker[0], sticker[1]);
+        }
+        
+        int first[] = new int[n];
+        first[0] = sticker[0];
+        first[1] = sticker[0];
+        
+        for (int i=2; i<n-1; i++){
+            first[i] = Math.max(first[i-1], first[i-2]+sticker[i]);
+        }
+        
+        int last[] = new int[n];
+        last[0] = 0;
+        last[1] = sticker[1];
+        
+        for (int i=2; i<n; i++){
+            last[i] = Math.max(last[i-1], last[i-2]+sticker[i]);
+        }
+        
+        return Math.max(first[n-2], last[n-1]);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/12971

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
원형으로 배치된 n개의 스티커가 있으며, 인접한 두 스티커를 동시에 뜯을 수 없다.  
각 스티커의 점수 합이 최대가 되도록 일부 스티커를 선택해야 한다.  
원형 구조이므로 첫 번째 스티커와 마지막 스티커도 서로 인접한다.

## 🔍 풀이 방법
원형 구조에서는 첫 번째 스티커와 마지막 스티커를 동시에 선택할 수 없으므로, 첫 스티커를 선택하는 경우와 선택하지 않는 경우로 나누어 생각한다.  

각 경우를 직선으로 이어진 스티커 문제로 바꾼 뒤, `dp[i] = max(dp[i-1], dp[i-2] + sticker[i])` 점화식을 이용해 최대 합을 구한다.
두 경우 중 더 큰 값이 정답이다.

## ⏳ 회고