### PR TITLE
[20260308] BOJ / G5 / 돌 게임 6 / 이준희

### DIFF
--- a/JHLEE325/202603/08 BOJ G5 돌 게임 6.md
+++ b/JHLEE325/202603/08 BOJ G5 돌 게임 6.md
@@ -1,0 +1,19 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        long N = Long.parseLong(br.readLine());
+
+        if (N % 7 == 0 || N % 7 == 2) {
+            System.out.println("CY");
+        } else {
+            System.out.println("SK");
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/9660

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
주어진 돌이 있고 각 차례 마다 1개, 3개, 4개 를 가지고 갈 수 있습니다.

이기는 사람을 출력하는 문제입니다.

## 🔍 풀이 방법
이기는 경우의 수를 계산했습니다.
돌이 1개일 때는 무조건 선턴이 이깁니다.
2개일 때는 1개를 가져가면 상대가 이깁니다.
3개일 때는 3개를 가지고 가면 선턴이 이깁니다.
4개일 때는 4개를 가지고 가면 선턴이 이깁니다.
5개일 때는 상대에게 돌이 4개, 2개, 1개를 줄 수가 있는데 이 때 2개를 남길 수 있기 때문에 선턴이 이깁니다.
6개... 쭉 계산했을 때
7개를 기점으로 반복됐습니다.

이를 이용해서 승리 조건, 패배 조건을 나누어 출력했습니다.

## ⏳ 회고
한땀한땀 찾아보는 문제였습니다.
조금 귀찮지만 n이 1조로 컸기 때문에 이러한 접근법도 필요한 것 같습니다.