### PR TITLE
[20260219] BOJ / G4 / 미친 로봇 / 이준희

### DIFF
--- a/JHLEE325/202602/19 BOJ G4 미친 로봇.md
+++ b/JHLEE325/202602/19 BOJ G4 미친 로봇.md
@@ -1,0 +1,49 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static int N;
+    static double[] probs = new double[4];
+    static boolean[][] visited = new boolean[30][30];
+    static int[] dr = {0, 0, 1, -1};
+    static int[] dc = {1, -1, 0, 0};
+    static double totalProb = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        for (int i = 0; i < 4; i++) {
+            probs[i] = Integer.parseInt(st.nextToken()) * 0.01;
+        }
+
+        visited[15][15] = true;
+        dfs(15, 15, 0, 1.0);
+
+        System.out.println(totalProb);
+    }
+
+    static void dfs(int r, int c, int cnt, double currentProb) {
+        if (cnt == N) {
+            totalProb += currentProb;
+            return;
+        }
+
+        for (int i = 0; i < 4; i++) {
+            if (probs[i] == 0) continue;
+
+            int nr = r + dr[i];
+            int nc = c + dc[i];
+
+            if (!visited[nr][nc]) {
+                visited[nr][nc] = true;
+                dfs(nr, nc, cnt + 1, currentProb * probs[i]);
+                visited[nr][nc] = false;
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1405

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
로봇이 있고 이 로봇은 각각 동서남북으로 이동할 확률이 있습니다.
이 로봇이 N번 움직였을 때 같은 곳을 한번 이상 방문하지 않으면 단순한 이동이라고 합니다.

N과 로봇의 각 방향 이동확률이 주어졌을 때
이 로봇의 이동이 단순한 이동일 확률을 구하는 문제입니다.

## 🔍 풀이 방법
백트래킹을 이용해서 풀었습니다.
각 시행마다 모든 방향을 방문하면서 이 진행대로 오게될 확률을 구하고
이미 방문한 곳을 방문했다면 백트래킹으로 돌아갔습니다.

만약 이동횟수가 N과 같아지면 이 시행의 확률을 더해주었습니다.

## ⏳ 회고
백트래킹인데 확률을 첨가한 맛이었습니다.