### PR TITLE
[20260302] BOJ / G5 / 링크와 스타트 / 이준희

### DIFF
--- a/JHLEE325/202603/02 BOJ G5 링크와 스타트.md
+++ b/JHLEE325/202603/02 BOJ G5 링크와 스타트.md
@@ -1,0 +1,69 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    
+    static int N;
+    static int[][] S;
+    static boolean[] startTeam;
+    static int minDiff = Integer.MAX_VALUE;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        N = Integer.parseInt(br.readLine());
+        S = new int[N][N];
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                S[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        startTeam = new boolean[N];
+
+        divide(0);
+
+        System.out.println(minDiff);
+    }
+
+    static void divide(int idx) {
+        if (idx == N) {
+            calculate();
+            return;
+        }
+
+        startTeam[idx] = true;
+        divide(idx + 1);
+
+        startTeam[idx] = false;
+        divide(idx + 1);
+    }
+
+    static void calculate() {
+        int startSum = 0;
+        int linkSum = 0;
+
+        for (int i = 0; i < N; i++) {
+            for (int j = i + 1; j < N; j++) {
+                if (startTeam[i] && startTeam[j]) {
+                    startSum += S[i][j] + S[j][i];
+                } else if (!startTeam[i] && !startTeam[j]) {
+                    linkSum += S[i][j] + S[j][i];
+                }
+            }
+        }
+
+        int diff = Math.abs(startSum - linkSum);
+
+        if (diff == 0) {
+            System.out.println(0);
+            System.exit(0);
+        }
+
+        minDiff = Math.min(minDiff, diff);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/15661

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
회사에서 링크팀, 스타트팀을 나누어 경기를 하려고 합니다.
이 때 각 사람들은 링크팀에 속했을 때와 스타트팀에 속했을 때 능력치가 다릅니다.

게임의 재미를 위해 두 팀에 속한 사람의 능력치 합의 차이가 최소가 되는 경우를 구하는 문제입니다.

## 🔍 풀이 방법
백트래킹을 이용해서 구했습니다.
모든 사람을 다 팀에 속하게 했을 때 능력치의 합을 각각 계산해서 차이를 구했습니다.
브루트포스로 모든 경우의 수를 찾았습니다.

## ⏳ 회고
N이 크지 않아 브루트포스로 가능한 문제였습니다.