### PR TITLE
[20260214] BOJ / G3 / 캐슬 디펜스 / 김민진

### DIFF
--- a/zinnnn37/202602/14 BOJ G3 캐슬 디펜스.md
+++ b/zinnnn37/202602/14 BOJ G3 캐슬 디펜스.md
@@ -1,0 +1,114 @@
+```java
+import java.io.*;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+public class BJ_17135_캐슬_디펜스 {
+
+    private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static       StringTokenizer st;
+
+    private static int N, M, D, ans;
+    private static int[]   archers;
+    private static int[][] map, grid;
+    private static Set<Integer> targets;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+
+        bw.write(ans + "");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void init() throws IOException {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        D = Integer.parseInt(st.nextToken());
+
+        map = new int[N][M];
+        grid = new int[N][M];
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        archers = new int[3];
+        targets = new HashSet<>();
+    }
+
+    private static void sol() {
+        for (int i = 0; i < M; i++) {
+            for (int j = i + 1; j < M; j++) {
+                for (int k = j + 1; k < M; k++) {
+                    archers[0] = i;
+                    archers[1] = j;
+                    archers[2] = k;
+
+                    ans = Math.max(ans, simulate());
+                }
+            }
+        }
+    }
+
+    private static int simulate() {
+        for (int i = 0; i < N; i++) {
+            grid[i] = map[i].clone();
+        }
+
+        int killed = 0;
+        for (int archerRow = N; archerRow >= 1; archerRow--) {
+            targets.clear();
+
+            for (int i = 0; i < 3; i++) {
+                findTarget(archerRow, archers[i]);
+            }
+
+            for (int target : targets) {
+                int row = target / M;
+                int col = target % M;
+                if (grid[row][col] == 1) {
+                    grid[row][col] = 0;
+                    killed++;
+                }
+            }
+        }
+
+        return killed;
+    }
+
+    private static void findTarget(int archerRow, int archerCol) {
+        int targetRow = -1;
+        int targetCol = -1;
+        int minDist   = Integer.MAX_VALUE;
+
+        for (int row = archerRow - 1; row >= 0; row--) {
+            for (int col = 0; col < M; col++) {
+                if (grid[row][col] == 0) continue;
+
+                int dist = Math.abs(archerRow - row) + Math.abs(archerCol - col);
+                if (dist > D) continue;
+
+                if (dist < minDist || (dist == minDist && col < targetCol)) {
+                    minDist = dist;
+                    targetRow = row;
+                    targetCol = col;
+                }
+            }
+        }
+
+        if (targetRow != -1) {
+            targets.add(targetRow * M + targetCol);
+        }
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[캐슬 디펜스](https://www.acmicpc.net/problem/17135)

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
궁수 3명을 배치하여 적을 최대한 많이 제거하시오
조건: 사거리 D 이내의 가장 가까운(같은 거리면 가장 왼쪽) 적을 공격하고, 공격이 끝나면 적이 한 칸 아래로 이동한다

## 🔍 풀이 방법
궁수 3명을 배치하는 모든 조합을 구하고 각 조합마다 게임을 시뮬레이션
적을 내리는 대신 궁수 행을 `+1` 함
매 턴마다 각 궁수의 사거리 내 모든 적을 순회해 거리가 최소가 되는 타겟 탐색
3명의 타겟을 `Set`에 모아서 중복으로 공격하는 상황은 제거

## ⏳ 회고
코테 대비 브루트포스 주간 시작
본가에 내려오니 헤이해지네요 연휴니까 이해해주길,,