### PR TITLE
[20260315] BOJ / G2 / 공항 / 이준희

### DIFF
--- a/JHLEE325/202603/15 BOJ G2 공항.md
+++ b/JHLEE325/202603/15 BOJ G2 공항.md
@@ -1,0 +1,47 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int[] parent;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int G = Integer.parseInt(br.readLine());
+        int P = Integer.parseInt(br.readLine());
+
+        parent = new int[G + 1];
+        for (int i = 1; i <= G; i++) {
+            parent[i] = i;
+        }
+
+        int count = 0;
+        for (int i = 0; i < P; i++) {
+            int gi = Integer.parseInt(br.readLine());
+
+            int availableGate = find(gi);
+
+            if (availableGate == 0) break;
+
+            count++;
+            
+            union(availableGate, availableGate - 1);
+        }
+
+        System.out.println(count);
+    }
+
+    static int find(int x) {
+        if (parent[x] == x) return x;
+        return parent[x] = find(parent[x]);
+    }
+
+    static void union(int x, int y) {
+        x = find(x);
+        y = find(y);
+        if (x != y) {
+            parent[x] = y;
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/10775

## 🧭 풀이 시간
70분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
공항에는 1 ~ G번까지의 게이트가 있습니다.
비행기는 각각의 번호가 주어져 있고 1 ~ 번호 까지의 게이트에 착륙할 수 있습니다.
비행기가 착륙하는 순서대로 비행기의 번호가 주어졌을 때
착륙할 수 있는 비행기의 최대 수를 구하는 문제입니다.

## 🔍 풀이 방법
비행기가 최대 자기의 번호의 게이트까지 착륙할 수 있으므로 최대한 높은 번호의 게이트에 착륙해야 합니다.
따라서 그리디적인 관점으로 각 비행기마다 가용한 가장 큰 번호의 게이트에 착륙시켰습니다.
이 때 가용한 최대 번호의 게이트를 찾는 것을 미리 유니온 파인드를 통해 묶어놔서 쉽게 찾았습니다.

ex)
처음에는 게이트가 각각 자기 자신을 가르킴
n 번째 게이트에 착률을 하면 n을 n-1과  묶어서 find(n)을 할 시 n-1을 가르키게 함

## ⏳ 회고
처음에는 쉽게 boolean 배열을 통해서 순회하면서 게이트를 찾았었는데 이를 통해서 시간 단축을 못시켰습니다.
접근 방법을 찾아보니 유니온 파인드를 통해 묶어서 쉽게 파악할 수 있었습니다.