### PR TITLE
[20260227] BOJ / P3 / 도시 왕복하기 2 / 권혁준

### DIFF
--- a/khj20006/202602/27 BOJ P3 도시 왕복하기 2.md
+++ b/khj20006/202602/27 BOJ P3 도시 왕복하기 2.md
@@ -1,0 +1,121 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static class IOManager {
+        static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        static StringTokenizer st = new StringTokenizer("");
+
+        private IOManager(){}
+
+        static String nextLine() throws Exception {
+            String line = br.readLine();
+            st = new StringTokenizer(line);
+            return line;
+        }
+
+        static String nextToken() throws Exception {
+            while (!st.hasMoreTokens())
+                nextLine();
+            return st.nextToken();
+        }
+
+        static int nextInt() throws Exception {
+            return Integer.parseInt(nextToken());
+        }
+
+        static long nextLong() throws Exception {
+            return Long.parseLong(nextToken());
+        }
+
+        static double nextDouble() throws Exception {
+            return Double.parseDouble(nextToken());
+        }
+
+        static void write(String content) throws Exception {
+            bw.write(content);
+        }
+
+        public static void close() throws Exception {
+            bw.flush();
+            bw.close();
+            br.close();
+        }
+    }
+
+    //
+
+    static final int INF = (int)1e9 + 7;
+
+    static int N, P;
+    static int ans = 0;
+    static int[][] flow, capacity;
+    static int[] level;
+
+    public static void main(String[] args) throws Exception {
+        N = IOManager.nextInt();
+        P = IOManager.nextInt();
+        flow = new int[2*N+1][2*N+1];
+        capacity = new int[2*N+1][2*N+1];
+        for(int i=3;i<=N;i++) {
+            capacity[i][i+N] = 1;
+        }
+        capacity[1][1+N] = capacity[2][2+N] = INF;
+
+        for(int i=0;i<P;i++) {
+            int a = IOManager.nextInt(), b = IOManager.nextInt();
+            capacity[a+N][b] = 1;
+            capacity[b+N][a] = 1;
+        }
+
+        while(bfs(1, 2)) {
+            while(dfs(1, INF, 2) > 0);
+        }
+        IOManager.write(ans + "\n");
+
+        IOManager.close();
+    }
+
+    public static boolean bfs(int source, int sink) {
+        level = new int[2*N+1];
+        Queue<Integer> queue = new ArrayDeque<>();
+        BitSet visited = new BitSet(2*N+1);
+        queue.add(source);
+        visited.set(source);
+        while(!queue.isEmpty()) {
+            int cur = queue.poll();
+            for(int nxt=1;nxt<=2*N;nxt++) {
+                if(!visited.get(nxt) && capacity[cur][nxt] - flow[cur][nxt] > 0) {
+                    visited.set(nxt);
+                    queue.add(nxt);
+                    level[nxt] = level[cur] + 1;
+                }
+            }
+        }
+        return visited.get(sink);
+    }
+
+    public static int dfs(int cur, int amount, int sink) {
+        if(cur == sink) {
+            ans++;
+            return amount;
+        }
+        for(int nxt=1;nxt<=2*N;nxt++) {
+            int residual = capacity[cur][nxt] - flow[cur][nxt];
+            if(residual > 0 && level[nxt] == level[cur] + 1) {
+                int min = Math.min(amount, residual);
+                int real = dfs(nxt, min, sink);
+                if(real > 0) {
+                    flow[cur][nxt] += real;
+                    flow[nxt][cur] -= real;
+                    return real;
+                }
+            }
+        }
+        return 0;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2316

## 🧭 풀이 시간
45분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
정점 N개 간선 P개인 무방향 그래프가 존재한다.
1번 도시와 2번 도시 사이를 왕복할 수 있는 최대 횟수를 구해보자.
단, 1,2번 도시를 제외한 다른 도시들은 여러 번 방문할 수 없다.

## 🔍 풀이 방법
무방향 그래프이기 때문에 1번 도시에서 2번 도시로 가는 겹치지 않는 경로의 최대 개수를 구하려고 시도했다.
-> 최대 유량을 구해 해결할 수 있지만, 도시를 중복 방문하지 않도록 추가적인 처리가 필요하다.

따라서, 정점 i의 클론 정점을 i+N으로 두고 i번 정점은 in 전용, i+N번 정점은 out 전용으로 관리했다.
다시 말하면, 간선 (u,v)에 대해 이를 용량이 1인 두 개의 간선 (u+N, v), (v+N, u)로 쪼갰다.

원래 정점에서 클론 정점으로 향하는 간선 (i, i+N)도 용량 1로 설정해주고, (1, 1+N)과 (2, 2+N)에 대해서만 예외로 용량을 INF로 설정해 주었다.

이후는 일반적인 디닉 알고리즘으로 해결했다.

## ⏳ 회고
강현이 덕분에 새로운 걸 배워서 좋았음