### PR TITLE
[20260307] BOJ / G5 / 극장 좌석 / 이준희

### DIFF
--- a/JHLEE325/202603/07 BOJ G5 극장 좌석.md
+++ b/JHLEE325/202603/07 BOJ G5 극장 좌석.md
@@ -1,0 +1,35 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        
+        int N = Integer.parseInt(br.readLine());
+        int M = Integer.parseInt(br.readLine());
+
+        int[] dp = new int[41];
+        dp[0] = 1;
+        dp[1] = 1;
+        for (int i = 2; i <= 40; i++) {
+            dp[i] = dp[i - 1] + dp[i - 2];
+        }
+
+        int answer = 1;
+        int vipNum = 0;
+
+        for (int i = 0; i < M; i++) {
+            int vip = Integer.parseInt(br.readLine());
+            int vipDist = vip - vipNum - 1;
+            answer *= dp[vipDist];
+            vipNum = vip;
+        }
+
+        answer *= dp[N - vipNum];
+
+        System.out.println(answer);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2302

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
극장 좌석은 기본적으로 자기 자리에 앉아야 하지만 좌석번호 기준 +-1 번호에 앉는 것도 가능합니다.
그러나 vip 손님의 경우에는 무조건 본인 자리에만 앉습니다.

좌석 길이와 vip 좌석이 주어졌을 때 좌석에 앉을 수 있는 경우의 수를 구하는 문제입니다.

## 🔍 풀이 방법
dp를 이용해서 풀었습니다.
좌석번호 기준 +-1 까지만 앉을 수 있기 때문에 기본적으로는 구간의 경우의 수가 dp[n] = dp[n-1] + dp[n-2]가 됩니다.

이 때 vip 좌석은 교환이 안되는 벽과 같은 느낌으로 vip 좌석으로 끊어서 각각의 경우의 수끼리 곱했습니다.

## ⏳ 회고
어제 풀었던 것과 비슷한 방식의 dp였던 것 같습니다.
