### PR TITLE
[20260324] BOJ / P2 / Maximum Strategic Savings / 권혁준

### DIFF
--- a/khj20006/202603/24 BOJ P2 Maximum Strategic Savings.md
+++ b/khj20006/202603/24 BOJ P2 Maximum Strategic Savings.md
@@ -1,0 +1,89 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class BOJ16025 {
+
+    static class DisjointSet {
+        int[] root;
+        DisjointSet(int size) {
+            root = new int[size+1];
+            for(int i=1;i<=size;i++) {
+                root[i] = i;
+            }
+        }
+
+        int find(int x) {
+            return x == root[x] ? x : (root[x] = find(root[x]));
+        }
+
+        boolean union(int a, int b) {
+            int x = find(a), y = find(b);
+            if(x == y) {
+                return false;
+            }
+            root[x] = y;
+            return true;
+        }
+    }
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+
+    static int N, M, P, Q;
+    static int[][] edges;
+    static DisjointSet dsx, dsy;
+
+    public static void main(String[] args) throws Exception {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        P = Integer.parseInt(st.nextToken());
+        Q = Integer.parseInt(st.nextToken());
+
+        edges = new int[P+Q][];
+        long sum = 0;
+        for(int i=0;i<P+Q;i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            int c = Integer.parseInt(st.nextToken());
+
+            int type = 0;
+            if(i >= P) {
+                type = 1;
+                sum += (long)c * M;
+            }
+            else {
+                sum += (long)c * N;
+            }
+            edges[i] = new int[]{a, b, c, type};
+        }
+
+        dsx = new DisjointSet(N);
+        dsy = new DisjointSet(M);
+        Arrays.sort(edges, (a,b) -> a[2]-b[2]);
+        long X = N, Y = M;
+        for(int[] edge : edges) {
+            int a = edge[0], b = edge[1], type = edge[3];
+            long c = edge[2];
+
+            if(type == 0) {
+                if(dsy.union(a, b)) {
+                    sum -= c * X;
+                    Y--;
+                }
+            }
+            else {
+                if(dsx.union(a, b)) {
+                    sum -= c * Y;
+                    X--;
+                }
+            }
+        }
+
+        bw.write(sum + "\n");
+        bw.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16025

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
N개의 행성이 존재하며, 각 행성에는 M개의 도시가 있다.
행성 e의 도시 f를 (e, f)와 같이 표기한다.
P종류의 간선 (a, b, c)는 임의의 행성 i에 대해, (i, a)와 (i, b)를 잇는 비용 c의 간선을 의미한다.
Q종류의 간선 (x, y, z)는 임의의 도시 j에 대해, (x, j)와 (y, j)를 잇는 비용 z의 간선을 의미한다.

모든 도시의 모든 행성들이 서로 연결되도록 하는 최소 비용을 구해보자.

## 🔍 풀이 방법
P종류의 간선은 도시 간의 이동에만 관여하고, Q종류의 간선은 행성 간의 이동에만 관여한다.
P종류의 간선을 아무리 연결해봤자 행성 간의 이동 가능 여부는 변하지 않는다.

즉, 도시에 대한 MST와 행성에 대한 MST로 분리하여 생각해도 무관하며, 이때는 연결해주는 간선의 개수만 잘 관리해주면 된다.
구체적으로, P종류의 간선 하나를 추가할 때는 그 시점에 존재하는 행성 컴포넌트의 개수만큼 그 간선이 추가되며,
Q종류의 간선 하나를 추가할 때는 그 시점에 존재하는 도시 컴포넌트의 개수만큼 그 간선이 추가된다.

## ⏳ 회고
ee