### PR TITLE
[20260325] BOJ / P1 / Railway / 권혁준

### DIFF
--- a/khj20006/202603/25 BOJ P1 Railway.md
+++ b/khj20006/202603/25 BOJ P1 Railway.md
@@ -1,0 +1,90 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class BOJ22197 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringTokenizer st;
+
+    static int N, M, K;
+    static List<int[]>[] tree;
+    static TreeMap<Integer, Integer>[] map;
+    static int[] size;
+    static int answerCount = 0;
+    static boolean[] isAnswer;
+
+    public static void main(String[] args) throws Exception {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+        tree = new List[N+1];
+        for(int i=1;i<=N;i++) {
+            tree[i] = new ArrayList<>();
+        }
+
+        for(int i=1;i<N;i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken()), b = Integer.parseInt(st.nextToken());
+            tree[a].add(new int[]{b,i});
+            tree[b].add(new int[]{a,i});
+        }
+
+        map = new TreeMap[N+1];
+        for(int i=1;i<=N;i++) {
+            map[i] = new TreeMap<>();
+        }
+        size = new int[M];
+        for(int i=0;i<M;i++) {
+            st = new StringTokenizer(br.readLine());
+            size[i] = Integer.parseInt(st.nextToken());
+            for(int j=0;j<size[i];j++) {
+                map[Integer.parseInt(st.nextToken())].put(i, 1);
+            }
+        }
+
+        isAnswer = new boolean[N];
+        dfs(1, 0);
+
+        bw.write(answerCount + "\n");
+        for(int i=1;i<N;i++) if(isAnswer[i]) {
+            bw.write(i + " ");
+        }
+
+        bw.close();
+    }
+
+    public static void dfs(int cur, int par) {
+        for(int[] edge : tree[cur]) {
+            int nxt = edge[0], edgeNum = edge[1];
+            if(nxt == par) {
+                continue;
+            }
+
+            dfs(nxt, cur);
+            if(map[nxt].size() >= K) {
+                answerCount++;
+                isAnswer[edgeNum] = true;
+            }
+
+            if(map[cur].size() < map[nxt].size()) {
+                TreeMap<Integer, Integer> temp = map[cur];
+                map[cur] = map[nxt];
+                map[nxt] = temp;
+            }
+
+            for(int key : map[nxt].keySet()) {
+                int newVal = map[cur].getOrDefault(key, 0) + map[nxt].get(key);
+                if(newVal != size[key]) {
+                    map[cur].put(key, newVal);
+                }
+                else if(map[cur].containsKey(key)) {
+                    map[cur].remove(key);
+                }
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/22197

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
정점이 N개이고, 간선에 가중치가 있는 트리에 M개의 쿼리가 주어진다.
처음에 모든 간선의 가중치는 0이다.

하나의 쿼리는 다음과 같이 구성된다.
- 정점 집합 S가 주어지면, S의 모든 정점을 포함하는 최소 부분 그래프의 간선들에 1을 더한다.

모든 쿼리가 끝난 후, 간선의 가중치가 K 이상인 것들을 모두 출력해보자.

## 🔍 풀이 방법
루트를 1로 정한다.

쿼리를 하나만 처리한다고 가정하면, 아래 과정으로 쿼리를 처리할 수 있다.
- 정점 집합 S의 모든 점에 1을 더한다.
- DFS를 사용해 어떤 정점 a의 자식들의 값을 모두 a에 더해준다.
- 자식들의 값이 1 이상이면, 해당 자식과 a를 잇는 간선은 최소 부분 그래프에 포함되므로, 이를 따로 기록해둔다.
- a의 값이 |S|가 되면 0으로 바꾼다. (최소 부분 그래프이므로 모두 모인 경우에는 더이상 위로 올라가면 안 된다.)

쿼리를 여러 개 처리해야 하지만, 위 방법을 응용해서 모든 점에 쿼리의 번호를 기록해두는 Map을 관리하는 방식을 고려해봤다.
- 모든 정점 집합 S에 대해, 해당 점의 Map에 쿼리 번호를 기록해둔다.
- DFS를 사용해 어떤 정점 a의 자식들의 Map을 모두 a의 Map으로 합쳐준다.
- 자식들의 특정 쿼리 번호 q의 개수가 그 자식과 부모를 잇는 간선의 가중치이고, 이 값이 K 이상이라면 정답 리스트에 추가한다.
- 쿼리 번호 q의 개수가 해당 쿼리의 정점 집합 크기와 동일해지면 Map에서 제거해준다.

자식들의 Map을 부모의 Map으로 합칠 때는,
작은 크기의 맵을 큰 크기의 맵에 합치면 전체 시간복잡도가 모든 정점 집합의 크기 합 X에 대해 O(XlogX)로 떨어진다.

## ⏳ 회고
다른 풀이도 있는 것 같은데 더 알아봐야겠다