### PR TITLE
[20260220] BOJ / G5 / 다이어트 / 이준희

### DIFF
--- a/JHLEE325/202602/20 BOJ G5 다이어트.md
+++ b/JHLEE325/202602/20 BOJ G5 다이어트.md
@@ -1,0 +1,38 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int G = Integer.parseInt(br.readLine());
+
+        long low = 1;
+        long high = 2;
+        boolean found = false;
+        StringBuilder sb = new StringBuilder();
+
+        while (true) {
+            long diff = high * high - low * low;
+
+            if (high - low == 1 && diff > G) break;
+
+            if (diff == G) {
+                sb.append(high).append("\n");
+                found = true;
+                high++;
+            } else if (diff < G) {
+                high++;
+            } else {
+                low++;
+            }
+        }
+
+        if (!found) {
+            System.out.println(-1);
+        } else {
+            System.out.print(sb.toString());
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1484

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
다이어트를 하려는 성원이가 G키로가 쪘다고 울부짖고 있습니다.
이 때 G키로는 성원이가 기억하던 예전 몸무게의 제곱과 현재 몸무게의 제곱의 차입니다.

성원이의 몸무게로 가능한 것을 오름차순으로 출력하는 문제입니다.

## 🔍 풀이 방법
투포인터를 이용해서 풀었습니다.
low는1, high는2로 시작하여 제곱의 차를 구해서 G보다 낮은 경우에는 범위를 늘려가며 값을 구했습니다.
low와 high의 차가 1일 때 제곱의 차가 G보다 크다면, 앞으로는 무조건 그 차들이 계속 커지기 때문에 종료했습니다.

## ⏳ 회고
처음에는 전체 탐색을 했는데, 투포인터를 활용해야해서 생각보다 어려웠던 것 같습니다.