### PR TITLE
[20260305] BOJ / D5 / 제설 작업 / 권혁준

### DIFF
--- a/khj20006/202603/05 BOJ D5 제설 작업.md
+++ b/khj20006/202603/05 BOJ D5 제설 작업.md
@@ -1,0 +1,231 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class BOJ34757 {
+
+    static class IOManager {
+        static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        static StringTokenizer st = new StringTokenizer("");
+
+        private IOManager(){}
+
+        static String nextLine() throws Exception {
+            return br.readLine();
+        }
+
+        static String nextToken() throws Exception {
+            while (!st.hasMoreTokens()) {
+                st = new StringTokenizer(nextLine());
+            }
+            return st.nextToken();
+        }
+
+        static int nextInt() throws Exception {
+            return Integer.parseInt(nextToken());
+        }
+
+        static long nextLong() throws Exception {
+            return Long.parseLong(nextToken());
+        }
+
+        static double nextDouble() throws Exception {
+            return Double.parseDouble(nextToken());
+        }
+
+        static void write(String content) throws Exception {
+            bw.write(content);
+        }
+
+        public static void close() throws Exception {
+            bw.flush();
+            bw.close();
+            br.close();
+        }
+    }
+
+    //
+
+    static class Node {
+        int left, right;
+        long amount;
+        Node(int left, int right, long amount) {
+            this.left = left;
+            this.right = right;
+            this.amount = amount;
+        }
+    }
+
+    static class Query extends Node implements Comparable<Query> {
+        int lo, hi, mid, num;
+        Query(int left, int right, long amount, int lo, int hi, int num) {
+            super(left, right, amount);
+            this.lo = lo;
+            this.hi = hi;
+            this.mid = (lo + hi) / 2;
+            this.num = num;
+        }
+
+        @Override
+        public int compareTo(Query o) {
+            if ((this.lo + this.hi) / 2 == (o.lo + o.hi) / 2) {
+                return this.num - o.num;
+            }
+            return (this.lo + this.hi) / 2 - (o.lo + o.hi) / 2;
+        }
+    }
+
+    static class DisjointSet {
+        int[] root;
+
+        DisjointSet() {}
+
+        void init(int size) {
+            root = new int[size + 2];
+            for(int i=1;i<=size + 1;i++) {
+                root[i] = i;
+            }
+        }
+
+        int find(int x) {
+            return x == root[x] ? x : (root[x] = find(root[x]));
+        }
+
+        void union(int a, int b) {
+            int x = find(a), y = find(b);
+            if(x == y) {
+                return;
+            }
+            root[x] = y;
+        }
+    }
+
+    static class SegmentTree {
+        long[] tree;
+
+        SegmentTree() {}
+
+        void init(int size) {
+            tree = new long[size * 4];
+        }
+
+        void update(int s, int e, int i, long v, int n) {
+            if(s == e) {
+                tree[n] += v;
+                return;
+            }
+            int m = (s+e)>>1;
+            if(i <= m) {
+                update(s, m, i, v, n*2);
+            }
+            else {
+                update(m+1, e, i, v, n*2+1);
+            }
+            tree[n] = tree[n*2] + tree[n*2+1];
+        }
+
+        long rangeSum(int s, int e, int l, int r, int n) {
+            if(l > r || l > e || r < s) {
+                return 0;
+            }
+            if(l <= s && e <= r) {
+                return tree[n];
+            }
+            int m = (s+e)>>1;
+            return rangeSum(s, m, l, r, n*2) + rangeSum(m+1, e, l, r, n*2+1);
+        }
+    }
+
+    static int N, M, Q;
+    static long[] snow;
+    static Node[] works;
+    static PriorityQueue<Query> queries;
+    static SegmentTree seg = new SegmentTree();
+    static DisjointSet ds = new DisjointSet();
+    static int[] answer;
+
+    public static void main(String[] args) throws Exception {
+        N = IOManager.nextInt();
+        M = IOManager.nextInt();
+        Q = IOManager.nextInt();
+
+        snow = new long[N+2];
+        for(int i=1;i<=N;i++) {
+            snow[i] = IOManager.nextLong();
+        }
+
+        works = new Node[M];
+        for(int i=0;i<M;i++) {
+            int left = IOManager.nextInt();
+            int right = IOManager.nextInt();
+            long amount = IOManager.nextLong();
+            works[i] = new Node(left, right, amount);
+        }
+
+        queries = new PriorityQueue<>();
+        for(int i=0;i<Q;i++) {
+            int left = IOManager.nextInt();
+            int right = IOManager.nextInt();
+            long amount = IOManager.nextLong();
+            queries.add(new Query(left, right, amount, 0, M, i));
+        }
+
+        answer = new int[Q];
+        while(!queries.isEmpty()) {
+            seg.init(N);
+            ds.init(N);
+            PriorityQueue<Query> temp = new PriorityQueue<>();
+            for(int i=0;i<M;i++) {
+                int left = works[i].left, right = works[i].right;
+                long amount = works[i].amount;
+
+                int x = ds.find(left);
+                while(amount > 0 && x <= right) {
+                    long cur = seg.rangeSum(1, N, x, x, 1);
+                    long diff = Math.min(snow[x] - cur, amount);
+                    amount -= diff;
+                    seg.update(1, N, x, diff, 1);
+                    if (cur + diff == snow[x]) {
+                        ds.union(x, x + 1);
+                        x = ds.find(x + 1);
+                    }
+                }
+
+                while(!queries.isEmpty() && queries.peek().mid == i) {
+                    Query query = queries.poll();
+                    long sum = seg.rangeSum(1, N, query.left, query.right, 1);
+                    if (sum >= query.amount) {
+                        query.hi = query.mid;
+                    }
+                    else {
+                        query.lo = query.mid + 1;
+                    }
+                    query.mid = (query.lo + query.hi) / 2;
+
+                    if(query.lo >= query.hi) {
+                        answer[query.num] = query.lo + 1;
+                        if(query.lo == M) {
+                            answer[query.num] = -1;
+                        }
+                    }
+                    else {
+                        if(query.mid != M) {
+                            temp.add(query);
+                        }
+                    }
+                }
+            }
+            queries = temp;
+        }
+
+        for(int i=0;i<Q;i++) {
+            IOManager.write(answer[i] + "\n");
+        }
+
+        IOManager.close();
+    }
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/34757

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
N개의 지점이 1번부터 N번까지 일렬로 나열되어 있고, 각 지점에는 S[i] 만큼의 눈이 쌓여있다.

제설 작업이 총 M번 진행되며, i번째 작업은 다음 과정으로 이루어진다.
- 용량이 C[i]인 제설차 한 대가 L[i]번 지점에 투입되어 R[i]번 지점까지 운행하며 남아있는 눈들을 제설차에 적재한다.
- 제설차가 위치한 지점에 남아있는 모든 눈을 치우기 전까지는 다음 지점으로 운행하지 않는다.
- 제설차가 R[i]번 지점까지의 눈을 모두 치웠거나, 용량 T[i]를 모두 채웠다면 운행을 종료한다.
작업들은 순차적으로 이루어진다.

Q개의 질문을 처리해보자. 각 질문은 세 정수 A, B, T로 이루어진다.
- t번째 작업까지 수행했을 때, A번 지점부터 B번 지점까지 치워진 눈의 용량이 T 이상이 되는 t의 최솟값?

## 🔍 풀이 방법
쿼리를 하나만 처리한다고 생각하면, 쿼리를 결정 문제로 변환하고 이분 탐색으로 풀 수 있다.
-> 여러 개의 쿼리를 처리해야 하니까 **병렬 이분 탐색**을 사용한다.

쿼리마다 이분 탐색의 범위 lo[i], hi[i]를 관리하고, 작업을 1번부터 M번까지 쭉 수행하며 mid[i]번째 작업이 끝난 직후 해당 쿼리에 대한 결정 문제를 풀어 탐색 범위를 조절한다.
여기서 결정 문제는 `작업을 mid[i]번째까지 진행했을 때 구간 [A, B]에서 치운 눈의 양이 T 이상인가?` 로 두었다.
-> 이분 탐색의 성질에 따라 탐색 범위가 조절되는 총 횟수는 O(logM)이 된다.

작업을 naive하게 처리하면 O(MN)이라서 **분리 집합**으로 최적화하여 O(MlogN)으로 만들어준다.
구간 합도 관리해야 하기 때문에 **세그먼트 트리**를 사용했다.

## ⏳ 회고
병렬 이분 탐색을 깨달아버렸다