### PR TITLE
[20260228] BOJ / G5 / 계란으로 계란치기 / 김민진

### DIFF
--- a/zinnnn37/202602/28 BOJ G5 계란으로 계란치기.md
+++ b/zinnnn37/202602/28 BOJ G5 계란으로 계란치기.md
@@ -1,0 +1,81 @@
+```java
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class BJ_16987_계란으로_계란치기 {
+
+    private static final BufferedReader  br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter  bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static       StringTokenizer st;
+
+    private static int N, ans;
+    private static int[][] eggs;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+
+        eggs = new int[N][2];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+
+            eggs[i][0] = Integer.parseInt(st.nextToken());
+            eggs[i][1] = Integer.parseInt(st.nextToken());
+        }
+    }
+
+    private static void sol() throws IOException {
+        dfs(0, 0);
+
+        bw.write(ans + "");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static void dfs(int depth, int broken) {
+        if (depth == N) {
+            ans = Math.max(ans, broken);
+            return;
+        }
+
+        if (eggs[depth][0] <= 0) {
+            dfs(depth + 1, broken);
+            return;
+        }
+
+        boolean canHit = false;
+
+        for (int i = 0; i < N; i++) {
+            if (i == depth) continue;
+            if (eggs[i][0] <= 0) continue;
+
+            canHit = true;
+
+            int beforeCur = eggs[depth][0];
+            int beforeOp  = eggs[i][0];
+
+            eggs[depth][0] -= eggs[i][1];
+            eggs[i][0] -= eggs[depth][1];
+
+            int brokenNow = 0;
+            if (beforeCur > 0 && eggs[depth][0] <= 0) brokenNow++;
+            if (beforeOp > 0 && eggs[i][0] <= 0) brokenNow++;
+
+            dfs(depth + 1, broken + brokenNow);
+
+            eggs[depth][0] = beforeCur;
+            eggs[i][0] = beforeOp;
+        }
+
+        if (!canHit) {
+            dfs(depth + 1, broken);
+        }
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
[계란으로 계란치기](https://www.acmicpc.net/problem/16987)

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
계란끼리 부딪혀서 계란을 깨려고 함
내구도와 무게가 주어지는데 내구도는 부딪힌 다른 계란의 무게만큼 줄어듦 - 두 개가 동시에 깨질 수도 있음
가장 왼쪽의 계란부터 들어서 깨기 시작
한 번 치면 내려놓고 그 오른쪽 거 들어서 치기, 칠 계란 없으면 오른쪽 계란으로 계속 옮기기... 를 N번 진행해서 가장 많이 깰 수 있는 계란의 수는?

## 🔍 풀이 방법
백트래킹 완탐
사실 대놓고 `N <= 8`이라...
`depth`랑 깨진 현 시점 계란 갯수 변수 전달해서 계란 깨기
지금 들고 있는 계란이 이미 깨졌으면 패스, 아니면 반복문 돌면서 계란 깨기
만약 반복문 다 돌았는데 깰 개란 없으면 다음 사이클로 넘기기

## ⏳ 회고
문제가 거진 깜지임
딱히 영양가는 없는 것이 딱 수능 영어 지문 st
졸려서 읽느라 혼났네요