### PR TITLE
[20260307] BOJ / G5 / 빚 / 이인희

### DIFF
--- a/LiiNi-coder/202603/07 BOJ 빚.md
+++ b/LiiNi-coder/202603/07 BOJ 빚.md
@@ -1,0 +1,47 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int t = Integer.parseInt(br.readLine());
+		StringBuilder sb = new StringBuilder();
+
+		while (t-- > 0){
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			int n = Integer.parseInt(st.nextToken());
+			long[] arr = new long[n];
+
+			for(int i = 0; i < n; i++){
+				arr[i] = Long.parseLong(st.nextToken());
+			}
+			Arrays.sort(arr);
+
+			long[] prefix = new long[n + 1];
+			for(int i = 1; i <= n; i++) {
+				prefix[i] = prefix[i - 1] + arr[i - 1];
+			}
+
+			long totalSum = 0;
+			for(int k = 2; k <= n; k++){
+				long minCost = Long.MAX_VALUE;
+				for(int j = k; j <= n; j++){
+					long sum = prefix[j] - prefix[j-k];
+					long cost = (arr[j-1] * k) - sum;
+					if(cost < minCost) {
+						minCost = cost;
+					}
+				}
+				totalSum += minCost;
+			}
+			sb.append(totalSum).append('\n');
+		}
+
+		System.out.print(sb);
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/10427
## 🧭 풀이 시간
55 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
- n이 길이인 arr이 주어지고, 그것에서 m개를 고르고 그것 중에서 고른것을 a라 할때, a*m - (a + m)이 최소가 되도록 고른 것에 대한 출력
## 🔍 풀이 방법
- 누적합
## ⏳ 회고
- 누적합 연습