### PR TITLE
[20260214] BOJ / G3 / 스티커 붙이기 / 이준희

### DIFF
--- a/JHLEE325/202602/14 BOJ G3 스티커 붙이기.md
+++ b/JHLEE325/202602/14 BOJ G3 스티커 붙이기.md
@@ -1,0 +1,88 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static int N, M, K;
+    static int[][] note;
+    static int R, C;
+    static int[][] sticker;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+        note = new int[N][M];
+
+        for (int s = 0; s < K; s++) {
+            st = new StringTokenizer(br.readLine());
+            R = Integer.parseInt(st.nextToken());
+            C = Integer.parseInt(st.nextToken());
+            sticker = new int[R][C];
+
+            for (int i = 0; i < R; i++) {
+                st = new StringTokenizer(br.readLine());
+                for (int j = 0; j < C; j++) sticker[i][j] = Integer.parseInt(st.nextToken());
+            }
+
+            for (int d = 0; d < 4; d++) {
+                if (tryAttach()) break;
+                rotate();
+            }
+        }
+
+        int count = 0;
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) if (note[i][j] == 1) count++;
+        }
+        System.out.println(count);
+    }
+
+    static boolean tryAttach() {
+        for (int i = 0; i <= N - R; i++) {
+            for (int j = 0; j <= M - C; j++) {
+                if (canAttach(i, j)) {
+                    attach(i, j);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    static boolean canAttach(int y, int x) {
+        for (int i = 0; i < R; i++) {
+            for (int j = 0; j < C; j++) {
+                if (sticker[i][j] == 1 && note[y + i][x + j] == 1) return false;
+            }
+        }
+        return true;
+    }
+
+    static void attach(int y, int x) {
+        for (int i = 0; i < R; i++) {
+            for (int j = 0; j < C; j++) {
+                if (sticker[i][j] == 1) note[y + i][x + j] = 1;
+            }
+        }
+    }
+
+    static void rotate() {
+        int[][] temp = new int[C][R];
+        for (int i = 0; i < R; i++) {
+            for (int j = 0; j < C; j++) {
+                temp[j][R - 1 - i] = sticker[i][j];
+            }
+        }
+        sticker = temp;
+        int t = R;
+        R = C;
+        C = t;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/18808

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
스티커가 주어지고 N*M의 노트에 스티커를 붙이려고 합니다.

이 때 스티커는 무조건 왼쪽 상단부터 붙혀야 하고 순서대로 붙힙니다.
스티커를 붙힐 칸이 안나오는 경우 90 180 270 도 회전시켜가면서 붙힙니다.

모든 스티커를 다 시도하였을 때 스티커가 붙혀진 칸의 개수를 구하는 문제입니다.

## 🔍 풀이 방법
구현문제였습니다.
주어진 스티커의 순서대로 스티커를 붙히는 과정을 구현했습니다.
그 과정에서 붙힌 경우에는 다음 스티커로, 못붙힌 경우에는 90 ~ 270도 돌려가면서 붙힐 수 있도록 구현했습니다.

## ⏳ 회고
B형에서 도형? 잉크?를 돌려서 뭔가 했던 기억이 떠오르는 문제였습니다.