### PR TITLE
[20260222] BOJ / G3 / 괄호 추가하기 / 김민진

### DIFF
--- a/zinnnn37/202602/22 BOJ G3 괄호 추가하기.md
+++ b/zinnnn37/202602/22 BOJ G3 괄호 추가하기.md
@@ -1,0 +1,70 @@
+```java
+import java.io.*;
+
+public class BJ_16637_괄호_추가하기 {
+
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+    private static int N, ans;
+    private static String line;
+    private static int[]  nums;
+    private static char[] ops;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+        ans = Integer.MIN_VALUE;
+
+        int numCnt = N / 2 + 1;
+        nums = new int[numCnt];
+        ops = new char[numCnt - 1];
+
+        line = br.readLine();
+        for (int i = 0; i < N; i++) {
+            if (i % 2 == 0) {
+                nums[i / 2] = line.charAt(i) - '0';
+            } else {
+                ops[i / 2] = line.charAt(i);
+            }
+        }
+    }
+
+    private static void sol() throws IOException {
+        rec(0, nums[0]);
+
+        bw.write(ans + "");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void rec(int idx, int cur) {
+        if (idx >= ops.length) {
+            ans = Math.max(ans, cur);
+            return;
+        }
+
+        int next      = nums[idx + 1];
+        int noBracket = calc(cur, next, ops[idx]);
+        rec(idx + 1, noBracket);
+
+        if (idx + 1 < ops.length) {
+            int bracketVal  = calc(next, nums[idx + 2], ops[idx + 1]);
+            int withBracket = calc(cur, bracketVal, ops[idx]);
+            rec(idx + 2, withBracket);
+        }
+    }
+
+    private static int calc(int a, int b, char op) {
+        if (op == '+') return a + b;
+        if (op == '-') return a - b;
+        return a * b;
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[괄호 추가하기](https://www.acmicpc.net/problem/16637)

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
`+`, `-`, `*`와 한자릿 수 수로 구성된 수식이 주어질 때 괄호를 적절하게 넣어 최댓값 구하기

## 🔍 풀이 방법
브루트포스
연산자 우선순위가 없어서 괄호 없이 그냥 계산하는 경우와 다음에 괄호가 온다고 가정할 때를 나누어 재귀

## ⏳ 회고
3일 연속 코테는 좀 힘드네요