### PR TITLE
[20260311] BOJ / D3 / LIS on Tree / 권혁준

### DIFF
--- a/khj20006/202603/11 BOJ D3 LIS on Tree.md
+++ b/khj20006/202603/11 BOJ D3 LIS on Tree.md
@@ -1,0 +1,271 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class BOJ33752 {
+
+    static class SegmentTree {
+        int[] tree;
+        SegmentTree(int size) {
+            tree = new int[size*4];
+        }
+
+        void update(int s, int e, int i, int v, int n) {
+            if(s == e) {
+                tree[n] = v;
+                return;
+            }
+            int m = (s+e) >> 1;
+            if(i <= m) {
+                update(s, m, i, v, n*2);
+            }
+            else {
+                update(m+1, e, i, v, n*2+1);
+            }
+            tree[n] = Math.max(tree[n*2], tree[n*2+1]);
+        }
+
+        int find(int s, int e, int l, int r, int n) {
+            if(l > r || l > e || r < s) return 0;
+            if(l <= s && e <= r) return tree[n];
+            int m = (s+e) >> 1;
+            return Math.max(find(s, m, l, r, n*2), find(m+1, e, l, r, n*2+1));
+        }
+    }
+
+    static class Choice {
+        int value, index;
+        Choice(int value, int index) {
+            this.value = value;
+            this.index = index;
+        }
+    }
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+
+    static int N;
+    static List<Integer>[] graph;
+    static int[][] infos;
+    static int[] arr, in, out, parent;
+    static Choice[] dec, asc, dec2, asc2;
+    static int order = 0;
+    static SegmentTree seg;
+
+    static List<Integer>[] ascLists, decLists;
+
+    public static void main(String[] args) throws Exception {
+        // 0. Input
+
+        N = Integer.parseInt(br.readLine());
+        arr = new int[N+1];
+        infos = new int[N][2];
+        graph = new List[N+1];
+
+        st = new StringTokenizer(br.readLine());
+        for(int i=1;i<=N;i++) {
+            graph[i] = new ArrayList<>();
+            arr[i] = Integer.parseInt(st.nextToken());
+            infos[i-1][0] = arr[i];
+            infos[i-1][1] = i;
+        }
+
+        for(int i=1;i<N;i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            graph[a].add(b);
+            graph[b].add(a);
+        }
+
+        int answer = solve(1);
+
+        bw.write(answer + "\n");
+        bw.close();
+    }
+
+    public static int solve(int root) throws Exception {
+        // 1. Euler-Tour Technique
+
+        in = new int[N+1];
+        out = new int[N+1];
+        parent = new int[N+1];
+        order = 0;
+        dfs(root, 0);
+
+        // 2. Segment Tree
+
+        /// 2-1. LIS : leaf -> root
+
+        asc = new Choice[N+1];
+        asc2 = new Choice[N+1];
+        Arrays.sort(infos, (a, b) -> Integer.compare(a[0], b[0]));
+        longestSubsequenceDP(infos, asc, asc2);
+
+        /// 2-2. LDS : leaf -> root
+
+        dec = new Choice[N+1];
+        dec2 = new Choice[N+1];
+        Arrays.sort(infos, (a, b) -> Integer.compare(b[0], a[0]));
+        longestSubsequenceDP(infos, dec, dec2);
+
+        // 3. Find Answer
+
+        /// Case 1) LIS contains LCA, 2nd best dp
+
+        int answer = 1;
+        for(int i=1;i<=N;i++) {
+            if(dec[i].index == asc[i].index) {
+                answer = Math.max(answer, Math.max(dec[i].value + asc2[i].value - 1, dec2[i].value + asc[i].value - 1));
+                answer = Math.max(answer, Math.max(dec[i].value, asc[i].value));
+            }
+            else {
+                answer = Math.max(answer, dec[i].value + asc[i].value - 1);
+            }
+        }
+
+        /// Case 2) LIS doesn't contains LCA, Smaller To Larger
+
+        ascLists = new List[N+1];
+        decLists = new List[N+1];
+        for(int i=1;i<=N;i++) {
+            ascLists[i] = new ArrayList<>();
+            decLists[i] = new ArrayList<>();
+        }
+
+        answer = Math.max(answer, dfs2(1, 0));
+
+        return answer;
+    }
+
+    public static void dfs(int cur, int par) {
+        in[cur] = ++order;
+        parent[cur] = par;
+        for(int nxt : graph[cur]) if(nxt != par) {
+            dfs(nxt, cur);
+        }
+        out[cur] = order;
+    }
+
+    public static void longestSubsequenceDP(int[][] arr, Choice[] ch1, Choice[] ch2) {
+        seg = new SegmentTree(N);
+        for(int i=1;i<=N;i++) {
+            ch1[i] = new Choice(1, 0);
+            ch2[i] = new Choice(1, -1);
+        }
+        for(int i=0;i<N;) {
+            int curValue = arr[i][0];
+            List<Integer> updates = new ArrayList<>();
+            while(i<N && arr[i][0] == curValue) {
+                int curIndex = arr[i][1];
+                for(int child : graph[curIndex]) if(child != parent[curIndex]) {
+                    int result = seg.find(1, N, in[child], out[child], 1) + 1;
+                    if(result > ch1[curIndex].value) {
+                        ch2[curIndex] = ch1[curIndex];
+                        ch1[curIndex] = new Choice(result, child);
+                    }
+                    else if(result > ch2[curIndex].value) {
+                        ch2[curIndex] = new Choice(result, child);
+                    }
+                }
+                updates.add(curIndex);
+                i++;
+            }
+
+            for(int node : updates) {
+                seg.update(1, N, in[node], ch1[node].value, 1);
+            }
+        }
+    }
+
+    public static int dfs2(int cur, int par) {
+        int ret = 0;
+        for(int nxt : graph[cur]) if(nxt != par) {
+            ret = Math.max(ret, dfs2(nxt, cur));
+
+            if (ascLists[nxt].size() + decLists[nxt].size() > ascLists[cur].size() + decLists[cur].size()) {
+                List<Integer> temp1 = ascLists[nxt];
+                ascLists[nxt] = ascLists[cur];
+                ascLists[cur] = temp1;
+                List<Integer> temp2 = decLists[nxt];
+                decLists[nxt] = decLists[cur];
+                decLists[cur] = temp2;
+            }
+
+            for(int i=0;i<ascLists[nxt].size();i++) {
+                int nxtVal = ascLists[nxt].get(i);
+
+                int s = -1, e = decLists[cur].size()-1, m = (s+e+1)>>1;
+                while(s < e) {
+                    int curr = decLists[cur].get(m);
+                    if(curr > nxtVal) {
+                        s = m;
+                    }
+                    else {
+                        e = m-1;
+                    }
+                    m = (s+e+1)>>1;
+                }
+                ret = Math.max(ret, m+i+2);
+            }
+
+            for(int i=0;i<decLists[nxt].size();i++) {
+                int nxtVal = decLists[nxt].get(i);
+
+                int s = -1, e = ascLists[cur].size()-1, m = (s+e+1)>>1;
+                while(s < e) {
+                    int curr = ascLists[cur].get(m);
+                    if(curr < nxtVal) {
+                        s = m;
+                    }
+                    else {
+                        e = m-1;
+                    }
+                    m = (s+e+1)>>1;
+                }
+                ret = Math.max(ret, i+m+2);
+            }
+
+            for(int i=0;i<ascLists[nxt].size();i++) {
+                if(i >= ascLists[cur].size()) {
+                    ascLists[cur].add((int)1e9 + 7);
+                }
+                int curVal = ascLists[cur].get(i);
+                int nxtVal = ascLists[nxt].get(i);
+                if(nxtVal < curVal) {
+                    ascLists[cur].set(i, nxtVal);
+                }
+            }
+
+            for(int i=0;i<decLists[nxt].size();i++) {
+                if(i >= decLists[cur].size()) {
+                    decLists[cur].add(0);
+                }
+                int curVal = decLists[cur].get(i);
+                int nxtVal = decLists[nxt].get(i);
+                if(nxtVal > curVal) {
+                    decLists[cur].set(i, nxtVal);
+                }
+            }
+
+        }
+
+        if(ascLists[cur].size() + 1 == asc[cur].value) {
+            ascLists[cur].add(arr[cur]);
+        }
+        else {
+            ascLists[cur].set(asc[cur].value-1, arr[cur]);
+        }
+
+        if(decLists[cur].size() + 1 == dec[cur].value) {
+            decLists[cur].add(arr[cur]);
+        }
+        else {
+            decLists[cur].set(dec[cur].value-1, arr[cur]);
+        }
+
+        return ret;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/33752

## 🧭 풀이 시간
300분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
정점 $N$개인 트리가 주어진다. 각 정점에는 가중치 $v_i$가 달려있다.
임의의 정점 $u$와 $v$를 잇는 경로에서 만나는 정점 번호를 차례대로 기록한 수열 $P$에 대해,
$P$에서 $0$개 이상의 원소를 제거하여 얻은 부분 수열 $S$를 **트리 부분 수열**이라고 정의한다.

**트리 부분 수열** $S = \{ s_1, s_2, \cdots, s_k \}$에 대해,
$v_{s_1} < v_{s_2} < \cdots < v_{s_k}$를 만족하는 $S$를 **증가하는 트리 부분 수열**이라고 정의한다.

주어진 트리에서 **증가하는 트리 부분 수열**의 최대 길이를 구해보자.

## 🔍 풀이 방법
트리의 지름을 구할 때와 비슷하게 생각해봤다.
어떤 점의 아래로 겹치지 않는 두 경로를 합친 것이 트리의 지름의 후보가 될 수 있는 것처럼,
어떤 점의 아래로 겹치지 않는 두 LIS, LDS를 합친 것이 **증가하는 트리 부분 수열**의 후보가 될 수 있다.

`asc[i] = 리프에서부터 i번 정점까지 도달하였을 때, i번 정점을 반드시 포함하는 LIS의 최대 길이`
`asc2[i] = 리프에서부터 i번 정점까지 도달하였을 때, i번 정점을 반드시 포함하는 LIS의 두 번째 최대 길이`
`dec[i] = 리프에서부터 i번 정점까지 도달하였을 때, i번 정점을 반드시 포함하는 LDS의 최대 길이`
`dec2[i] = 리프에서부터 i번 정점까지 도달하였을 때, i번 정점을 반드시 포함하는 LDS의 두 번째 최대 길이`

이렇게 정의하면, 각 i마다 asc[i] + dec[i] - 1가 답의 후보가 된다.
만약, asc[i]와 dec[i]의 경로가 겹치는 경우는 asc2[i] + dec[i] - 1, asc[i] + dec2[i] - 1 중 최댓값을 택하면 된다.

다음으로는, 저 asc, asc2, dec, dec2를 효율적으로 구하는 방법을 생각해봤다.
i번 정점으로 도달하는 LIS를 구하려면, $v_i$보다 작은 가중치를 가지는 정점은 이미 다 처리된 상태여야 한다.
i번 정점을 루트로 하는 서브트리 내에서 asc 값이 가장 큰 정점을 하나 선택하고 거기에 +1을 해주면 되겠다고 생각했다.
-> 트리에서 업데이트 쿼리가 가능해야 하고 서브트리에 대한 max연산도 지원해야 하니까, `오일러 경로 테크닉` + `세그먼트 트리`로 구현할 수 있다.

트리의 지름을 구할 때는 경로 상의 모든 점이 지름에 기여하지만, LIS는 그렇지 않을 수도 있다.
중간에 빠져도 되는 점들이 있을 수 있기 때문에, asc[i]와 dec[i]가 i번 정점에서 사용될 수도 있고 i번 정점의 조상에서도 사용될 수 있어야 한다.

따라서 `DFS` + `smaller to larger`로 리프에서부터 올라가면서 asc, dec를 잘 합쳐주며 정답을 갱신해 나갔다.

## ⏳ 회고
구현도 너무 복잡했고 아이디어를 떠올리는 것도 힘들었다.
손으로 반례를 못 찾겠어서 naive 정답 코드와 내 코드의 결과가 다르게 나올 때까지 무한루프로 테케를 생성해서 겨우 찾아냈다.