### PR TITLE
[20260226] BOJ / G3 / 소문난 칠공주 / 김민진

### DIFF
--- a/zinnnn37/202602/26 BOJ G3 소문난 칠공주.md
+++ b/zinnnn37/202602/26 BOJ G3 소문난 칠공주.md
@@ -1,0 +1,87 @@
+```java
+import java.io.*;
+
+public class BJ_1941_소문난_칠공주 {
+
+    private static final int   N    = 5;
+    private static final int   SIZE = 25;
+    private static final int[] dx   = { -1, 1, 0, 0 };
+    private static final int[] dy   = { 0, 0, -1, 1 };
+
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+    private static int         ans;
+    private static boolean[]   visited;
+    private static boolean[][] isS;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        isS = new boolean[N][N];
+        for (int i = 0; i < N; i++) {
+            String line = br.readLine();
+            for (int j = 0; j < N; j++) {
+                isS[i][j] = line.charAt(j) == 'S';
+            }
+        }
+        visited = new boolean[1 << SIZE];
+    }
+
+    private static void sol() throws IOException {
+        for (int i = 0; i < SIZE; i++) {
+            if (!isS[i / N][i % N]) continue;
+
+            int mask = 1 << i;
+
+            visited[mask] = true;
+            dfs(1, 1, mask);
+        }
+
+        bw.write(ans + "");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void dfs(int depth, int sCount, int mask) {
+        if (7 - depth + sCount < 4) return;
+
+        if (depth == 7) {
+            ans++;
+            return;
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            if ((mask & (1 << i)) == 0) continue;
+
+            int x = i / N;
+            int y = i % N;
+
+            for (int d = 0; d < 4; d++) {
+                int nx = x + dx[d];
+                int ny = y + dy[d];
+
+                if (OOB(nx, ny)) continue;
+
+                int next     = nx * N + ny;
+                int nextMask = mask | (1 << next);
+
+                if ((mask & (1 << next)) != 0) continue;
+                if (visited[nextMask]) continue;
+
+                visited[nextMask] = true;
+                dfs(depth + 1, sCount + (isS[nx][ny] ? 1 : 0), nextMask);
+            }
+        }
+    }
+
+    private static boolean OOB(int x, int y) {
+        return x < 0 || N <= x || y < 0 || N <= y;
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[소문난 칠공주](https://www.acmicpc.net/problem/1941)

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
자리 배치가 주어짐
상하좌우 인접한 7개의 좌석을 고를 때, `S`가 포함된 자석이 4개 이상인 경우의 수는?

## 🔍 풀이 방법
`mask` 조합 탐색
`visited` 조합 중복 선택 방지

조합은 0부터 24까지로 만들고 `num / 5`, `num % 5` 해서 좌표값 구하기
재귀 돌면서 조합을 하나씩 선택 - 인접한 칸만 확인
`visited`로 탐색한 조합인지 아닌지 확인
조건에 맞으면 `+1`

## ⏳ 회고
처음엔 조합 다 구하고 그걸로 bfs 돌렸는데 시간이 좀 오래걸림
비트마스킹이 시간 줄이는 데 진짜 최고긴 하다..