### PR TITLE
[20260312] BOJ / D4 / Internet Monopoly / 권혁준

### DIFF
--- a/khj20006/202603/12 BOJ D4 Internet Monopoly.md
+++ b/khj20006/202603/12 BOJ D4 Internet Monopoly.md
@@ -1,0 +1,127 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class BOJ29851 {
+
+    static class Query {
+        int type, a, b;
+        Query(int a) {
+            this.type = 0;
+            this.a = a;
+        }
+        Query(int a, int b) {
+            this.type = 1;
+            this.a = a;
+            this.b = b;
+        }
+    }
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+
+    static int N, Q;
+    static Query[] queries;
+    static BitSet cantUnion;
+    static List<Integer>[] tree;
+    static int[] root, parent, depth;
+
+    public static int find(int x) {
+        return x == root[x] ? x : (root[x] = find(root[x]));
+    }
+
+    public static boolean union(int a, int b) {
+        int x = find(a), y = find(b);
+        if(x == y) return false;
+        root[x] = y;
+        return true;
+    }
+
+    public static void main(String[] args) throws Exception {
+        // 0. Input + Construct Tree
+
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        Q = Integer.parseInt(st.nextToken());
+
+        queries = new Query[Q];
+        cantUnion = new BitSet(Q);
+        tree = new List[N+1];
+        root = new int[N+1];
+        for(int i=1;i<=N;i++) {
+            root[i] = i;
+            tree[i] = new ArrayList<>();
+        }
+        for(int i=0;i<Q;i++) {
+            st = new StringTokenizer(br.readLine());
+            if ("+".equals(st.nextToken())) {
+                int a = Integer.parseInt(st.nextToken());
+                int b = Integer.parseInt(st.nextToken());
+                if(union(a,b)) {
+                    tree[a].add(b);
+                    tree[b].add(a);
+                }
+                else {
+                    cantUnion.set(i);
+                }
+                queries[i] = new Query(a, b);
+            }
+            else {
+                queries[i] = new Query(Integer.parseInt(st.nextToken()));
+            }
+        }
+
+        // 1. DFS
+        parent = new int[N+1];
+        depth = new int[N+1];
+        dfs(1, 0, 0);
+
+        // 2. Count Non-bridge
+
+        root = new int[N+1];
+        for(int i=1;i<=N;i++) {
+            root[i] = i;
+        }
+        int nonBridges = 0;
+        for(int i=0;i<Q;i++) {
+            Query query = queries[i];
+            int type = query.type, a = query.a, b = query.b;
+            if(type == 1) {
+                if(!cantUnion.get(i)) continue;
+                a = find(a);
+                b = find(b);
+                while(a != b) {
+                    nonBridges++;
+                    if(depth[a] > depth[b]) {
+                        union(a, parent[a]);
+                        a = find(parent[a]);
+                    }
+                    else {
+                        union(b, parent[b]);
+                        b = find(parent[b]);
+                    }
+                }
+            }
+            else {
+                if(nonBridges <= a && a <= N-1) {
+                    bw.write("JAH\n");
+                }
+                else {
+                    bw.write("EI\n");
+                }
+            }
+        }
+        bw.close();
+    }
+
+    public static void dfs(int cur, int par, int dep) {
+        parent[cur] = par;
+        depth[cur] = dep;
+        for(int nxt : tree[cur]) if(nxt != par) {
+            dfs(nxt, cur, dep+1);
+        }
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/29851

## 🧭 풀이 시간
45분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
정점 N개인 간선 없는 그래프가 주어진다. 두 종류의 쿼리를 총 Q개 처리해보자.
- `+ a b` : 그래프에 간선 (a, b)를 추가한다.
- `? k` : 현재 그래프에서 k개의 간선들은 가중치를 1로 정하고 나머지 간선들의 가중치는 2로 정할 때, 가중치를 잘 분배해서 이 그래프의 **최소 스패닝 트리가 유일**하도록 만들 수 있을까?

## 🔍 풀이 방법
일단 아무 MST를 하나 구성하고, MST에 쓰이지 않은 간선들 모두가 MST의 **대체 간선**이 될 수 없다면 그 MST는 유일하다고 봐도 된다.
**대체 간선**이라는 것은, 그 간선을 넣고 MST에 존재하는 다른 간선을 하나 빼도 MST를 유지하는 것을 의미한다.

따라서, MST에 쓰이지 않은 간선 (u, v)에 대해,
MST 상에서 u와 v를 잇는 경로 상의 간선들 중 (u, v)와 가중치가 같은 간선이 있다면 (u, v)는 대체 간선이 된다.

반대로 생각하면, MST가 유일하려면 MST에 쓰이지 않은 간선들은 모두 가중치가 2여야 하고,
그 간선들의 양 끝 점을 잇는 MST 상에서의 경로에 존재하는 간선 가중치는 모두 1이 되어야 한다.

이렇게 해서 특정 간선들의 가중치는 1 혹은 2로 고정을 시키고, 가중치가 고정되지 않은 나머지 간선들은 가중치가 뭐든 상관 없다.
따라서, 가중치가 1로 고정된 간선의 개수를 d라고 하면, d <= k <= N-1인 경우에만 MST가 유일하다.

구현을 효율적으로 하려면 쿼리 응답하기 전에 미리 트리를 알아야 해서, 일단 크루스칼 알고리즘으로 MST부터 구성해줬다.
다음으로, 쿼리를 다시 훑으며 MST에 사용되지 않은 간선이 등장한 경우에는 가중치를 1로 고정시키는 작업을 유니온 파인드로 수행했다.

## ⏳ 회고
재밌다