### PR TITLE
[20260310] BOJ / G2 / 친구 네트워크 / 이준희

### DIFF
--- a/JHLEE325/202603/10 BOJ G2 친구 네트워크.md
+++ b/JHLEE325/202603/10 BOJ G2 친구 네트워크.md
@@ -1,0 +1,58 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int[] parent;
+    static int[] count;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+
+        StringBuilder sb = new StringBuilder();
+        while (T-- > 0) {
+            int F = Integer.parseInt(br.readLine());
+
+            parent = new int[F * 2];
+            count = new int[F * 2];
+            for (int i = 0; i < F * 2; i++) {
+                parent[i] = i;
+                count[i] = 1;
+            }
+
+            Map<String, Integer> map = new HashMap<>();
+            int id = 0;
+
+            for (int i = 0; i < F; i++) {
+                StringTokenizer st = new StringTokenizer(br.readLine());
+                String f1 = st.nextToken();
+                String f2 = st.nextToken();
+
+                if (!map.containsKey(f1)) map.put(f1, id++);
+                if (!map.containsKey(f2)) map.put(f2, id++);
+
+                sb.append(union(map.get(f1), map.get(f2))).append("\n");
+            }
+        }
+        System.out.print(sb.toString());
+    }
+
+    static int find(int x) {
+        if (parent[x] == x) return x;
+        return parent[x] = find(parent[x]);
+    }
+
+    static int union(int x, int y) {
+        x = find(x);
+        y = find(y);
+
+        if (x != y) {
+            parent[y] = x;
+            count[x] += count[y];
+        }
+
+        return count[x];
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/4195

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
친구 관계가 주어졌을 때
각각 주어질 때 마다 두사람의 친구 네트워크에 총 몇 명이 있는지 구하는 문제입니다.

## 🔍 풀이 방법
문제를 보자마자 유니온 파인드를 활용할 것을 예상했습니다.
그러나 이름으로 주어졌을 때의 접근 방법을 고민해야 했습니다.
이 때 각 사람들을 Map<String, Integer>을 이용하고
map에 없을 때 마다 id를 증가시켜가면서 이름에 id를 부여하는 방식으로 관리했습니다.
이후 각 맵의 밸류값을 이용하여 유니온, 파인드를 진행했습니다.

## ⏳ 회고
맵과 disjoint set을 활용하는 짬뽕 문제였는데 떠올리기 어려운 접근이엇습니다.