### PR TITLE
[20260318] BOJ / G3 / 파일 합치기 / 이준희

### DIFF
--- a/JHLEE325/202603/18 BOJ G3 파일 합치기.md
+++ b/JHLEE325/202603/18 BOJ G3 파일 합치기.md
@@ -1,0 +1,36 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+
+        for (int t = 0; t < T; t++) {
+            int K = Integer.parseInt(br.readLine());
+            int[] files = new int[K + 1];
+            int[] sum = new int[K + 1];
+            int[][] dp = new int[K + 1][K + 1];
+
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int i = 1; i <= K; i++) {
+                files[i] = Integer.parseInt(st.nextToken());
+                sum[i] = sum[i - 1] + files[i];
+            }
+
+            for (int d = 1; d < K; d++) {
+                for (int i = 1; i + d <= K; i++) {
+                    int j = i + d;
+                    dp[i][j] = Integer.MAX_VALUE;
+
+                    for (int k = i; k < j; k++) {
+                        dp[i][j] = Math.min(dp[i][j], dp[i][k] + dp[k + 1][j] + (sum[j] - sum[i - 1]));
+                    }
+                }
+            }
+            System.out.println(dp[1][K]);
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11066

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
파일을 합칠 때 각 파일의 크기의 합만큼 코스트가 발생합니다. 파일은 인접한 것 2개 끼리 합칠 수 있습니다.
여러개의 파일이 주어졌을 때 파일을 전부 합쳤을 때 드는 최소비용을 구하는 문제입니다.

## 🔍 풀이 방법
DP를 이용해서 풀었습니다.
3중 for문에서 dp를 활용하여 2개 묶음, 3개 묶음... 이런 식으로 묶음의 크기를 늘렸습니다.
그 속에서 어떤식으로 묶었을 때 최소비용인지를 dp 배열을 이용해서 갱신했습니다.
dp[i][j] = dp[i][k] + dp[k+1][j] 로 i번부터 j번 파일까지 합치는 비용을 계산했습니다.

## ⏳ 회고
그리디적인 방법으로 접근하려 했으나 인접한 2개 끼리만 합칠 수 있다는 조건으로 다른 방법을 생각하는 것이 쉽지 않았습니다.
