### PR TITLE
[20260228] BOJ / G4 / 체스판 다시 칠하기 2 / 이준희

### DIFF
--- a/JHLEE325/202602/28 BOJ G4 체스판 다시 칠하기 2.md
+++ b/JHLEE325/202602/28 BOJ G4 체스판 다시 칠하기 2.md
@@ -1,0 +1,54 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int N, M, K;
+    static char[][] board;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+        board = new char[N + 1][M + 1];
+        for (int i = 1; i <= N; i++) {
+            String line = br.readLine();
+            for (int j = 1; j <= M; j++) {
+                board[i][j] = line.charAt(j - 1);
+            }
+        }
+
+        System.out.println(Math.min(coloring('B'), coloring('W')));
+    }
+
+    static int coloring(char start) {
+        int[][] sum = new int[N + 1][M + 1];
+
+        for (int i = 1; i <= N; i++) {
+            for (int j = 1; j <= M; j++) {
+                int value = 0;
+                if ((i + j) % 2 == 0) {
+                    if (board[i][j] != start) value = 1;
+                } else {
+                    if (board[i][j] == start) value = 1;
+                }
+
+                sum[i][j] = sum[i - 1][j] + sum[i][j - 1] - sum[i - 1][j - 1] + value;
+            }
+        }
+
+        int painting = Integer.MAX_VALUE;
+        for (int i = K; i <= N; i++) {
+            for (int j = K; j <= M; j++) {
+                int count = sum[i][j] - sum[i - K][j] - sum[i][j - K] + sum[i - K][j - K];
+                painting = Math.min(painting, count);
+            }
+        }
+        return painting;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/25682

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
N X M 으로 그려져 있는 체스판이 있습니다.
이 체스판은 정상적으로 그려져 있지 않은 경우가 있어서 체스판 모양대로 격자로 흰,검 으로 다시 칠해야 합니다.
이 때 N X M 판을 K X K 만큼 잘라내었을 때 가장 적은 칸을 다시 칠하는 경우를 찾는 문제입니다.

## 🔍 풀이 방법
전체 N X M의 판을 체스판처럼 다시 칠하는 경우를 누적합을 이용해서 찾았습니다.

이후 K X K의 체스판을 잘라냈을때 왼쪽상단 우측하단 값을 통해서 K X K에서 몇개를 다시 칠해야될지 구할 수 있습니다.

이를 이용해서 K ~ N, M 만큼 순회하면서 최솟값을 찾았습니다.

## ⏳ 회고
처음에는 브루트포스로 했다가 시간초과가 나서 다시 풀었습니다.
문제의 요구조건에 따른 인사이트를 길러야할 필요가 있을 것 같습니다.