### PR TITLE
[20260317] BOJ / P1 / 지형 평탄화 탐색기 / 권혁준

### DIFF
--- a/khj20006/202603/17 BOJ P1 지형 평탄화 탐색기.md
+++ b/khj20006/202603/17 BOJ P1 지형 평탄화 탐색기.md
@@ -1,0 +1,127 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class BOJ33908 {
+
+    static class Count {
+        int[] count;
+        Count() {
+            count = new int[1953125];
+        }
+
+        void add(int value) {
+            if(value < 0) return;
+            count[value]++;
+        }
+
+        void remove(int value) {
+            if(value < 0) return;
+            count[value]--;
+        }
+
+        int get(int value) {
+            return count[value];
+        }
+    }
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+
+    static int N, M, Q;
+    static int[][] arr;
+
+    static Count[][] type;
+
+    public static void main(String[] args) throws Exception {
+        // 0. Input
+
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        arr = new int[N][M];
+        for(int i=0;i<N;i++) {
+            st = new StringTokenizer(br.readLine());
+            for(int j=0;j<M;j++) {
+                arr[i][j] = Integer.parseInt(st.nextToken()) - 1;
+            }
+        }
+
+        // 1. Find All Types
+
+        type = new Count[10][];
+        for(int r=1;r<=9;r++) {
+            type[r] = new Count[9/r + 1];
+        }
+
+        for(int r=1;r<=9;r++) for(int c=1;r*c<=9;c++) {
+            type[r][c] = new Count();
+            for(int i=0;i+r<=N;i++) for(int j=0;j+c<=M;j++) {
+                type[r][c].add(compute(i, j, r, c));
+            }
+        }
+
+        // 2. Solve queries
+
+        Q = Integer.parseInt(br.readLine());
+        while(Q-- > 0) {
+            st = new StringTokenizer(br.readLine());
+            int q = Integer.parseInt(st.nextToken());
+            if(q == 1) {
+                int x = Integer.parseInt(st.nextToken()) - 1;
+                int y = Integer.parseInt(st.nextToken()) - 1;
+                int h = Integer.parseInt(st.nextToken()) - 1;
+                for(int r=1;r<=9;r++) for(int c=1;r*c<=9;c++) {
+                    for(int i=Math.max(x-r+1, 0);i<=Math.min(x, N-r);i++) for(int j=Math.max(y-c+1, 0);j<=Math.min(y, M-c);j++) {
+                        type[r][c].remove(compute(i, j, r, c));
+                    }
+                }
+                arr[x][y] = h;
+                for(int r=1;r<=9;r++) for(int c=1;r*c<=9;c++) {
+                    for(int i=Math.max(x-r+1, 0);i<=Math.min(x, N-r);i++) for(int j=Math.max(y-c+1, 0);j<=Math.min(y, M-c);j++) {
+                        type[r][c].add(compute(i, j, r, c));
+                    }
+                }
+            }
+            else {
+                int r = Integer.parseInt(st.nextToken());
+                int c = Integer.parseInt(st.nextToken());
+                int[][] arr2 = new int[r][c];
+                int min = 4, max = -1;
+                for(int i=0;i<r;i++) for(int j=0;j<c;j++) {
+                    arr2[i][j] = Integer.parseInt(st.nextToken()) - 1;
+                    min = Math.min(min, arr2[i][j]);
+                    max = Math.max(max, arr2[i][j]);
+                }
+
+                int answer = 0;
+                for(int z=-min;z<=4-max;z++) {
+                    int k = 1, value = 0;
+                    for(int i=0;i<r;i++) for(int j=0;j<c;j++) {
+                        value += k * (arr2[i][j] + z);
+                        k *= 5;
+                    }
+                    answer += type[r][c].get(value);
+                }
+
+                bw.write(answer + "\n");
+            }
+        }
+        bw.close();
+    }
+
+    static int compute(int x, int y, int r, int c) {
+        if(0 <= x && x+r <= N && 0 <= y && y+c <= M) {
+            int k = 1, value = 0;
+            for(int i=x;i<x+r;i++) for(int j=y;j<y+c;j++) {
+                value += k * arr[i][j];
+                k *= 5;
+            }
+            return value;
+        }
+        return -1;
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/33908

## 🧭 풀이 시간
$\infty$

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
N*M 격자 모양의 지형이 있고, 각 칸의 높이는 1 이상 5 이하이다.
두 종류의 쿼리를 처리해보자.
- 1 x y h : x행 y열의 높이를 h로 변경
- 2 r c : r행 c열의 작업계획도가 주어진다. 이 작업계획도를 지형의 가능한 곳들에 매핑하여 높이를 낮췄을 때, 매핑된 곳의 높이가 모두 동일해지는 경우의 수를 구하기

## 🔍 풀이 방법
높이 정보를 0 이상 4 이하로 변경한다면, 모든 가능한 작업계획도를 5진법으로 해싱할 수 있다.

`type[r][c] = r행 c열의 작업계획도에 대한 Count 클래스` 라고 정의했다.
Count 클래스에는 각 해시값에 대한 경우의 수를 int 배열에 저장한다.
해시값의 범위는 [0, 5^9)이며, 이는 1953125 미만이기 때문에 TreeMap 대신 배열을 선택했다.

모든 매핑에 대한 경우의 수를 미리 다 구해놓고, 변경될 때마다 변경된 곳에 대한 해시만 다시 계산해서 넣어주는 방식으로 구현했다.

## ⏳ 회고
드디어