### PR TITLE
[20260216] BOJ / G3 / 소문난 칠공주 / 이준희

### DIFF
--- a/JHLEE325/202602/16 BOJ G3 소문난 칠공주.md
+++ b/JHLEE325/202602/16 BOJ G3 소문난 칠공주.md
@@ -1,0 +1,70 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static char[][] map = new char[5][5];
+    static int[] selected = new int[7];
+    static int ans = 0;
+    static int[] dr = {-1, 1, 0, 0};
+    static int[] dc = {0, 0, -1, 1};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        for (int i = 0; i < 5; i++) {
+            map[i] = br.readLine().toCharArray();
+        }
+
+        combination(0, 0, 0);
+        System.out.println(ans);
+    }
+
+    static void combination(int idx, int cnt, int sCnt) {
+        if (cnt - sCnt > 3) return;
+
+        if (cnt == 7) {
+            if (sCnt >= 4) {
+                if (isConnected()) ans++;
+            }
+            return;
+        }
+
+        if (idx == 25) return;
+
+        selected[cnt] = idx;
+        combination(idx + 1, cnt + 1, sCnt + (map[idx / 5][idx % 5] == 'S' ? 1 : 0));
+
+        combination(idx + 1, cnt, sCnt);
+    }
+
+    static boolean isConnected() {
+        boolean[] visited = new boolean[7];
+        Deque<Integer> q = new ArrayDeque<>();
+
+        q.add(0);
+        visited[0] = true;
+        int count = 1;
+
+        while (!q.isEmpty()) {
+            int curIdx = q.poll();
+            int r = selected[curIdx] / 5;
+            int c = selected[curIdx] % 5;
+
+            for (int i = 0; i < 4; i++) {
+                int nr = r + dr[i];
+                int nc = c + dc[i];
+
+                for (int next = 0; next < 7; next++) {
+                    if (!visited[next] && selected[next] / 5 == nr && selected[next] % 5 == nc) {
+                        visited[next] = true;
+                        count++;
+                        q.add(next);
+                    }
+                }
+            }
+        }
+        return count == 7;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1941

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
5*5 교실에 각각 학생이 앉아 있는데 세력싸움을 하고 있습니다.
이다솜파와 임도연파 중 임도연파의 세력이 커져 이다솜파는 소문난 칠공주를 결성하기로 했습니다.

7명 모두 가로 또는 세로로 이어진 7명 중 이다솜파가 4명 이상인 경우의 수를 구하는 문제입니다.

## 🔍 풀이 방법
처음에는 백트래킹 방식으로 이다솜파가 4명 이상인 경우를 구하려고 하였으나
T자 같은 경우를 커버하지 못했습니다.

따라서 다른 방식 중 조합으로 이다솜파가 4명 이상인 모든 경우의 수를 찾은 후
BFS를 통해서 이 7명을 모두 방문할 수 있는지를 검사했습니다.

## ⏳ 회고
2차원 배열의 인덱스를 1차원으로 적용하는 방식을 사용해 봤습니다.