### PR TITLE
[20260225] BOJ / P4 / 도시 왕복하기 1 / 이강현

### DIFF
--- a/lkhyun/202602/25 P4 도시 왕복하기 1.md
+++ b/lkhyun/202602/25 P4 도시 왕복하기 1.md
@@ -1,0 +1,74 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static class Edge {
+        int to, weight;
+        public Edge(int to, int weight) {
+            this.to = to;
+            this.weight = weight;
+        }
+    }
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int N, P;
+    static List<Integer>[] adjList;
+    static List<Edge> edges = new ArrayList<>();
+    static int ans = 0;
+
+    public static void main(String[] args) throws Exception {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        P = Integer.parseInt(st.nextToken());
+        adjList = new List[N + 1];
+        for (int i = 0; i <= N; i++) {
+            adjList[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < P; i++) {
+            st = new StringTokenizer(br.readLine());
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+            adjList[from].add(edges.size());
+            edges.add(new Edge(to, 1));
+            adjList[to].add(edges.size());
+            edges.add(new Edge(from, 0));
+        }
+
+        while (findPath()) ans++;
+        System.out.println(ans);
+    }
+
+    public static boolean findPath() {
+        int[] prev = new int[N+1];
+        Arrays.fill(prev, -1);
+        ArrayDeque<Integer> q = new ArrayDeque<>();
+        q.offer(1);
+        prev[1] = 0;
+
+        while(!q.isEmpty()){
+            int cur = q.poll();
+            if(cur == 2) break;
+            for(int i : adjList[cur]){
+                int next = edges.get(i).to;
+                if(prev[next] == -1 && edges.get(i).weight > 0){
+                    prev[next] = i;
+                    q.offer(next);
+                }
+            }
+        }
+
+        if(prev[2] == -1) return false;
+
+        int cur = 2;
+        while(cur != 1){
+            int idx = prev[cur];
+            edges.get(idx).weight--;
+            edges.get(idx ^ 1).weight++;
+            cur = edges.get(idx ^ 1).to;
+        }
+        return true;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17412
## 🧭 풀이 시간
120분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
1부터 2까지 가는 경로의 최대 개수를 구한다.
특정 경로내의 길들은 다른 경로의 포함될 수 없다.(즉, 1번만 사용가능하다.)
## 🔍 풀이 방법
최대 유량
가상의 역방향 간선을 생각하는 에드워드 카프 알고리즘을 통해 구현
BFS를 구현하는 것과 유사하게 구현하되 추가 작업이 필요했다.
먼저 prev라는 배열에 특정 노드에 올때 거쳐온 간선을 저장했다. 
이를 i라고 한다면 i ^ 1은 역방향 간선이 되는 것이다.
BFS를 진행하면서 목적지 노드에 도달할 수 있다면 간선의 weight를 수정한다.
거꾸로 거슬러 올라가면서 정방향은 -1, 역방향은 +1을 해준다.
이를 목적지 노드에 도착할 수 없을때까지 반복하면 된다.

## ⏳ 회고
최대 유량이라는 알고리즘에 흥미가 생겨서 좀 알아봤는데 재미있었다.
특히 idx와 idx ^ 1은 0과 1, 2와 3, 4와 5 ... 를 서로 참조하고 있을 수 있다는 아이디어에서 초기 인접 리스트에 간선을 넣는 방식과 일치시키면 정방향과 역방향 간선을 서로 참조할 수 있어서 간편했다. 