### PR TITLE
[20260218] BOJ / G5 / 두 수의 합 / 이인희

### DIFF
--- a/LiiNi-coder/202602/18 BOJ 두수의합.md
+++ b/LiiNi-coder/202602/18 BOJ 두수의합.md
@@ -1,0 +1,52 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int t = Integer.parseInt(br.readLine());
+		StringBuilder sb = new StringBuilder();
+		while (t-- > 0) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			int n = Integer.parseInt(st.nextToken());
+			int K = Integer.parseInt(st.nextToken());
+			int[] arr = new int[n];
+			st = new StringTokenizer(br.readLine());
+			for (int i = 0; i < n; i++) {
+				arr[i] = Integer.parseInt(st.nextToken());
+			}
+
+			Arrays.sort(arr);
+			int l = 0;
+			int r = n - 1;
+			int minDiff = Integer.MAX_VALUE;
+			int count = 0;
+
+			while (l < r) {
+				int sum = arr[l] + arr[r];
+				int diff = Math.abs(K - sum);
+
+				if (diff < minDiff) {
+					minDiff = diff;
+					count = 1;
+				} else if (diff == minDiff) {
+					count++;
+				}
+				if (sum < K) {
+					l++;
+				} else {
+					r--;
+				}
+			}
+			sb.append(count).append("\n");
+		}
+
+		System.out.print(sb);
+	}
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/9024
## 🧭 풀이 시간
50 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 최대 50000개를 길이로 하는 정수 배열이 주어지고, 정수 K가 주어질때, 배열 중에서 서로다른 두개의 조합 중에서 합이 K와 가장 가까운 것의 조합 개수 출력
## 🔍 풀이 방법
- 정렬 + 투포인터
## ⏳ 회고
- 투포인터는 양끝에서도 시작할수있음을 기억하자