### PR TITLE
[20260218] BOJ / G3 / 사다리 조작 / 이준희

### DIFF
--- a/JHLEE325/202602/18 BOJ G3 사다리 조작.md
+++ b/JHLEE325/202602/18 BOJ G3 사다리 조작.md
@@ -1,0 +1,71 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int N, M, H, answer;
+    static int[][] map;
+    static boolean finish = false;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        H = Integer.parseInt(st.nextToken());
+
+        map = new int[H + 1][N + 1];
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            map[a][b] = 1;
+        }
+
+        for (int i = 0; i <= 3; i++) {
+            answer = i;
+            dfs(1, 0);
+            if (finish) break;
+        }
+
+        System.out.println(finish ? answer : -1);
+    }
+
+    static void dfs(int startR, int count) {
+        if (finish) return;
+        if (answer == count) {
+            if (check()) finish = true;
+            return;
+        }
+
+        for (int i = startR; i <= H; i++) {
+            for (int j = 1; j < N; j++) {
+                if (map[i][j] == 1) continue;
+                if (map[i][j - 1] == 1) continue;
+                if (j + 1 <= N && map[i][j + 1] == 1) continue;
+
+                map[i][j] = 1;
+                dfs(i, count + 1);
+                map[i][j] = 0;
+            }
+        }
+    }
+
+    static boolean check() {
+        for (int i = 1; i <= N; i++) {
+            int currentPos = i;
+            for (int j = 1; j <= H; j++) {
+                if (map[j][currentPos] == 1) {
+                    currentPos++;
+                } else if (map[j][currentPos - 1] == 1) {
+                    currentPos--;
+                }
+            }
+            if (currentPos != i) return false;
+        }
+        return true;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/15684

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
N*H크기의 사다리 타기 게임에서 가로줄을 몇개 추가하여 모든 i번째에서 출발한 것이 i번째로 들어오게 하려고 할 때
필요한 가로줄의 최소 갯수를 구하는 문제입니다.

## 🔍 풀이 방법
구현을 통해서 풀었습니다.
[H+1][N+1] 크기의 배열을 선언하여 이동하는 칸을 1로 적용시켜 시뮬레이션을 돌렸습니다.
그리고 가능한 모든 가로선에 대해 대입하여 브루트포스로 풀었습니다.

## ⏳ 회고
약 1년전에 사다리타기 문제에서 가로줄 방문처리 관련하여 무한루프 타는 경우가 있었는데
이번에는 무조건 각 탐색마다 j++을 통해서 아래로 내려가면서 이동하게 처리했습니다.
