### PR TITLE
[20260303] BOJ / G4 / 도서관 / 이준희

### DIFF
--- a/JHLEE325/202603/03 BOJ G4 도서관.md
+++ b/JHLEE325/202603/03 BOJ G4 도서관.md
@@ -1,0 +1,38 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        int[] book = new int[N];
+        
+        st = new StringTokenizer(br.readLine());
+        
+        int maxDist = 0;
+        for (int i = 0; i < N; i++) {
+            book[i] = Integer.parseInt(st.nextToken());
+            maxDist = Math.max(maxDist, Math.abs(book[i]));
+        }
+
+        Arrays.sort(book);
+
+        long totalStep = 0;
+
+        for (int i = 0; i < N && book[i] < 0; i += M) {
+            totalStep += Math.abs(book[i]) * 2;
+        }
+
+        for (int i = N - 1; i >= 0 && book[i] > 0; i -= M) {
+            totalStep += book[i] * 2;
+        }
+
+        System.out.println(totalStep - maxDist);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1461

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
0에 위치한 세준이가 도서를 정리하려고 합니다.
도서의 위치는 절대값이 10000 이하인 정수이고 한번에 M권의 책을 들고 이동할 수 있습니다.

N권의 책을 모두 정리하는 데 세준이가 최소한으로 이동할 때의 이동거리를 구하는 문제입니다.

단, 마지막 책을 정리 했을 때는 다시 0으로 돌아오지 않아도 됩니다.

## 🔍 풀이 방법
배열을 정렬한 후
for문을 2개 이용하여 음수 방향으로 이동하는 것과
양수 방향으로 이동하는 것에 대해 구현했습니다.

처음 책의 위치를 받을 때 미리 절대값이 가장 큰 곳에 대해 찾아서
가장 멀리 가는 경우를 돌아오지 않을 수 있도록 하였습니다.

## ⏳ 회고
처음에는 그냥 단순하게 배열을 정리하고
M만큼 건너뛰면서 체크하려 했는데 양수와, 음수에 대해서 따로 처리해야된다는 것을 깨달았습니다.
