### PR TITLE
[20260225] BOJ / G5 / 공약수 / 김민진

### DIFF
--- a/zinnnn37/202602/25 BOJ G5 공약수.md
+++ b/zinnnn37/202602/25 BOJ G5 공약수.md
@@ -1,0 +1,56 @@
+```java
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class BJ_2436_공약수 {
+
+    private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static       StringTokenizer st;
+
+    private static int gcd, lcm;
+    private static long resA, resB;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        st = new StringTokenizer(br.readLine());
+        gcd = Integer.parseInt(st.nextToken());
+        lcm = Integer.parseInt(st.nextToken());
+    }
+
+    private static void sol() throws IOException {
+        long div = lcm / gcd;
+
+        for (int i = 1; i <= Math.sqrt(div); i++) {
+            if (div % i == 0) {
+                long a = i;
+                long b = div / i;
+
+                if (gcd(a, b) == 1) {
+                    resA = a;
+                    resB = b;
+                }
+            }
+        }
+        bw.write((resA * gcd) + " " + (resB * gcd));
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static long gcd(long a, long b) {
+        while (b != 0) {
+            long tmp = b;
+            b = a % b;
+            a = tmp;
+        }
+
+        return a;
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[공약수](https://www.acmicpc.net/problem/2436)

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
어떤 두 수의 최대공약수와 최소공배수가 주어질 때 어떤 수 쌍 찾기
수 쌍이 여러개인 경우 두 수의 합이 작은 것을 출력하시오

## 🔍 풀이 방법
유클리드 호제법..
1. `a * b == gcd * lcm`이기 때문에 주어진 두 수를 먼저 곱하기
2. 약수 구하는 것처럼 `sqrt(gcd * lcm)` 해서 확인
    → 두 약수의 차가 적어야 하기 때문에 반복문 끝까지 진행
3. 약수인 경우 `i`와 `div / i`가 서로소인 것을 확인하고 결과에 저장함
    → 서로소여야 `a`와 `b`가 각각 최대공약수, 최소공배수가 되기 때문에 두 약수의 최대공약수가 1인지 확인하는 과정 필요

## ⏳ 회고
어려워