### PR TITLE
[20260309] BOJ / G4 / 작업 / 이준희

### DIFF
--- a/JHLEE325/202603/09 BOJ G4 작업.md
+++ b/JHLEE325/202603/09 BOJ G4 작업.md
@@ -1,0 +1,33 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+
+        int[] dp = new int[N + 1];
+        int res = 0;
+
+        for (int i = 1; i <= N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+
+            int time = Integer.parseInt(st.nextToken());
+            int count = Integer.parseInt(st.nextToken());
+
+            int prevTask = 0;
+            for (int j = 0; j < count; j++) {
+                int prev = Integer.parseInt(st.nextToken());
+                prevTask = Math.max(prevTask, dp[prev]);
+            }
+
+            dp[i] = prevTask + time;
+
+            res = Math.max(res, dp[i]);
+        }
+
+        System.out.println(res);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2056

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
작업의 갯수, 각 작업이 걸리는 시간 및 선행 작업들이 주어졌을 때
모든 작업이 끝날 수 있는 최소 시간을 구하는 문제입니다.

## 🔍 풀이 방법
처음 봤을 때는 위상정렬 후 계산하는 문제인 줄 알았으나
이미 입력받는대로 위상정렬이 자동으로 되어 있어서 dp를 이용해서 작업 시간을 계산했습니다.

작업 갯수만큼 dp 배열을 정의한 후
각 작업의 작업이 끝나는 시간을 계산하는 데 이 때 선행 작업 중 가장 늦게 끝나는 시간 + 현재 작업에 걸리는 시간으로 계산했습니다.

## ⏳ 회고
문제를 잘 읽는 것으로 위상정렬을 하지 않고 쉽게 풀 수 있었던 것 같습니다.