### PR TITLE
[20260227] BOJ / G5 / 주사위 쌓기 / 이준희

### DIFF
--- a/JHLEE325/202602/27 BOJ G5 주사위 쌓기.md
+++ b/JHLEE325/202602/27 BOJ G5 주사위 쌓기.md
@@ -1,0 +1,60 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int N;
+    static int[][] dice;
+    static int[] pair = {5, 3, 4, 1, 2, 0};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        dice = new int[N][6];
+
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < 6; j++) {
+                dice[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        int maxTotal = 0;
+
+        for (int i = 1; i <= 6; i++) {
+            maxTotal = Math.max(maxTotal, solve(i));
+        }
+
+        System.out.println(maxTotal);
+    }
+
+    static int solve(int firstnum) {
+        int sideSum = 0;
+        int curBottom = firstnum;
+
+        for (int i = 0; i < N; i++) {
+            int bottomIdx = 0;
+            for (int j = 0; j < 6; j++) {
+                if (dice[i][j] == curBottom) {
+                    bottomIdx = j;
+                    break;
+                }
+            }
+
+            int topIdx = pair[bottomIdx];
+            int topNum = dice[i][topIdx];
+
+            int sideMax = 0;
+            for (int j = 0; j < 6; j++) {
+                if (j == bottomIdx || j == topIdx) continue;
+                sideMax = Math.max(sideMax, dice[i][j]);
+            }
+
+            sideSum += sideMax;
+            curBottom = topNum;
+        }
+
+        return sideSum;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2116

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
정육면체를 쌓으려고 합니다.
이 때 아래에 깔린 정육면체의 위에 잇는 숫자는 위에 있는 정육면체의 아래에 있는 숫자와 같습니다.
(같은 숫자가 맞닿아 있습니다)
이 때 주사위를 쌓았을 때 위 아래면이 아닌 옆면의 숫자의 합이 가장 큰 경우를 구하는 문제입니다.

## 🔍 풀이 방법
맨 아래에 있는 정육면체를 어떤식으로 놓을지에 따라 위의 정육면체들은 고정되기 때문에
아래에 있는 것의 각 면에 맞게 6번 순회합니다.
이 때 각 주사위마다 가장 큰 숫자들을 한 면으로 몰아서 계산했습니다.

## ⏳ 회고
약간 노가다식의 문제였습니다