### PR TITLE
[20260222] BOJ / G4 / 가장 가까운 공통 조상 / 이준희

### DIFF
--- a/JHLEE325/202602/23 BOJ G4 가장 가까운 공통 조상.md
+++ b/JHLEE325/202602/23 BOJ G4 가장 가까운 공통 조상.md
@@ -1,0 +1,43 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+
+        while (T-- > 0) {
+            int N = Integer.parseInt(br.readLine());
+            int[] parent = new int[N + 1];
+            boolean[] visited = new boolean[N + 1];
+
+            for (int i = 0; i < N - 1; i++) {
+                StringTokenizer st = new StringTokenizer(br.readLine());
+                int p = Integer.parseInt(st.nextToken());
+                int c = Integer.parseInt(st.nextToken());
+                parent[c] = p;
+            }
+
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int nodeA = Integer.parseInt(st.nextToken());
+            int nodeB = Integer.parseInt(st.nextToken());
+
+            int current = nodeA;
+            while (current != 0) {
+                visited[current] = true;
+                current = parent[current];
+            }
+
+            current = nodeB;
+            while (current != 0) {
+                if (visited[current]) {
+                    System.out.println(current);
+                    break;
+                }
+                current = parent[current];
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/3584

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
트리의 부모자식 정보들이 주어졌을 때
2개의 노드의 조상 중 가장 가까운 공통 조상을 구하는 문제입니다(노드에서 가장 가까운, 루트에서 가장 먼)

## 🔍 풀이 방법
부모자식 정보에 따라서 트리를 구성합니다.
이후 첫번째 노드에서부터 루트로 거슬러 올라가면서 조상 정보를 기록합니다.
다음 두번째 노드에서부터 루트로 거슬러 올라가면서 첫번째 노드에서 기록한 조상 중 겹치는 부분에서 멈추고 출력합니다

## ⏳ 회고
단순하게 2번 탐색하는 문제였습니다.