### PR TITLE
[20260308] BOJ / G1 / XOR 합 3 / 권혁준

### DIFF
--- a/khj20006/202603/08 BOJ G1 XOR 합 3.md
+++ b/khj20006/202603/08 BOJ G1 XOR 합 3.md
@@ -1,0 +1,40 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class BOJ13710 {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        int N = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int[] arr = new int[N];
+        for(int i=0;i<N;i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        long ans = 0;
+        for(int k=0;k<30;k++) {
+            long odd = 0, even = 1;
+            int sum = 0;
+            for(int i=0;i<N;i++) {
+                int a = (arr[i] & (1 << k)) == 0 ? 0 : 1;
+                sum ^= a;
+                if(sum == 0) {
+                    ans += odd * (1L << k);
+                    even++;
+                }
+                else {
+                    ans += even * (1L << k);
+                    odd++;
+                }
+            }
+        }
+        bw.write(ans + "\n");
+        bw.close();
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/13710

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
수열의 XOR 합이란 수열에 들어있는 모든 원소를 다 XOR한 값이다.
수열 A 주어졌을 때, A의 모든 연속하는 부분 수열의 XOR 합을 더한 값을 구하는 프로그램을 작성하시오.

## 🔍 풀이 방법
XOR 연산은 bitwise 연산이다. (비트 단위로 적용된다.)
비트 별로 독립적으로 합을 구해줘도 된다.

각 비트 별로 수열을 재구성하면 반드시 0과 1 만으로 구성된다.
재구성한 수열에서 연속 부분 수열이 홀수인 경우의 수를 구한 뒤, 해당 비트의 실제 값만큼 곱해주면 된다.
연속 부분 수열이 홀수라는 것은, 누적 합 배열에서 홀수 - 짝수 or 짝수 - 홀수인 경우 뿐이고, 이를 odd, even 변수로 누적해서 관리해줬다.

## ⏳ 회고
eez