### PR TITLE
[20260226] BOJ / P3 / 도시 왕복하기 2 / 이강현

### DIFF
--- a/lkhyun/202602/26 BOJ P3 도시 왕복하기 2.md
+++ b/lkhyun/202602/26 BOJ P3 도시 왕복하기 2.md
@@ -1,0 +1,88 @@
+ ```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static class Edge {
+        int to, weight;
+        public Edge(int to, int weight) {
+            this.to = to;
+            this.weight = weight;
+        }
+    }
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int N, P;
+    static List<Integer>[] adjList;
+    static List<Edge> edges;
+    static final int MAX = Integer.MAX_VALUE / 2;
+
+    public static void main(String[] args) throws Exception {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        P = Integer.parseInt(st.nextToken());
+
+        adjList = new List[2 * N + 1];
+        for (int i = 0; i <= 2 * N; i++) adjList[i] = new ArrayList<>();
+        edges = new ArrayList<>();
+
+        for (int i = 1; i <= N; i++) {
+            int cap = (i == 1 || i == 2) ? MAX : 1;
+            adjList[i].add(edges.size());
+            edges.add(new Edge(i + N, cap));
+            adjList[i + N].add(edges.size());
+            edges.add(new Edge(i, 0));
+        }
+
+        for (int i = 0; i < P; i++) {
+            st = new StringTokenizer(br.readLine());
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+
+            adjList[from + N].add(edges.size());
+            edges.add(new Edge(to, MAX));
+            adjList[to].add(edges.size());
+            edges.add(new Edge(from + N, 0));
+
+            adjList[to + N].add(edges.size());
+            edges.add(new Edge(from, MAX));
+            adjList[from].add(edges.size());
+            edges.add(new Edge(to + N, 0));
+        }
+
+        int ans = 0;
+        while (findPath()) ans++;
+        System.out.println(ans);
+    }
+
+    public static boolean findPath() {
+        int[] prev = new int[2 * N + 1];
+        Arrays.fill(prev, -1);
+        prev[1] = -2;
+        ArrayDeque<Integer> q = new ArrayDeque<>();
+        q.offer(1);
+
+        while (!q.isEmpty()) {
+            int cur = q.poll();
+            for (int i : adjList[cur]) {
+                int to = edges.get(i).to;
+                if (prev[to] == -1 && edges.get(i).weight > 0) {
+                    prev[to] = i;
+                    if (to == 2) {
+                        int node = 2;
+                        while (node != 1) {
+                            int idx = prev[node];
+                            edges.get(idx).weight--;
+                            edges.get(idx ^ 1).weight++;
+                            node = edges.get(idx ^ 1).to;
+                        }
+                        return true;
+                    }
+                    q.offer(to);
+                }
+            }
+        }
+        return false;
+    }
+}
+```


### PR DESCRIPTION
# 🧷 문제 링크
https://www.acmicpc.net/problem/2316
## 🧭 풀이 시간
90분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
도시들이 양방향으로 연결되어있다. 도시 1과 2를 왔다갔다 할 수 있는 경우의 수를 구하자.
이때, 한번 방문했던 도시는 다시 방문할 수 없다.
## 🔍 풀이 방법
정점 분리, 최대 유량
하나의 정점을 입구와 출구로 나누어서 가상의 간선을 하나 만든다.
도시 왕복하기 1과는 다르게 간선들은 양방향이고 무한정 사용가능하고, 정점들을 한번만 방문 가능하기에 정점 내부에서의 간선들만 1로 가중치를 설정하고 정점 외부 간선들은 MAX로 설정한다. 이후 에드몬드 카프 알고리즘을 적용한다. 
## ⏳ 회고
어제 풀었던 문제의 연장선이었다.
정점을 간선과 같이 바라보고 정점 내부에 간선을 만든다는 아이디어를 생각해내서 뿌듯하다.(정점 분리)
하지만 이후에 1과 2를 번갈아가는 횟수를 측정하는 문제였어서 그래프 업데이트를 어느 시점에 해야하는지를 생각하는게 어려웠다.
하지만 그래프가 양방향 간선의 형태로 존재하기 때문에 1에서 2로 독립적인 경로로 가는 경우만 생각하면 됐다. 

이 부분이 처음에는 이해가 잘 안됐는데, 정점 내부에 가상의 역방향 간선을 두었고 우리는 1에서 2로 갈 수 있는 경로가 존재하면 2에서 1로 갈 수 있다는 것을 알 수 있다. 다만 중복되면 안된다는 문제 조건을 충족하기 위해 가지 못한다고 가정하는 것일 뿐, 실제로는 갈 수 있다. 따라서 1에서 2로 갈 수 있는 유니크한 경로를 모두 찾으면 그것이 왔다갔다하는 모든 경우의 수가 되는 것이다.