### PR TITLE
[20260301] BOJ / G4 / 유닛 이동시키기 / 이인희

### DIFF
--- a/LiiNi-coder/202603/01 BOJ 유닛 이동시키기.md
+++ b/LiiNi-coder/202603/01 BOJ 유닛 이동시키기.md
@@ -1,0 +1,87 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.StringTokenizer;
+
+public class Main {
+	private static int N;
+	private static int M;
+	private static int A;
+	private static int B;
+	private static int[][] board;
+	private static boolean[][] visited;
+	private static final int[][] Drdcs = {
+		{1, 0},
+		{0, 1},
+		{-1, 0},
+		{0, -1}
+	};
+	public static void main(String[] args)throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		A = Integer.parseInt(st.nextToken());
+		B = Integer.parseInt(st.nextToken());
+		int K = Integer.parseInt(st.nextToken());
+		board = new int[N+1][M+1];
+		visited = new boolean[N+1][M+1];
+		for(int i=0; i<K;i++){
+			st = new StringTokenizer(br.readLine());
+			int r = Integer.parseInt(st.nextToken());
+			int c = Integer.parseInt(st.nextToken());
+			board[r][c] = 1;
+		}
+		st = new StringTokenizer(br.readLine());
+		int sr = Integer.parseInt(st.nextToken());
+		int sc = Integer.parseInt(st.nextToken());
+		st = new StringTokenizer(br.readLine());
+		int er = Integer.parseInt(st.nextToken());
+		int ec = Integer.parseInt(st.nextToken());
+
+		System.out.println(bfs(sr,sc,er,ec));
+	}
+
+	private static int bfs(int sr, int sc, int er, int ec){
+		Deque<int[]> q = new ArrayDeque<>();
+		q.offer(new int[]{sr, sc, 0});
+		visited[sr][sc] = true;
+		while(!q.isEmpty()){
+			int[] cur = q.poll();
+			int r = cur[0];
+			int c = cur[1];
+			int dist = cur[2];
+			if(r==er && c==ec){
+				return dist;
+			}
+
+			for(int i=0;i<4;i++){
+				int nr = r + Drdcs[i][0];
+				int nc = c + Drdcs[i][1];
+
+				if(nr<1||nc<1||nr+A-1>N||nc+B-1>M) continue;
+				if(visited[nr][nc]) continue;
+				if(isBlocked(nr,nc)) continue;
+				visited[nr][nc] = true;
+				q.offer(new int[]{nr,nc,dist+1});
+			}
+		}
+
+		return -1;
+	}
+
+	private static boolean isBlocked(int r, int c){
+		for(int i=r; i<r+A; i++){
+			for(int j=c; j<c+B; j++){
+				if(board[i][j]==1){
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2194
## 🧭 풀이 시간
50 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- 쉬운 BFS 미로찾기인데, 유닛이 AxB 크기의 직사각형
## 🔍 풀이 방법
- 그냥 1x1로 취급하여 bfs하고, 장애물 겹치는지 판단할때만 AxB로 취급하여 판단
## ⏳ 회고
- AxB의 직사각형 안에 벽이 있는지없는지 O(1)에 어떻게 알수있을까? -> `누적합`
- 해당 문제에선 안써도 풀리지만, 누적합을 통해 시간을 많이 아낄수있음
- 일반 bfs에서 큐에 넣을때 visited에 넣는게 좋다. 그래야 한 좌표를 중복으로 bfs for루프에서 다시보는 현상이 안생김